### PR TITLE
docs: show on-demand and dart-install invocations for data_flow CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ dart run cognitive_complexity:data_flow --format=text lib/src/my_file.dart:45-80
 dart run cognitive_complexity:data_flow --name=_processItem lib/src/my_file.dart:45-80
 ```
 
+Like the scanner, it also runs on-demand without a project dependency, and
+`dart install cognitive_complexity` puts a `data_flow` executable on your PATH:
+
+```bash
+# On-demand (resolves the latest published version)
+dart run cognitive_complexity:data_flow@ lib/src/my_file.dart:45-80
+
+# After global installation
+data_flow lib/src/my_file.dart:45-80
+```
+
 ### Programmatic Data-Flow API
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add the package to your `dev_dependencies` in `pubspec.yaml`:
 
 ```yaml
 dev_dependencies:
-  cognitive_complexity: ^0.2.0
+  cognitive_complexity: ^0.2.2
 ```
 
 And run:
@@ -112,7 +112,7 @@ Exposes programmatic analyzers for Dart and Flutter applications.
 Add to `pubspec.yaml`:
 ```yaml
 dependencies:
-  cognitive_complexity: ^0.2.0
+  cognitive_complexity: ^0.2.2
 ```
 
 ### Programmatic Scan Example


### PR DESCRIPTION
The scanner section documents on-demand (@) and global (dart install)
usage, but the data_flow section only showed the in-project form. Add
both, verified against the published 0.2.2.
