### PR TITLE
ci: migrate to official setup-dart reusable publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository_owner == 'kevmoo' }}
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     permissions:
       id-token: write # Required for authentication using OIDC
       pull-requests: write # Required for writing the pull request note

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,8 +3,6 @@
 name: Publish
 
 on:
-  pull_request:
-    branches: [ main ]
   push:
     tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
 


### PR DESCRIPTION
- Replace uses: dart-lang/ecosystem/publish.yaml@main with uses: dart-lang/setup-dart/publish.yml@v1
- Aligns with standard pub.dev OIDC guidelines and uses a version-locked tag
