### PR TITLE
fix(data-flow): treat loop-carried reads as live outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   - Signatures now propagate `await for` async-ness, use use-site static types
     (preserving promotion), include enclosing type parameters with their
     bounds, and sanitize/deduplicate record field names.
+  - Liveness now follows loop back edges: a variable mutated in a slice inside
+    a loop is reported as an output when it is read anywhere in that loop,
+    even textually before the slice.
 
 ## 0.2.1
 

--- a/lib/src/data_flow/data_flow_analyzer.dart
+++ b/lib/src/data_flow/data_flow_analyzer.dart
@@ -216,7 +216,7 @@ class DataFlowAnalyzer {
     return typeParams;
   }
 
-  List<({int offset, int end})> _collectEnclosingLoopSpans(
+  List<({int offset, int end, int carryBoundary})> _collectEnclosingLoopSpans(
     AstNode enclosingNode,
     int sliceStartOffset,
     int sliceEndOffset,
@@ -246,31 +246,42 @@ class DataFlowAnalyzer {
 class _EnclosingLoopCollector extends RecursiveAstVisitor<void> {
   final int sliceStartOffset;
   final int sliceEndOffset;
-  final List<({int offset, int end})> spans = [];
+  final List<({int offset, int end, int carryBoundary})> spans = [];
 
   _EnclosingLoopCollector(this.sliceStartOffset, this.sliceEndOffset);
 
-  void _addIfEnclosing(AstNode node) {
+  void _addIfEnclosing(AstNode node, int carryBoundary) {
     if (node.offset < sliceStartOffset && node.end > sliceEndOffset) {
-      spans.add((offset: node.offset, end: node.end));
+      spans.add((
+        offset: node.offset,
+        end: node.end,
+        carryBoundary: carryBoundary,
+      ));
     }
   }
 
   @override
   void visitForStatement(ForStatement node) {
-    _addIfEnclosing(node);
+    // A C-style header declaration (`for (var i = 0; ...)`) carries its value
+    // across iterations via the condition and updaters, so it sits inside the
+    // carry boundary. A for-in variable is re-bound from the iterator every
+    // iteration and cannot carry a slice write backwards.
+    final boundary = node.forLoopParts is ForParts
+        ? node.body.offset
+        : node.offset;
+    _addIfEnclosing(node, boundary);
     super.visitForStatement(node);
   }
 
   @override
   void visitWhileStatement(WhileStatement node) {
-    _addIfEnclosing(node);
+    _addIfEnclosing(node, node.offset);
     super.visitWhileStatement(node);
   }
 
   @override
   void visitDoStatement(DoStatement node) {
-    _addIfEnclosing(node);
+    _addIfEnclosing(node, node.offset);
     super.visitDoStatement(node);
   }
 }

--- a/lib/src/data_flow/data_flow_analyzer.dart
+++ b/lib/src/data_flow/data_flow_analyzer.dart
@@ -152,6 +152,11 @@ class DataFlowAnalyzer {
       lineInfo: lineInfo,
       internalDeclarations: inBlockVisitor.internalDeclarations,
       mutations: inBlockVisitor.mutations,
+      enclosingLoopSpans: _collectEnclosingLoopSpans(
+        enclosingNode,
+        startOffset,
+        endOffset,
+      ),
     );
     enclosingNode.accept(postBlockVisitor);
 
@@ -211,6 +216,16 @@ class DataFlowAnalyzer {
     return typeParams;
   }
 
+  List<({int offset, int end})> _collectEnclosingLoopSpans(
+    AstNode enclosingNode,
+    int sliceStartOffset,
+    int sliceEndOffset,
+  ) {
+    final collector = _EnclosingLoopCollector(sliceStartOffset, sliceEndOffset);
+    enclosingNode.accept(collector);
+    return collector.spans;
+  }
+
   String _getDeclarationName(AstNode node) {
     if (node is FunctionDeclaration) {
       return node.name.lexeme;
@@ -222,6 +237,41 @@ class DataFlowAnalyzer {
       return node.name?.lexeme ?? 'new';
     }
     return 'unknown';
+  }
+}
+
+/// Collects the source spans of loops that strictly enclose the slice; loops
+/// contained in (or identical to) the slice have their back edge extracted
+/// along with it and carry no liveness outside the slice.
+class _EnclosingLoopCollector extends RecursiveAstVisitor<void> {
+  final int sliceStartOffset;
+  final int sliceEndOffset;
+  final List<({int offset, int end})> spans = [];
+
+  _EnclosingLoopCollector(this.sliceStartOffset, this.sliceEndOffset);
+
+  void _addIfEnclosing(AstNode node) {
+    if (node.offset < sliceStartOffset && node.end > sliceEndOffset) {
+      spans.add((offset: node.offset, end: node.end));
+    }
+  }
+
+  @override
+  void visitForStatement(ForStatement node) {
+    _addIfEnclosing(node);
+    super.visitForStatement(node);
+  }
+
+  @override
+  void visitWhileStatement(WhileStatement node) {
+    _addIfEnclosing(node);
+    super.visitWhileStatement(node);
+  }
+
+  @override
+  void visitDoStatement(DoStatement node) {
+    _addIfEnclosing(node);
+    super.visitDoStatement(node);
   }
 }
 

--- a/lib/src/data_flow/visitors/post_block_visitor.dart
+++ b/lib/src/data_flow/visitors/post_block_visitor.dart
@@ -13,6 +13,10 @@ class PostBlockVisitor extends RecursiveAstVisitor<void> {
   final Set<Element> internalDeclarations;
   final Map<Element, VariableUsage> mutations;
 
+  /// Source spans of loops that fully enclose the slice. A read anywhere
+  /// inside such a loop is reachable from the slice via the loop's back edge.
+  final List<({int offset, int end})> enclosingLoopSpans;
+
   /// Variables that are live after the block and must be returned.
   final Map<Element, VariableUsage> liveOutputs = {};
 
@@ -22,6 +26,7 @@ class PostBlockVisitor extends RecursiveAstVisitor<void> {
     required this.lineInfo,
     required this.internalDeclarations,
     required this.mutations,
+    this.enclosingLoopSpans = const [],
   });
 
   bool _isAfterSlice(AstNode node) => node.offset > sliceEndOffset;
@@ -29,6 +34,7 @@ class PostBlockVisitor extends RecursiveAstVisitor<void> {
   @override
   void visitSimpleIdentifier(SimpleIdentifier node) {
     if (!_isAfterSlice(node)) {
+      _maybeRecordLoopCarriedRead(node);
       super.visitSimpleIdentifier(node);
       return;
     }
@@ -97,17 +103,53 @@ class PostBlockVisitor extends RecursiveAstVisitor<void> {
     // afterwards.
     if (mutations.containsKey(element)) {
       if (!liveOutputs.containsKey(element)) {
-        final mutation = mutations[element]!;
-        liveOutputs[element] = VariableUsage(
-          name: element.name ?? node.name,
-          type: typeName,
-          isMutated: true,
-          declarationOffset: declOffset,
-          declarationLine: declLine,
-          firstMutationLine: mutation.firstMutationLine,
-        );
+        _recordMutatedOutput(element, node, declOffset);
       }
     }
+  }
+
+  /// A read inside an enclosing loop is downstream of the slice via the
+  /// loop's back edge, so a variable the slice mutates stays live even when
+  /// the read sits textually before the slice — provided the declaration
+  /// predates the loop (a binding declared inside the loop is re-created
+  /// each iteration and cannot carry the slice's write backwards).
+  void _maybeRecordLoopCarriedRead(SimpleIdentifier node) {
+    final element = node.element;
+    if (element is! VariableElement || !mutations.containsKey(element)) {
+      return;
+    }
+    if (liveOutputs.containsKey(element)) return;
+    if (_isPropertyOrLabel(node) || !node.inGetterContext()) return;
+
+    final declOffset = _resolveOffset(element);
+    for (final loop in enclosingLoopSpans) {
+      if (node.offset >= loop.offset &&
+          node.end <= loop.end &&
+          declOffset >= 0 &&
+          declOffset < loop.offset) {
+        _recordMutatedOutput(element, node, declOffset);
+        return;
+      }
+    }
+  }
+
+  void _recordMutatedOutput(
+    VariableElement element,
+    SimpleIdentifier node,
+    int declOffset,
+  ) {
+    final currentLine = lineInfo.getLocation(node.offset).lineNumber;
+    final declLine = declOffset >= 0
+        ? lineInfo.getLocation(declOffset).lineNumber
+        : currentLine;
+    liveOutputs[element] = VariableUsage(
+      name: element.name ?? node.name,
+      type: _resolveTypeName(element),
+      isMutated: true,
+      declarationOffset: declOffset,
+      declarationLine: declLine,
+      firstMutationLine: mutations[element]!.firstMutationLine,
+    );
   }
 
   int _resolveOffset(Element element) => element.firstFragment.nameOffset ?? -1;

--- a/lib/src/data_flow/visitors/post_block_visitor.dart
+++ b/lib/src/data_flow/visitors/post_block_visitor.dart
@@ -15,7 +15,9 @@ class PostBlockVisitor extends RecursiveAstVisitor<void> {
 
   /// Source spans of loops that fully enclose the slice. A read anywhere
   /// inside such a loop is reachable from the slice via the loop's back edge.
-  final List<({int offset, int end})> enclosingLoopSpans;
+  /// A declaration at an offset below `carryBoundary` survives the back edge;
+  /// bindings declared at or past it are re-created each iteration.
+  final List<({int offset, int end, int carryBoundary})> enclosingLoopSpans;
 
   /// Variables that are live after the block and must be returned.
   final Map<Element, VariableUsage> liveOutputs = {};
@@ -126,7 +128,7 @@ class PostBlockVisitor extends RecursiveAstVisitor<void> {
       if (node.offset >= loop.offset &&
           node.end <= loop.end &&
           declOffset >= 0 &&
-          declOffset < loop.offset) {
+          declOffset < loop.carryBoundary) {
         _recordMutatedOutput(element, node, declOffset);
         return;
       }

--- a/test/data_flow/analyzer_test.dart
+++ b/test/data_flow/analyzer_test.dart
@@ -458,6 +458,51 @@ void perItem(List<int> items) {
       check(result.outputs).isEmpty();
     });
 
+    test(
+      'C-style loop header variable mutated in slice is loop-carried',
+      () async {
+        const code = '''
+void skipper(List<int> items) {
+  for (var i = 0; i < items.length; i++) {
+    // Target: Line 4
+    i += items[i];
+  }
+}
+''';
+        final result = await analyzer.analyzeSource(
+          sourceCode: code,
+          startLine: 4,
+          endLine: 4,
+        );
+        // The write to i feeds the loop condition and updater via the back
+        // edge; a void extraction would loop forever.
+        check(result.outputs.map((o) => o.name).toList()).deepEquals(['i']);
+        check(
+          result.suggestedSignature,
+        ).equals('int _extracted(int i, List<int> items)');
+      },
+    );
+
+    test('for-in loop variable mutated in slice is not loop-carried', () async {
+      const code = '''
+void rewrite(List<int> items) {
+  for (var item in items) {
+    print(item);
+    // Target: Line 5
+    item = item * 2;
+  }
+}
+''';
+      final result = await analyzer.analyzeSource(
+        sourceCode: code,
+        startLine: 5,
+        endLine: 5,
+      );
+      // item is re-bound from the iterator every iteration, so the slice's
+      // write never survives the back edge.
+      check(result.outputs).isEmpty();
+    });
+
     test('VULN-10: Pattern variable declarations', () async {
       const code = '''
 void testMethod(List<int> list) {

--- a/test/data_flow/analyzer_test.dart
+++ b/test/data_flow/analyzer_test.dart
@@ -392,6 +392,72 @@ T process<T extends num>(T item) {
       check(result.suggestedSignature).contains('<T extends num>');
     });
 
+    test('Loop-carried read makes a mutated variable a live output', () async {
+      const code = '''
+void tally(List<int> items) {
+  var total = 0;
+  for (var i = 0; i < items.length; i++) {
+    print(total);
+    // Target: Line 6
+    total = total + items[i];
+  }
+}
+''';
+      final result = await analyzer.analyzeSource(
+        sourceCode: code,
+        startLine: 6,
+        endLine: 6,
+      );
+      // total flows around the loop back edge into print(total) and the
+      // slice's own read; extracting with a void signature would lose it.
+      check(result.outputs.map((o) => o.name).toList()).deepEquals(['total']);
+      check(
+        result.suggestedSignature,
+      ).equals('int _extracted(int total, List<int> items, int i)');
+    });
+
+    test(
+      'Mutated variable never read in the loop is not a live output',
+      () async {
+        const code = '''
+void reset(List<int> items) {
+  var flag = 0;
+  for (var i = 0; i < items.length; i++) {
+    // Target: Line 5
+    flag = i;
+  }
+}
+''';
+        final result = await analyzer.analyzeSource(
+          sourceCode: code,
+          startLine: 5,
+          endLine: 5,
+        );
+        check(result.outputs).isEmpty();
+      },
+    );
+
+    test('Variable re-declared each iteration is not loop-carried', () async {
+      const code = '''
+void perItem(List<int> items) {
+  for (final item in items) {
+    var acc = 0;
+    print(acc);
+    // Target: Line 6
+    acc = item * 2;
+  }
+}
+''';
+      final result = await analyzer.analyzeSource(
+        sourceCode: code,
+        startLine: 6,
+        endLine: 6,
+      );
+      // acc is re-initialized every iteration, so the slice's write never
+      // survives the back edge.
+      check(result.outputs).isEmpty();
+    });
+
     test('VULN-10: Pattern variable declarations', () async {
       const code = '''
 void testMethod(List<int> list) {


### PR DESCRIPTION
Liveness was decided by scanning source text after the slice, but lexical
order is not execution order: when a slice sits inside a loop, a variable
it mutates flows around the back edge into reads that appear textually
earlier (loop body before the slice, condition, updater, or the slice's
own reads). Those variables were reported as dead, producing void
signatures that silently drop the mutation on extraction.

- Collect spans of loops strictly enclosing the slice.
- In PostBlockVisitor, a read inside such a loop marks a slice-mutated
  variable as a live output, provided its declaration predates the loop
  (bindings declared inside the loop are re-created each iteration and
  cannot carry the write backwards).
- Sound over-approximation: may over-report an output, never emits the
  broken void signature.

Tracks the precise CFG-based solution in #15.

Fixes the demonstrated case:

    void tally(List<int> items) {
      var total = 0;
      for (var i = 0; i < items.length; i++) {
        print(total);
        total = total + items[i];  // slice
      }
    }

outputs [] -> [total]; signature void -> int _extracted(...).
