### PR TITLE
fix: align scoring with Cognitive Complexity whitepaper v1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 0.2.0-wip
+
+Scoring fixes aligning with the SonarSource Cognitive Complexity whitepaper
+(v1.7) and its reference implementation (sonar-java):
+
+- `else if` chains no longer deepen nesting: branch contents sit one level
+  below the head `if` (previously each chain link added an extra level).
+- `switch` statements/expressions and `catch` clauses now receive the
+  standard nesting increment when nested (previously flat +1).
+- Local function declarations no longer add a structural +1; like lambdas,
+  they only deepen nesting.
+
+Analyzer coverage and CLI fixes:
+
+- Constructor initializers and parameter default values are now scored.
+- Top-level functions named with pseudo-keywords (`show`, `on`, ...) are no
+  longer skipped.
+- Top-level getters/setters are reported with a `get `/`set ` prefix,
+  matching class members.
+- `--fail-on-increase` no longer flags newly added declarations (they have
+  no baseline); they are governed by `--fail-threshold` alone.
+- Directory exclusion (`.git`, `.dart_tool`, `build`) now matches whole path
+  segments, so `.github/` and similar directories are scanned correctly.
+
 ## 0.1.0
 
 - Initial version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0-wip
+## 0.2.0
 
 Scoring fixes aligning with the SonarSource Cognitive Complexity whitepaper
 (v1.7) and its reference implementation (sonar-java):

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Add the package to your `dev_dependencies` in `pubspec.yaml`:
 
 ```yaml
 dev_dependencies:
-  cognitive_complexity: ^0.1.0
+  cognitive_complexity: ^0.2.0
 ```
 
 And run:
@@ -114,7 +114,7 @@ Exposes programmatic analyzers for Dart and Flutter applications.
 Add to `pubspec.yaml`:
 ```yaml
 dependencies:
-  cognitive_complexity: ^0.1.0-wip
+  cognitive_complexity: ^0.2.0
 ```
 
 ### Programmatic Scan Example

--- a/README.md
+++ b/README.md
@@ -21,6 +21,41 @@ Campbell.
 
 ---
 
+## Scoring Model
+
+Scores follow the [SonarSource Cognitive Complexity whitepaper][whitepaper]
+(G. Ann Campbell, v1.7):
+
+* **Structural (+1, plus current nesting depth)**: `if`, the conditional
+  (`?:`) operator, `switch` statements and expressions, `for` (including
+  `for-in` and `await for`), `while`, `do-while`, and `catch`. Each also
+  deepens nesting for its contents.
+* **Hybrid (flat +1, no nesting penalty)**: `else` and `else if`. An
+  `else if` chain does not deepen nesting — contents of every branch sit one
+  level below the head `if`.
+* **Fundamental (flat +1)**: each sequence of like logical operators
+  (`a && b && c` is +1) with +1 for each alternation between `&&` and `||`,
+  and labeled `break`/`continue`.
+* **Nesting only (+0)**: lambdas and local function declarations deepen
+  nesting for their contents but add nothing themselves.
+* **Free (+0)**: `try`/`finally`, `throw`/`rethrow`, early `return`,
+  unlabeled `break`/`continue`, null-aware operators (`??`, `??=`, `?.`),
+  `assert`, and `switch` case labels.
+
+Dart-specific interpretations of the spec:
+
+* Pattern `when` guards add +1 (a guard is an extra condition to evaluate).
+* Pattern-level combinators (`case 1 || 2:`, `case > 0 && < 10`) are free —
+  an or-pattern is the modern spelling of stacked case labels, which the
+  spec scores at zero.
+* The whitepaper's "+1 for each method in a recursion cycle" is not
+  implemented, matching SonarSource's own reference implementation
+  (sonar-java), which omits it as well.
+
+[whitepaper]: https://www.sonarsource.com/docs/CognitiveComplexity.pdf
+
+---
+
 ## 💻 CLI Usage
 
 You can run the scanner on-demand without installation, locally inside a project, or globally.

--- a/lib/src/cognitive_complexity_visitor.dart
+++ b/lib/src/cognitive_complexity_visitor.dart
@@ -2,15 +2,29 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
-/// An AST visitor that calculates Cognitive Complexity algorithmically.
+/// An AST visitor that calculates Cognitive Complexity following the
+/// SonarSource whitepaper specification (G. Ann Campbell, v1.7).
 ///
-/// Follows standard Cognitive Complexity rules:
-/// - Rule 1 (+0 Penalty): Null-aware operators and switch labels cost +0.
-/// - Rule 2 (+1 Base): Flow interruptions (`if`, `for`, `while`, `catch`,
-///   logical operators, and pattern `when` guards). Exhaustive `switch` blocks
-///   cost a flat +1 base regardless of arm count.
-/// - Rule 3 (+D Depth): Nesting multiplier added to base cost for nested flow.
-///   Exceptions: `else`, `else if`, and `catch` get flat +1 without depth.
+/// - Structural increments (+1 plus the current nesting depth): `if`, the
+///   conditional (`?:`) operator, `switch` statements and expressions, `for`
+///   (including `for-in` and `await for`), `while`, `do-while`, and `catch`.
+///   Each also increases the nesting depth for its contents.
+/// - Hybrid increments (flat +1, no nesting penalty): `else` and `else if`.
+///   An `else if` chain does not deepen nesting: contents of every branch in
+///   the chain sit one level below the head `if`.
+/// - Fundamental increments (flat +1): each sequence of like logical
+///   operators (`&&`/`||`, with +1 for each alternation between them),
+///   labeled `break`/`continue`, and pattern `when` guards (a Dart-specific
+///   extension of the spec).
+/// - Nesting only (+0): lambdas and local function declarations increase
+///   depth for their contents but add no increment themselves.
+/// - Free (+0): `try`/`finally`, `throw`/`rethrow`, early `return`,
+///   unlabeled `break`/`continue`, null-aware operators (`??`, `?.`),
+///   `switch` case labels and patterns, and `assert`.
+///
+/// Known deviation: the whitepaper's "+1 for each method in a recursion
+/// cycle" is not implemented (matching SonarSource's own reference
+/// implementation, which omits it as well).
 class CognitiveComplexityVisitor extends RecursiveAstVisitor<void> {
   int _score = 0;
   int _depth = 0;
@@ -26,6 +40,16 @@ class CognitiveComplexityVisitor extends RecursiveAstVisitor<void> {
     _depth++;
     f();
     _depth--;
+  }
+
+  /// Accumulates the score of every non-null node in [nodes].
+  ///
+  /// Useful for scoring a declaration made of several disjoint parts, such
+  /// as a constructor's parameter list, initializers, and body.
+  void visitAll(Iterable<AstNode?> nodes) {
+    for (final node in nodes) {
+      node?.accept(this);
+    }
   }
 
   @override
@@ -52,9 +76,10 @@ class CognitiveComplexityVisitor extends RecursiveAstVisitor<void> {
     final elseStmt = node.elseStatement;
     if (elseStmt != null) {
       if (elseStmt is IfStatement) {
-        _withIncrementedDepth(() {
-          elseStmt.accept(this);
-        });
+        // `else if` links are hybrid increments: the chained `if` scores a
+        // flat +1 and its branches nest relative to the head `if`, so no
+        // extra depth is added here.
+        elseStmt.accept(this);
       } else {
         _addScore(1);
         _withIncrementedDepth(() {
@@ -88,9 +113,8 @@ class CognitiveComplexityVisitor extends RecursiveAstVisitor<void> {
     final elseEl = node.elseElement;
     if (elseEl != null) {
       if (elseEl is IfElement) {
-        _withIncrementedDepth(() {
-          elseEl.accept(this);
-        });
+        // Hybrid increment: same handling as `else if` statements.
+        elseEl.accept(this);
       } else {
         _addScore(1);
         _withIncrementedDepth(() {
@@ -138,7 +162,7 @@ class CognitiveComplexityVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitSwitchStatement(SwitchStatement node) {
-    _addScore(1);
+    _addScore(1 + _depth);
     node.expression.accept(this);
     _withIncrementedDepth(() {
       for (final member in node.members) {
@@ -149,7 +173,7 @@ class CognitiveComplexityVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitSwitchExpression(SwitchExpression node) {
-    _addScore(1);
+    _addScore(1 + _depth);
     node.expression.accept(this);
     _withIncrementedDepth(() {
       for (final caseArm in node.cases) {
@@ -170,7 +194,7 @@ class CognitiveComplexityVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitCatchClause(CatchClause node) {
-    _addScore(1);
+    _addScore(1 + _depth);
     _withIncrementedDepth(() {
       node.body.accept(this);
     });
@@ -196,14 +220,6 @@ class CognitiveComplexityVisitor extends RecursiveAstVisitor<void> {
   void visitWhenClause(WhenClause node) {
     _addScore(1);
     super.visitWhenClause(node);
-  }
-
-  @override
-  void visitFunctionDeclaration(FunctionDeclaration node) {
-    if (node.parent is! CompilationUnit) {
-      _addScore(1);
-    }
-    super.visitFunctionDeclaration(node);
   }
 
   @override

--- a/lib/src/complexity_analyzer.dart
+++ b/lib/src/complexity_analyzer.dart
@@ -35,6 +35,18 @@ class FunctionComplexity {
   String toString() => '$name ($filePath:L$startLine-$endLine): $score';
 }
 
+/// Whether [relativePath] sits inside a directory that should never be
+/// scanned (`.dart_tool`, `.git`, or `build` output).
+///
+/// Matches whole path segments, so `.github/` or `builders/` are not
+/// mistaken for `.git/` or `build/`.
+bool isExcludedPath(String relativePath) {
+  final segments = p.split(p.normalize(relativePath));
+  return segments.contains('.dart_tool') ||
+      segments.contains('.git') ||
+      segments.contains('build');
+}
+
 /// Analyzes Dart files and directories to compute Cognitive Complexity scores.
 class ComplexityAnalyzer {
   final FeatureSet _featureSet = FeatureSet.latestLanguageVersion();
@@ -53,10 +65,8 @@ class ComplexityAnalyzer {
     } else if (dir.existsSync()) {
       for (final entity in dir.listSync(recursive: true, followLinks: false)) {
         if (entity is File && p.extension(entity.path) == '.dart') {
-          final normalized = p.normalize(entity.path);
-          if (normalized.contains('.dart_tool') ||
-              normalized.contains('.git') ||
-              normalized.contains('build${p.separator}')) {
+          final relative = p.relative(entity.path, from: targetPath);
+          if (isExcludedPath(relative)) {
             continue;
           }
           results.addAll(analyzeFile(entity.path));
@@ -109,6 +119,12 @@ class ComplexityAnalyzer {
   }
 }
 
+String _accessorPrefix({required bool isGetter, required bool isSetter}) {
+  if (isGetter) return 'get ';
+  if (isSetter) return 'set ';
+  return '';
+}
+
 class _DeclarationFinder extends RecursiveAstVisitor<void> {
   final String filePath;
   final LineInfo lineInfo;
@@ -139,9 +155,12 @@ class _DeclarationFinder extends RecursiveAstVisitor<void> {
     return null;
   }
 
-  void _record(String name, AstNode declarationNode, AstNode bodyNode) {
+  /// Scores [parts] (parameter lists carry default values, constructors
+  /// carry initializers) with a single visitor so nothing outside the body
+  /// proper is missed.
+  void _record(String name, AstNode declarationNode, List<AstNode?> parts) {
     final visitor = CognitiveComplexityVisitor();
-    bodyNode.accept(visitor);
+    visitor.visitAll(parts);
 
     final startLoc = lineInfo.getLocation(declarationNode.offset);
     final endLoc = lineInfo.getLocation(declarationNode.end);
@@ -159,21 +178,33 @@ class _DeclarationFinder extends RecursiveAstVisitor<void> {
 
   @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
-    if (node.parent is CompilationUnit && !node.name.type.isKeyword) {
-      _record(node.name.lexeme, node, node.functionExpression.body);
+    // Note: pseudo-keywords (`show`, `on`, ...) are legal declaration names
+    // and parse with keyword-typed name tokens, so no keyword filtering here.
+    if (node.parent is CompilationUnit) {
+      final prefix = _accessorPrefix(
+        isGetter: node.isGetter,
+        isSetter: node.isSetter,
+      );
+      _record('$prefix${node.name.lexeme}', node, [
+        node.functionExpression.parameters,
+        node.functionExpression.body,
+      ]);
     }
   }
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
     final rawName = node.name.lexeme;
-    final prefix = node.isGetter ? 'get ' : (node.isSetter ? 'set ' : '');
+    final prefix = _accessorPrefix(
+      isGetter: node.isGetter,
+      isSetter: node.isSetter,
+    );
     final enclosing = _getEnclosingName(node);
     final fullName = enclosing != null
         ? '$prefix$enclosing.$rawName'
         : '$prefix$rawName';
 
-    _record(fullName, node, node.body);
+    _record(fullName, node, [node.parameters, node.body]);
   }
 
   @override
@@ -182,6 +213,6 @@ class _DeclarationFinder extends RecursiveAstVisitor<void> {
     final constName = node.name?.lexeme;
     final fullName = constName == null ? enclosing : '$enclosing.$constName';
 
-    _record(fullName, node, node.body);
+    _record(fullName, node, [node.parameters, ...node.initializers, node.body]);
   }
 }

--- a/lib/src/delta_analyzer.dart
+++ b/lib/src/delta_analyzer.dart
@@ -36,7 +36,9 @@ class ComplexityDelta {
   int get delta => (newScore ?? 0) - (oldScore ?? 0);
 
   bool isViolation({int? failThreshold, bool failOnIncrease = false}) {
-    if (failOnIncrease && delta > 0) {
+    // Newly added declarations have no baseline to "increase" from; they are
+    // governed by [failThreshold] alone.
+    if (failOnIncrease && status == DeltaStatus.increased) {
       return true;
     }
     if (failThreshold != null &&

--- a/lib/src/git_diff_service.dart
+++ b/lib/src/git_diff_service.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:path/path.dart' as p;
+import 'complexity_analyzer.dart';
 
 /// A service wrapping Git commands for repository evaluation and diffing.
 class GitDiffService {
@@ -62,10 +63,7 @@ class GitDiffService {
       if (relPath.isEmpty || p.extension(relPath) != '.dart') {
         continue;
       }
-      final norm = p.normalize(relPath);
-      if (norm.contains('.dart_tool') ||
-          norm.contains('.git') ||
-          norm.contains('build${p.separator}')) {
+      if (isExcludedPath(relPath)) {
         continue;
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cognitive_complexity
 description: Algorithmic Cognitive Complexity calculation library and CLI tool for Dart and Flutter.
-version: 0.2.0-wip
+version: 0.2.0
 repository: https://github.com/kevmoo/cognitive_complexity.dart
 
 executables:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cognitive_complexity
 description: Algorithmic Cognitive Complexity calculation library and CLI tool for Dart and Flutter.
-version: 0.1.0
+version: 0.2.0-wip
 repository: https://github.com/kevmoo/cognitive_complexity.dart
 
 executables:

--- a/test/cognitive_complexity_test.dart
+++ b/test/cognitive_complexity_test.dart
@@ -87,6 +87,8 @@ void main() {
     });
 
     test('Nested else-if chain', () {
+      // if (a) +1, else-if (b) +1 flat, if (c) +2 (nesting relative to the
+      // head if, per the whitepaper's toRegexp example).
       check(
         _getComplexity('''
         if (a) {
@@ -97,7 +99,7 @@ void main() {
           }
         }
       '''),
-      ).equals(5);
+      ).equals(4);
     });
 
     test('Loops', () {
@@ -183,6 +185,8 @@ void main() {
     });
 
     test('Nested catch inside catch', () {
+      // Outer catch +1, inner catch +2 (nesting = 1), per the whitepaper's
+      // addVersion example.
       check(
         _getComplexity('''
         try {
@@ -195,7 +199,7 @@ void main() {
           }
         }
       '''),
-      ).equals(2);
+      ).equals(3);
     });
 
     test('If inside catch', () {
@@ -283,6 +287,8 @@ void main() {
     });
 
     test('Nested function', () {
+      // Local functions add no structural increment; they only deepen
+      // nesting, so the inner `if` costs +2.
       check(
         _getComplexity('''
         void outer() {
@@ -293,7 +299,7 @@ void main() {
           }
         }
       '''),
-      ).equals(3);
+      ).equals(2);
     });
 
     test('Lambda expression nesting', () {
@@ -323,13 +329,13 @@ void main() {
             } else {                         // D=1 -> +1 (else flat)
                 return 1000;
               }
-            } else if (protocol == 'ftp') {    // D=0 -> +1 (else if flat) +3 (nested...)
-            return isSecure ? 10000 : 2000;
+            } else if (protocol == 'ftp') {    // D=0 -> +1 (else if flat)
+            return isSecure ? 10000 : 2000;  // D=1 -> +2 (ternary + depth 1)
           }
           return 0;
         }
       ''';
-      check(_getComplexity(code)).equals(12);
+      check(_getComplexity(code)).equals(11);
     });
 
     test('After Refactoring Sample 1', () {
@@ -355,6 +361,234 @@ void main() {
         }
       ''';
       check(_getComplexity(code)).equals(2);
+    });
+  });
+
+  group('Whitepaper spec conformance', () {
+    test('Switch statement nested in if receives nesting increment', () {
+      check(
+        _getComplexity('''
+        if (a) {
+          switch (x) {
+            case 1:
+              print(1);
+          }
+        }
+      '''),
+      ).equals(3);
+    });
+
+    test('Switch expression nested in if receives nesting increment', () {
+      check(
+        _getComplexity('''
+        if (a) {
+          final y = switch (x) {
+            1 => 'one',
+            _ => 'other',
+          };
+          print(y);
+        }
+      '''),
+      ).equals(3);
+    });
+
+    test('Catch nested in if receives nesting increment', () {
+      check(
+        _getComplexity('''
+        if (a) {
+          try {
+            print(1);
+          } catch (e) {
+            print(e);
+          }
+        }
+      '''),
+      ).equals(3);
+    });
+
+    test('Catch nested in while receives nesting increment', () {
+      // Mirrors the whitepaper `addVersion` example: catch inside a loop
+      // costs +2 (nesting = 1).
+      check(
+        _getComplexity('''
+        while (a) {
+          try {
+            print(1);
+          } catch (e) {
+            print(e);
+          }
+        }
+      '''),
+      ).equals(3);
+    });
+
+    test('Try and finally are free', () {
+      check(
+        _getComplexity('''
+        try {
+          if (a) print(1);
+        } finally {
+          print(2);
+        }
+      '''),
+      ).equals(1);
+    });
+
+    test('Do-while nests its body', () {
+      check(
+        _getComplexity('''
+        do {
+          if (a) print(1);
+        } while (b);
+      '''),
+      ).equals(3);
+    });
+
+    test('Null-aware operators are free', () {
+      check(
+        _getComplexity('''
+        int? f(List<int>? a, int? b) {
+          b ??= a?.length;
+          final c = [?b, ...?a];
+          return c.firstOrNull ?? 0;
+        }
+      '''),
+      ).equals(0);
+    });
+
+    test('Mixed logical operator sequences (whitepaper example)', () {
+      // if +1, `&& &&` +1, `|| ||` +1, `&&` +1.
+      check(
+        _getComplexity('if (a && b && c || d || e && f) { print(1); }'),
+      ).equals(4);
+    });
+
+    test('Negation starts a new logical sequence (whitepaper example)', () {
+      // if +1, outer `&&` +1, `&&` inside `!(...)` +1.
+      check(_getComplexity('if (a && !(b && c)) { print(1); }')).equals(3);
+    });
+
+    test('Logical sequences count outside conditions', () {
+      check(_getComplexity('final x = a && b && c;')).equals(1);
+    });
+
+    test('Logical-or pattern in a case is free, like multiple labels', () {
+      check(
+        _getComplexity('''
+        void f(int x) {
+          switch (x) {
+            case 1 || 2:
+              print(x);
+          }
+        }
+      '''),
+      ).equals(1);
+    });
+
+    test('Relational and logical-and patterns in if-case are free', () {
+      check(
+        _getComplexity('''
+        void f(Object x) {
+          if (x case > 0 && < 10) {
+            print(x);
+          }
+        }
+      '''),
+      ).equals(1);
+    });
+
+    test('When guard on a switch case adds one', () {
+      check(
+        _getComplexity('''
+        void f(Object x) {
+          switch (x) {
+            case final int i when i.isEven:
+              print(i);
+          }
+        }
+      '''),
+      ).equals(2);
+    });
+
+    test('Else-if chains share the head nesting level (toRegexp shape)', () {
+      // Condensed version of the whitepaper's toRegexp example.
+      check(
+        _getComplexity('''
+        while (i < n) {           // +1
+          if (a) {                // +2 (nesting = 1)
+            print(1);
+          } else if (b) {         // +1
+            if (c && d) {         // +3 (nesting = 2), +1 for `&&`
+              if (e) {            // +4 (nesting = 3)
+                print(2);
+              } else {            // +1
+                print(3);
+              }
+            } else {              // +1
+              print(4);
+            }
+          } else if (f) {         // +1
+            print(5);
+          } else {                // +1
+            print(6);
+          }
+        }
+      '''),
+      ).equals(16);
+    });
+  });
+
+  group('Declaration discovery', () {
+    final analyzer = ComplexityAnalyzer();
+
+    test('Constructor initializers are scored', () {
+      final results = analyzer.analyzeCode('''
+        class A {
+          final int x;
+          A(bool b) : x = b ? 1 : 2;
+        }
+      ''');
+      check(results).length.equals(1);
+      check(results.single.name).equals('A');
+      check(results.single.score).equals(1);
+    });
+
+    test('Default parameter values are scored', () {
+      final results = analyzer.analyzeCode('''
+        void f([int x = bool.fromEnvironment('a') ? 1 : 2]) {}
+      ''');
+      check(results.single.score).equals(1);
+    });
+
+    test('Top-level getters and setters are named with accessor prefix', () {
+      final results = analyzer.analyzeCode('''
+        int get foo => 1 > 0 ? 1 : 2;
+        set bar(int v) {}
+      ''');
+      check(results.map((r) => r.name)).unorderedEquals(['get foo', 'set bar']);
+    });
+
+    test('Functions named with pseudo-keywords are discovered', () {
+      final results = analyzer.analyzeCode('''
+        void show() {
+          if (a) print(1);
+        }
+      ''');
+      check(results.single.name).equals('show');
+      check(results.single.score).equals(1);
+    });
+
+    test('Local functions fold into their enclosing declaration', () {
+      final results = analyzer.analyzeCode('''
+        void f(bool a) {
+          void g() {
+            if (a) print(1);
+          }
+          g();
+        }
+      ''');
+      check(results.single.name).equals('f');
+      check(results.single.score).equals(2);
     });
   });
 }

--- a/test/delta_analyzer_test.dart
+++ b/test/delta_analyzer_test.dart
@@ -76,6 +76,22 @@ void main() {
       check(removed.oldScore).isNotNull().equals(1);
       check(removed.newScore).isNull();
     });
+
+    test('fail-on-increase ignores newly added functions', () {
+      const oldCode = 'void existing() {}';
+      const newCode = '''
+        void existing() {}
+        void brandNew(bool a) { if (a) print(1); }
+      ''';
+
+      final deltas = analyzer.computeDeltaForCode(oldCode, newCode);
+      final added = deltas.firstWhere((d) => d.name == 'brandNew');
+      check(added.status).equals(DeltaStatus.added);
+      // A new function has no baseline to increase from; it is governed by
+      // the fail threshold instead.
+      check(added.isViolation(failOnIncrease: true)).isFalse();
+      check(added.isViolation(failOnIncrease: true, failThreshold: 0)).isTrue();
+    });
   });
 
   group('GitHubReporter Annotation Emissions', () {


### PR DESCRIPTION
Verified against the SonarSource whitepaper (Appendix B and its worked
examples) and the sonar-java reference implementation.

Scoring fixes:
- `else if` chains no longer deepen nesting; branch contents sit one
  level below the head `if`
- `switch` statements/expressions and `catch` clauses now receive the
  standard nesting increment when nested (previously flat +1)
- Local function declarations no longer add a structural +1; like
  lambdas, they only deepen nesting

Analyzer and CLI fixes:
- Constructor initializers and parameter default values are now scored
- Top-level functions named with pseudo-keywords (`show`, `on`, ...) are
  no longer skipped
- Top-level getters/setters gain a `get `/`set ` name prefix
- `--fail-on-increase` no longer flags newly added declarations; they
  are governed by `--fail-threshold` alone
- Directory exclusion matches whole path segments, so `.github/` is no
  longer swallowed by the `.git` filter

Documents the scoring model and deliberate deviations (pattern `when`
guards +1, pattern combinators free, recursion increment omitted) in the
README; bumps to 0.2.0-wip. Tests: 42 -> 62.
