### PR TITLE
ci(publish): restore ecosystem firehose publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,13 +3,15 @@
 name: Publish
 
 on:
+  pull_request:
+    branches: [ main ]
   push:
     tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
 
 jobs:
   publish:
     if: ${{ github.repository_owner == 'kevmoo' }}
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
     permissions:
       id-token: write # Required for authentication using OIDC
       pull-requests: write # Required for writing the pull request note


### PR DESCRIPTION
- Revert publish workflow to use dart-lang/ecosystem/.github/workflows/publish.yaml@main

- Re-enable pull_request trigger on main to restore automated Firehose dry-run validation and review feedback notes on pull requests
