### PR TITLE
feat(skills): anti-goodhart rubric with data_flow tier selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.2+1
+
+- Update the `dart-cognitive-complexity` agent skill: anti-goodhart 3-tier
+  decomposition rubric with deterministic tier selection via the `data_flow`
+  CLI, and a gated Tier 3 method-object reference
+  (`references/method-object.md`) absorbed from `kevmoo/kevmoo_skills`.
+- No library or CLI code changes.
+
 ## 0.2.2
 
 - Introduce `data_flow` analysis tool and library (`package:cognitive_complexity/data_flow.dart`):

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cognitive_complexity
 description: Algorithmic Cognitive Complexity calculation and Data-Flow analysis library and CLI tools for Dart and Flutter.
-version: 0.2.2
+version: 0.2.2+1
 repository: https://github.com/kevmoo/cognitive_complexity.dart
 
 executables:

--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: Apache-2.0
 key_features:
   - Automated CLI evaluation
-  - 3-tier execution scope matrix
+  - Scoped execution matrix (targeted / delta / full)
   - Interactive refactoring triage
   - Dart 3 pattern matching refactorings
 ---
@@ -48,7 +48,7 @@ complexity scores deterministically without LLM arithmetic or AST interpretation
 
 Select the execution scope based on the user's task instructions:
 
-### Tier 1: Targeted Scope (Specific File, Directory, or Class)
+### Scope 1: Targeted (Specific File, Directory, or Class)
 When the user references a discrete component (e.g., "check complexity in
 `lib/src/auth/`" or "audit `order_service.dart`"), pass explicit targets:
 
@@ -56,7 +56,7 @@ When the user references a discrete component (e.g., "check complexity in
 dart run cognitive_complexity@ --threshold 15 lib/src/auth/
 ```
 
-### Tier 2: Delta Scope (Pull Request, Branch, or Pre-flight Audit)
+### Scope 2: Delta (Pull Request, Branch, or Pre-flight Audit)
 When reviewing a feature branch, active commit stack, or PR, avoid full-project
 scanning. Isolate evaluation strictly to modified declarations against trunk:
 
@@ -64,7 +64,7 @@ scanning. Isolate evaluation strictly to modified declarations against trunk:
 dart run cognitive_complexity@ --git-diff origin/main --fail-on-increase
 ```
 
-### Tier 3: Whole-Project Scope (Default Naked Invocation)
+### Scope 3: Whole-Project (Default Naked Invocation)
 When invoked without targeting parameters ("scan my project for complexity" or
 `/cognitive-complexity`), audit the standard source and test roots:
 
@@ -106,7 +106,7 @@ Output a ranked Markdown **Complexity Triage Report** directly in chat (or to an
 artifact for extensive findings) containing:
 * Flagged function name and clickable file local path.
 * Current complexity score versus operational ceiling.
-* Recommended refactoring strategy (Pattern A, B, or C) and unit test status.
+* Recommended refactoring strategy (Pattern A, B, D, or a Pattern C tier) and unit test status.
 
 ### Stage 2: Interactive User Selection (Confirmation Gate)
 Pause execution and prompt the user (via interactive choice or chat) to select
@@ -236,42 +236,48 @@ Future<void> syncPayload(User? user, Payload? data) async {
 #### Deterministic Tier Selection via `data_flow`
 
 Do not eyeball which tier a candidate slice belongs to. Run the companion
-statement-level data-flow analyzer on the exact line slice you intend to
-extract:
+statement-level data-flow analyzer (on-demand form; same SDK 3.12.0+
+requirement as the scanner) on each line slice you intend to extract:
 
 ```bash
-dart run cognitive_complexity:data_flow lib/src/my_file.dart:45-80
+dart run cognitive_complexity:data_flow@ lib/src/my_file.dart:45-80
 ```
 
-Its report (inputs, mutations, live outputs, control-flow escapes, and a
-synthesized Dart 3 record signature) selects the tier for you:
+Its report (`inputs`, `mutations`, live `outputs`, control-flow escapes, and
+a synthesized Dart 3 record signature) selects the tier. These bullets are
+the ONLY selection rules:
 
-* **Cleanly extractable, ≤ 3 live outputs** → Tier 1 or 2. Use the
-  synthesized record signature verbatim.
+* **Cleanly extractable, ≤ 1 live output, ≤ 3 inputs** → Tier 2: extract a
+  standard private helper returning that value.
+* **Cleanly extractable, 2–3 live outputs** → Tier 1: extract a static or
+  top-level function and use the synthesized record signature verbatim.
 * **4+ live outputs** → Tier 1 with a dedicated `Result` dataclass instead of
   a wide record.
-* **Control-flow escapes (`return`/`break`/`continue` targeting outer
-  scopes)** → restructure with guard clauses (Pattern B) first, then re-run
-  the analysis.
-* **Dense mutation web across multiple slices** (the same 3+ mutable
-  variables threading through every candidate extraction) → only then is
-  Tier 3 on the table.
+* **Control-flow escapes** → not extractable as-is. For `return`, `break`,
+  or `continue` targeting outer scopes, restructure with guard clauses
+  (Pattern B) and re-run the analysis. For `yield`, restructure the
+  generator before attempting any extraction.
+* **Tier 3 gate (mutation-web check)** → Tier 3 requires recorded evidence,
+  not judgment. Run `data_flow` on at least two distinct candidate slices of
+  the function. Tier 3 is permitted ONLY if the intersection of their
+  `mutations` variable names contains 3 or more entries — i.e. the same
+  mutable variables thread through every candidate extraction. Paste the
+  JSON reports into the Triage Report as evidence; without that evidence,
+  stay in Tier 1/2.
 
 When choosing how to reduce complexity on a large Dart function, follow this **3-Tier Decision Hierarchy**:
 
-1. **Tier 1 (First Choice - Pure Functional Decomposition)**:
-   - For sequential workflows, data pipelines, and validation suites.
-   - Extract static or top-level functions using Dart 3 records (`final (:data, :errors) = _stepOne(input);`).
-   - *Soft Cap*: Limit record returns to 3 simple values. If the pipeline yields 4+ distinct variables, mandate a dedicated `Result` or `Response` dataclass instead of a massive tuple to preserve schema readability.
-2. **Tier 2 (Second Choice - Standard Extract Method)**:
-   - For sub-routines requiring $\le3$ arguments without duplicating state. Extract standard private helper methods.
-3. **Tier 3 (Third Choice - Encapsulated Method Object / Runner Class)**:
-   - Reserved strictly for excessive "data trampolining"—when extracting standard methods would require passing the same 3+ mutable variables tightly coupled across multiple mutually recursive callbacks.
-   - **Gated Reference**: Read
-     [references/method-object.md](references/method-object.md) for the full
-     extraction mechanics and mandatory idioms — but ONLY after `data_flow`
-     analysis has demonstrated the mutation web described above. Do not load
-     or apply it speculatively.
+1. **Tier 1 — Pure Functional Decomposition (first choice)**: static or
+   top-level functions returning Dart 3 records
+   (`final (:data, :errors) = _stepOne(input);`), or a dedicated `Result` /
+   `Response` dataclass when the selection rules mandate one.
+2. **Tier 2 — Standard Extract Method (second choice)**: standard private
+   helper methods taking <= 3 arguments.
+3. **Tier 3 — Encapsulated Method Object (last resort)**: permitted only
+   when the mutation-web check above passes with recorded evidence. Then
+   read [references/method-object.md](references/method-object.md) for the
+   extraction mechanics and mandatory idioms. Do not load or apply it
+   speculatively.
 
 ---
 
@@ -306,8 +312,10 @@ for (final raw in rawTasks) {
 
 Run these verification commands before committing refactored code:
 
-1. **Complexity Audit**: Run `dart run cognitive_complexity@ --fail-threshold 15`
-   to verify zero declarations exceed operational ceilings.
+1. **Complexity Audit**: Run `dart run cognitive_complexity@
+   --fail-threshold 15 <refactored files>` scoped to the files you touched.
+   Pre-existing breaches elsewhere in the project do not invalidate the
+   refactor.
 2. **Code Presentation**: Run `dart format .` to maintain uniform syntactic
    styling.
 3. **Static Analysis**: Run `dart analyze` to ensure zero static warnings, lint

--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -140,7 +140,7 @@ verification baseline:
    flagged function is inadequate, pause execution and explicitly warn the user:
    > ⚠️ **Low Test Coverage Warning**: Function `<name>` in `<path>` lacks unit
    > test coverage. Structural refactoring risks silent behavioral regression.
-   
+
    Offer clear remediation paths:
    1. **(Recommended)** Write unit tests to lock in baseline behavior first.
    2. Proceed with structural refactoring and verify functionality manually.
@@ -229,27 +229,76 @@ Future<void> syncPayload(User? user, Payload? data) async {
 
 ---
 
-### Pattern C: Encapsulated Method Object Extraction
+### Pattern C: The 3-Tier Decomposition Rubric (Anti-Goodhart)
 
-When a monolithic function contains dense closures capturing heavy local variable
-state that prevents simple function extraction, migrate the function body into a
-dedicated private runner class. Promoting local variables to class instance fields
-collapses closure nesting penalties and unlocks focused helper method
-decomposition.
+**Anti-Goodhart Guardrail**: Do NOT blindly wrap monolithic functions in single-use runner classes with mutable instance variables just to bring scores below 15. Reducing the metric must never sacrifice transparent data flow or hide bugs.
 
-> **Companion Skill Hint**: If the **`encapsulated-method-object`** companion skill
-> is installed in your agent runtime, load and follow its instructions for
-> class-based encapsulation (it includes explicit overuse guardrails against
-> applying runner classes to stateless or sequential methods). Otherwise, execute
-> the standard refactoring workflow below.
+#### Deterministic Tier Selection via `data_flow`
 
-#### Refactoring Workflow
-1. Create a private class (e.g., `_PayloadProcessor`) accepting required state
-   through its constructor.
-2. Store mutable local variables as instance fields on the private class.
-3. Replace the original monolithic function body with a single instantiation and
-   method invocation on the runner object (`_PayloadProcessor(args).execute()`).
-4. Deconstruct the inner execution body into small, focused instance methods.
+Do not eyeball which tier a candidate slice belongs to. Run the companion
+statement-level data-flow analyzer on the exact line slice you intend to
+extract:
+
+```bash
+dart run cognitive_complexity:data_flow lib/src/my_file.dart:45-80
+```
+
+Its report (inputs, mutations, live outputs, control-flow escapes, and a
+synthesized Dart 3 record signature) selects the tier for you:
+
+* **Cleanly extractable, ≤ 3 live outputs** → Tier 1 or 2. Use the
+  synthesized record signature verbatim.
+* **4+ live outputs** → Tier 1 with a dedicated `Result` dataclass instead of
+  a wide record.
+* **Control-flow escapes (`return`/`break`/`continue` targeting outer
+  scopes)** → restructure with guard clauses (Pattern B) first, then re-run
+  the analysis.
+* **Dense mutation web across multiple slices** (the same 3+ mutable
+  variables threading through every candidate extraction) → only then is
+  Tier 3 on the table.
+
+When choosing how to reduce complexity on a large Dart function, follow this **3-Tier Decision Hierarchy**:
+
+1. **Tier 1 (First Choice - Pure Functional Decomposition)**:
+   - For sequential workflows, data pipelines, and validation suites.
+   - Extract static or top-level functions using Dart 3 records (`final (:data, :errors) = _stepOne(input);`).
+   - *Soft Cap*: Limit record returns to 3 simple values. If the pipeline yields 4+ distinct variables, mandate a dedicated `Result` or `Response` dataclass instead of a massive tuple to preserve schema readability.
+2. **Tier 2 (Second Choice - Standard Extract Method)**:
+   - For sub-routines requiring $\le3$ arguments without duplicating state. Extract standard private helper methods.
+3. **Tier 3 (Third Choice - Encapsulated Method Object / Runner Class)**:
+   - Reserved strictly for excessive "data trampolining"—when extracting standard methods would require passing the same 3+ mutable variables tightly coupled across multiple mutually recursive callbacks.
+   - **Gated Reference**: Read
+     [references/method-object.md](references/method-object.md) for the full
+     extraction mechanics and mandatory idioms — but ONLY after `data_flow`
+     analysis has demonstrated the mutation web described above. Do not load
+     or apply it speculatively.
+
+---
+
+### Pattern D: Fast-Fail Type Matching & Silent Data Swallowing
+
+When refactoring loops and type checks to reduce branching, **never** replace explicit type casts with pattern matching that silently drops data.
+
+**Flawed Structure (Silent Failure):**
+```dart
+for (final raw in rawTasks) {
+  // SILENTLY DROPS malformed data if raw is not a Map
+  if (raw case final Map<String, dynamic> taskMap) {
+    _applyTask(taskMap);
+  }
+}
+```
+
+**Correct Structure (Fast-Fail Preservation):**
+```dart
+for (final raw in rawTasks) {
+  if (raw is! Map<String, dynamic>) {
+    errors.add('Malformed task item (expected Map, got ${raw.runtimeType}): $raw');
+    continue;
+  }
+  _applyTask(raw);
+}
+```
 
 ---
 

--- a/skills/dart-cognitive-complexity/references/method-object.md
+++ b/skills/dart-cognitive-complexity/references/method-object.md
@@ -1,0 +1,240 @@
+# Tier 3 Reference: Encapsulated Method Object
+
+> **GATE**: This is the last-resort tier of the 3-Tier Decomposition Rubric in
+> [SKILL.md](../SKILL.md). Apply it ONLY after `data_flow` analysis of the
+> candidate slices has demonstrated a dense mutation web — the same 3+ mutable
+> variables threading through every candidate extraction ("data
+> trampolining"). If Tier 1 (records/`Result` dataclass) or Tier 2 (standard
+> private helpers) can express the extraction, use those instead and do not
+> apply this pattern.
+
+This is a Dart-specific variation of Martin Fowler's classic refactoring
+**"Replace Method with Method Object"**.
+
+## Contraindications (Do NOT apply when...)
+
+* **Simpler refactoring suffices**: State can be cleanly passed via
+  parameters without bloating signatures — use standard private helpers.
+* **Sequential pipelines & transformations**: Never convert pure linear
+  pipelines, simple scripts, or validation routines into runner classes.
+  Pass state via arguments; return via Dart 3 records or `Result` classes.
+  Encapsulation resolves *shared mutable state* and *nested scope bloat*,
+  NOT line length.
+* **No dense closure capturing**: If the function lacks inner functions
+  capturing heavy shared outer state, a runner class is over-engineering.
+
+## Mechanics
+
+1. **Phase 1 — Method Object Extraction**: Migrate the function's logic into
+   a dedicated class. Parameters become constructor arguments, local
+   variables become instance fields, inner functions become instance
+   methods.
+2. **Phase 2 — Facade Delegation**: Make the runner class **private**
+   (`_`-prefixed). The original public function remains as a one-line facade
+   that instantiates the runner and calls its orchestrator method
+   (typically `run()`).
+
+### Workflow
+
+1. **Confirm coverage**: Verify the target has passing tests before touching
+   it (see the Pre-Refactoring Assessment gate in SKILL.md).
+2. **Analyze scopes**: Inputs → constructor args; locals → instance fields;
+   if the outer function is an instance method, pass the enclosing instance
+   (`this`) to the runner's constructor.
+3. **Draft the private runner**: `_OriginalFunctionNameRunner` (or
+   `..._State`), private fields, entry point `run()`.
+4. **Port sub-tasks**: Each inner function becomes a private instance
+   method; replace closure captures with field access.
+5. **Construct the facade**: Replace the original body with a single runner
+   call; prefer fat-arrow syntax if it fits on one line.
+6. **Verify**: `dart format`, `dart analyze` (zero diagnostics),
+   `dart test` — and re-run the complexity scan.
+
+## Pattern A: Basic Bloated Closure
+
+**Before:**
+```dart
+Result processOrder(Order order, User user, PaymentDetails payment) {
+  bool isValidated = false;
+  List<String> auditLogs = [];
+
+  void validate() {
+    if (order.items.isEmpty) throw Exception("Empty order");
+    isValidated = true;
+    auditLogs.add("Validated by ${user.id}");
+  }
+
+  void charge() {
+    if (!isValidated) throw Exception("Must validate first");
+    // complex charging logic using payment details...
+    auditLogs.add("Charged ${payment.method}");
+  }
+
+  validate();
+  charge();
+
+  return Result(success: true, logs: auditLogs);
+}
+```
+
+**After:**
+```dart
+// The Facade (Original API signature preserved)
+Result processOrder(Order order, User user, PaymentDetails payment) =>
+    _ProcessOrderRunner(order, user, payment).run();
+
+// The Method Object (Private to the file/library)
+class _ProcessOrderRunner {
+  final Order _order;
+  final User _user;
+  final PaymentDetails _payment;
+
+  // Local variables promoted to private instance fields
+  bool _isValidated = false;
+  final List<String> _auditLogs = [];
+
+  _ProcessOrderRunner(this._order, this._user, this._payment);
+
+  Result run() {
+    _validate();
+    _charge();
+    return Result(success: true, logs: _auditLogs);
+  }
+
+  void _validate() {
+    if (_order.items.isEmpty) throw Exception("Empty order");
+    _isValidated = true;
+    _auditLogs.add("Validated by ${_user.id}");
+  }
+
+  void _charge() {
+    if (!_isValidated) throw Exception("Must validate first");
+    // complex charging logic using payment details...
+    _auditLogs.add("Charged ${_payment.method}");
+  }
+}
+```
+
+## Pattern B: Outer Instance Binding (Async + Generics)
+
+When the target is an instance method, keep a reference to the enclosing
+class so the runner can reach its dependencies:
+
+```dart
+class DataProcessor {
+  final StorageService storage;
+  final Logger logger;
+
+  DataProcessor(this.storage, this.logger);
+
+  // Facade remains identical. Generics map directly to the runner class.
+  Future<List<T>> processDataBatch<T>(
+    String batchId,
+    List<Map<String, dynamic>> items,
+    T Function(Map<String, dynamic>) parser,
+  ) =>
+      _ProcessDataBatchRunner<T>(this, batchId, items, parser).run();
+}
+
+class _ProcessDataBatchRunner<T> {
+  final DataProcessor _outer; // enclosing instance for deps (logger, storage)
+  final String _batchId;
+  final List<Map<String, dynamic>> _items;
+  final T Function(Map<String, dynamic>) _parser;
+
+  int _successCount = 0;
+  final List<T> _results = [];
+
+  _ProcessDataBatchRunner(this._outer, this._batchId, this._items, this._parser);
+
+  Future<List<T>> run() async {
+    for (final item in _items) {
+      await _processItem(item);
+    }
+    await _saveBatch();
+    return _results;
+  }
+
+  // ... ported helpers access _outer.logger / _outer.storage ...
+}
+```
+
+## Constraints
+
+* **API Footprint Preservation**: The original public signature (parameters,
+  return type, annotations, generics) MUST be preserved unchanged.
+* **Strict Class Encapsulation**: The runner class MUST be `_`-private.
+* **Single-use Execution Scope**: A runner instance represents one
+  invocation. Never store it long-term or call `run()` twice.
+* **Command-Query Separation**: Lookup/search/resolver methods on the runner
+  must be pure. State mutations occur only in orchestrator methods upon
+  confirmed resolution success.
+* **Testability Demotion**: If a computational or parsing subroutine is
+  complex enough to need dedicated unit tests, it must NOT live inside the
+  private runner — extract it to a top-level function or public utility
+  class, since `_Runner` is inaccessible to external test files.
+* **Constructor Purity**: Constructors only map inputs and perform
+  lightweight, non-throwing initialization. Logic, async work, and side
+  effects live in `run()`.
+
+## Anti-Patterns & Mandatory Idioms
+
+### 🚫 `late final` Constructor Unpacking
+
+When the runner receives a complex input object (`Command`, `ArgResults`),
+do NOT mark fields `late final` and unpack them in the constructor body.
+
+**❌ BANNED:**
+```dart
+final class _ScanRunner {
+  final ScanCommand command;
+
+  late final ArgResults results;
+  late final String? project;
+  late final bool detailed;
+
+  _ScanRunner({required this.command}) {
+    results = command.argResults!;
+    project = results.option('project');
+    detailed = results.flag('detailed');
+  }
+}
+```
+
+**✅ MANDATORY — private generative constructor + factory unpacking:**
+```dart
+final class _ScanRunner {
+  final ArgResults results;
+  final String? project;
+  final bool detailed;
+
+  const _ScanRunner._({
+    required this.results,
+    required this.project,
+    required this.detailed,
+  });
+
+  factory _ScanRunner(ScanCommand command) {
+    final results = command.argResults!;
+    return _ScanRunner._(
+      results: results,
+      project: results.option('project'),
+      detailed: results.flag('detailed'),
+    );
+  }
+}
+```
+
+All fields stay truly `final` (no `LateInitializationError` hazard), and
+tests can call `_ScanRunner._(...)` directly with mock primitives.
+
+### 🚫 "Global-in-a-Box" & Parameterless Voids
+
+Never use a Method Object just to avoid passing arguments. A runner must not
+become a dumping ground of mutable `this.*` state.
+
+* **The `void` Ban**: Private runner methods should almost never be
+  parameterless `void` methods that silently mutate instance fields.
+* **Explicit Data Flow**: Subroutines accept explicit parameters and return
+  explicit values. Mutate internal state explicitly at the call site
+  (e.g. `currentCount = _calculateNewCount(currentCount);`).

--- a/skills/dart-cognitive-complexity/references/method-object.md
+++ b/skills/dart-cognitive-complexity/references/method-object.md
@@ -1,124 +1,149 @@
 # Tier 3 Reference: Encapsulated Method Object
 
 > **GATE**: This is the last-resort tier of the 3-Tier Decomposition Rubric in
-> [SKILL.md](../SKILL.md). Apply it ONLY after `data_flow` analysis of the
-> candidate slices has demonstrated a dense mutation web — the same 3+ mutable
-> variables threading through every candidate extraction ("data
-> trampolining"). If Tier 1 (records/`Result` dataclass) or Tier 2 (standard
-> private helpers) can express the extraction, use those instead and do not
-> apply this pattern.
+> [SKILL.md](../SKILL.md). Apply it ONLY when the mutation-web check has
+> passed with recorded evidence: `data_flow` reports on at least two distinct
+> candidate slices whose `mutations` variable names intersect in 3 or more
+> entries. If Tier 1 (records / `Result` dataclass) or Tier 2 (standard
+> private helpers) can express the extraction, use those instead.
 
 This is a Dart-specific variation of Martin Fowler's classic refactoring
 **"Replace Method with Method Object"**.
 
 ## Contraindications (Do NOT apply when...)
 
-* **Simpler refactoring suffices**: State can be cleanly passed via
+* **The gate did not pass**: fewer than 3 shared mutable variables in the
+  intersection, or only a single candidate slice was analyzed.
+* **Simpler refactoring suffices**: state can be cleanly passed via
   parameters without bloating signatures — use standard private helpers.
-* **Sequential pipelines & transformations**: Never convert pure linear
+* **Sequential pipelines & transformations**: never convert pure linear
   pipelines, simple scripts, or validation routines into runner classes.
   Pass state via arguments; return via Dart 3 records or `Result` classes.
   Encapsulation resolves *shared mutable state* and *nested scope bloat*,
   NOT line length.
-* **No dense closure capturing**: If the function lacks inner functions
-  capturing heavy shared outer state, a runner class is over-engineering.
 
 ## Mechanics
 
-1. **Phase 1 — Method Object Extraction**: Migrate the function's logic into
-   a dedicated class. Parameters become constructor arguments, local
-   variables become instance fields, inner functions become instance
-   methods.
-2. **Phase 2 — Facade Delegation**: Make the runner class **private**
+1. **Phase 1 — Method Object Extraction**: migrate the function's logic into
+   a dedicated class. Parameters become constructor arguments, the shared
+   mutable locals become instance fields, and inner functions become
+   instance methods.
+2. **Phase 2 — Facade Delegation**: make the runner class **private**
    (`_`-prefixed). The original public function remains as a one-line facade
    that instantiates the runner and calls its orchestrator method
    (typically `run()`).
 
 ### Workflow
 
-1. **Confirm coverage**: Verify the target has passing tests before touching
+1. **Confirm coverage**: verify the target has passing tests before touching
    it (see the Pre-Refactoring Assessment gate in SKILL.md).
-2. **Analyze scopes**: Inputs → constructor args; locals → instance fields;
-   if the outer function is an instance method, pass the enclosing instance
-   (`this`) to the runner's constructor.
+2. **Analyze scopes**: inputs → constructor args; shared mutable locals →
+   instance fields; if the outer function is an instance method, pass the
+   enclosing instance (`this`) to the runner's constructor.
 3. **Draft the private runner**: `_OriginalFunctionNameRunner` (or
    `..._State`), private fields, entry point `run()`.
-4. **Port sub-tasks**: Each inner function becomes a private instance
-   method; replace closure captures with field access.
-5. **Construct the facade**: Replace the original body with a single runner
+4. **Port sub-tasks**: decision logic becomes *pure query methods* returning
+   explicit values; all mutations of instance state happen in `run()` at the
+   call sites of those queries (see the example and the void ban below).
+5. **Construct the facade**: replace the original body with a single runner
    call; prefer fat-arrow syntax if it fits on one line.
 6. **Verify**: `dart format`, `dart analyze` (zero diagnostics),
-   `dart test` — and re-run the complexity scan.
+   `dart test` — and re-run the complexity scan on the refactored file.
 
-## Pattern A: Basic Bloated Closure
+## Worked Example: Interleaved Mutation Web
 
-**Before:**
+The gate-qualifying smell: 3+ mutable locals shared by multiple inner
+functions whose reads and writes interleave, so any standard extraction
+would trampoline the same variables through every helper signature.
+
+**Before** (shared mutable web: `applied`, `conflicts`, `warnings`):
 ```dart
-Result processOrder(Order order, User user, PaymentDetails payment) {
-  bool isValidated = false;
-  List<String> auditLogs = [];
+SyncReport reconcileInventory(List<Item> local, List<Item> remote) {
+  final applied = <Change>[];
+  final conflicts = <Conflict>[];
+  final warnings = <String>[];
 
-  void validate() {
-    if (order.items.isEmpty) throw Exception("Empty order");
-    isValidated = true;
-    auditLogs.add("Validated by ${user.id}");
+  void noteConflict(Item mine, Item theirs) {
+    conflicts.add(Conflict(mine, theirs));
+    warnings.add('local ${mine.id} is newer than remote');
   }
 
-  void charge() {
-    if (!isValidated) throw Exception("Must validate first");
-    // complex charging logic using payment details...
-    auditLogs.add("Charged ${payment.method}");
+  void apply(Change change) {
+    // Reads `conflicts`, writes `applied` and `warnings`.
+    if (change.isDestructive && conflicts.isNotEmpty) {
+      warnings.add('skipped destructive ${change.id} amid conflicts');
+      return;
+    }
+    applied.add(change);
   }
 
-  validate();
-  charge();
-
-  return Result(success: true, logs: auditLogs);
+  for (final mine in local) {
+    final theirs = remote.firstWhereOrNull((r) => r.id == mine.id);
+    if (theirs == null || mine.revision == theirs.revision) continue;
+    if (mine.updatedAt.isAfter(theirs.updatedAt)) {
+      noteConflict(mine, theirs);
+    } else {
+      apply(Change.update(mine.id, theirs));
+    }
+  }
+  return SyncReport(applied, conflicts, warnings);
 }
 ```
 
-**After:**
+**After** — facade + private runner. Note the shape: helpers are *pure
+queries*; every mutation of instance state is visible in `run()`:
 ```dart
-// The Facade (Original API signature preserved)
-Result processOrder(Order order, User user, PaymentDetails payment) =>
-    _ProcessOrderRunner(order, user, payment).run();
+// The Facade (original API signature preserved)
+SyncReport reconcileInventory(List<Item> local, List<Item> remote) =>
+    _ReconcileRunner(local, remote).run();
 
-// The Method Object (Private to the file/library)
-class _ProcessOrderRunner {
-  final Order _order;
-  final User _user;
-  final PaymentDetails _payment;
+// The Method Object (private to the library)
+class _ReconcileRunner {
+  final List<Item> _local;
+  final List<Item> _remote;
 
-  // Local variables promoted to private instance fields
-  bool _isValidated = false;
-  final List<String> _auditLogs = [];
+  // The shared mutable web, promoted to private instance fields.
+  final List<Change> _applied = [];
+  final List<Conflict> _conflicts = [];
+  final List<String> _warnings = [];
 
-  _ProcessOrderRunner(this._order, this._user, this._payment);
+  _ReconcileRunner(this._local, this._remote);
 
-  Result run() {
-    _validate();
-    _charge();
-    return Result(success: true, logs: _auditLogs);
+  // Orchestrator: the ONLY place instance state is mutated.
+  SyncReport run() {
+    for (final mine in _local) {
+      final theirs = _remote.firstWhereOrNull((r) => r.id == mine.id);
+      if (theirs == null || mine.revision == theirs.revision) continue;
+
+      if (mine.updatedAt.isAfter(theirs.updatedAt)) {
+        _conflicts.add(Conflict(mine, theirs));
+        _warnings.add('local ${mine.id} is newer than remote');
+      } else {
+        final change = Change.update(mine.id, theirs);
+        if (_isSafe(change)) {
+          _applied.add(change);
+        } else {
+          _warnings.add('skipped destructive ${change.id} amid conflicts');
+        }
+      }
+    }
+    return SyncReport(_applied, _conflicts, _warnings);
   }
 
-  void _validate() {
-    if (_order.items.isEmpty) throw Exception("Empty order");
-    _isValidated = true;
-    _auditLogs.add("Validated by ${_user.id}");
-  }
-
-  void _charge() {
-    if (!_isValidated) throw Exception("Must validate first");
-    // complex charging logic using payment details...
-    _auditLogs.add("Charged ${_payment.method}");
-  }
+  // Pure query over current state: no mutation, result returned explicitly.
+  bool _isSafe(Change change) => !change.isDestructive || _conflicts.isEmpty;
 }
 ```
 
-## Pattern B: Outer Instance Binding (Async + Generics)
+In a larger gate-qualifying function, decision logic grows into further pure
+query methods returning explicit values; mutations stay in `run()`.
 
-When the target is an instance method, keep a reference to the enclosing
-class so the runner can reach its dependencies:
+## Outer Instance Binding
+
+When the target is an *instance method* (one that has already passed the
+gate), the runner needs the enclosing object's dependencies. Bind the
+enclosing instance in the constructor; generics map directly onto the
+runner class:
 
 ```dart
 class DataProcessor {
@@ -127,55 +152,50 @@ class DataProcessor {
 
   DataProcessor(this.storage, this.logger);
 
-  // Facade remains identical. Generics map directly to the runner class.
-  Future<List<T>> processDataBatch<T>(
+  // Facade remains identical.
+  Future<List<T>> processBatch<T>(
     String batchId,
     List<Map<String, dynamic>> items,
-    T Function(Map<String, dynamic>) parser,
+    T Function(Map<String, dynamic>) parse,
   ) =>
-      _ProcessDataBatchRunner<T>(this, batchId, items, parser).run();
+      _ProcessBatchRunner<T>(this, batchId, items, parse).run();
 }
 
-class _ProcessDataBatchRunner<T> {
-  final DataProcessor _outer; // enclosing instance for deps (logger, storage)
+class _ProcessBatchRunner<T> {
+  // Enclosing instance: helpers reach _outer.logger, _outer.storage.
+  final DataProcessor _outer;
   final String _batchId;
   final List<Map<String, dynamic>> _items;
-  final T Function(Map<String, dynamic>) _parser;
+  final T Function(Map<String, dynamic>) _parse;
 
-  int _successCount = 0;
-  final List<T> _results = [];
-
-  _ProcessDataBatchRunner(this._outer, this._batchId, this._items, this._parser);
+  _ProcessBatchRunner(this._outer, this._batchId, this._items, this._parse);
 
   Future<List<T>> run() async {
-    for (final item in _items) {
-      await _processItem(item);
-    }
-    await _saveBatch();
-    return _results;
+    // Orchestrator body elided: binding mechanics are the point here. A
+    // real target must still exhibit the gate-qualifying mutation web.
+    throw UnimplementedError();
   }
-
-  // ... ported helpers access _outer.logger / _outer.storage ...
 }
 ```
 
 ## Constraints
 
-* **API Footprint Preservation**: The original public signature (parameters,
+* **API Footprint Preservation**: the original public signature (parameters,
   return type, annotations, generics) MUST be preserved unchanged.
-* **Strict Class Encapsulation**: The runner class MUST be `_`-private.
-* **Single-use Execution Scope**: A runner instance represents one
+* **Strict Class Encapsulation**: the runner class MUST be `_`-private.
+* **Single-use Execution Scope**: a runner instance represents one
   invocation. Never store it long-term or call `run()` twice.
-* **Command-Query Separation**: Lookup/search/resolver methods on the runner
+* **Command-Query Separation**: lookup/search/resolver methods on the runner
   must be pure. State mutations occur only in orchestrator methods upon
   confirmed resolution success.
-* **Testability Demotion**: If a computational or parsing subroutine is
+* **Testability Demotion**: if a computational or parsing subroutine is
   complex enough to need dedicated unit tests, it must NOT live inside the
   private runner — extract it to a top-level function or public utility
-  class, since `_Runner` is inaccessible to external test files.
-* **Constructor Purity**: Constructors only map inputs and perform
-  lightweight, non-throwing initialization. Logic, async work, and side
-  effects live in `run()`.
+  class, since `_Runner` is library-private and inaccessible to external
+  test files.
+* **Constructor Purity**: constructors and factories only map and validate
+  inputs (an input-validation throw such as a null-assert is acceptable).
+  Logic, async work, and side effects live in `run()`.
 
 ## Anti-Patterns & Mandatory Idioms
 
@@ -225,16 +245,17 @@ final class _ScanRunner {
 }
 ```
 
-All fields stay truly `final` (no `LateInitializationError` hazard), and
-tests can call `_ScanRunner._(...)` directly with mock primitives.
+All fields stay truly `final` (no `late` fields, no
+`LateInitializationError` hazard), and initialization order is explicit in
+one place.
 
 ### 🚫 "Global-in-a-Box" & Parameterless Voids
 
 Never use a Method Object just to avoid passing arguments. A runner must not
 become a dumping ground of mutable `this.*` state.
 
-* **The `void` Ban**: Private runner methods should almost never be
+* **The `void` Ban**: private runner methods should almost never be
   parameterless `void` methods that silently mutate instance fields.
-* **Explicit Data Flow**: Subroutines accept explicit parameters and return
-  explicit values. Mutate internal state explicitly at the call site
-  (e.g. `currentCount = _calculateNewCount(currentCount);`).
+* **Explicit Data Flow**: subroutines accept explicit parameters and return
+  explicit values. Mutate instance state explicitly at the call site in the
+  orchestrator (e.g. `currentCount = _calculateNewCount(currentCount);`).


### PR DESCRIPTION
- Update dart-cognitive-complexity rubric with anti-goodhart guardrails:
  method object demoted to Tier 3, last resort behind pure functional
  decomposition (records) and standard extract-method.
- Tier selection is now deterministic: run the data_flow CLI on the
  candidate slice and let its report (live outputs, control-flow escapes,
  mutation web) pick the tier - no more agents getting lazy.
- Absorb the encapsulated-method-object skill (formerly standalone in
  kevmoo/kevmoo_skills) as a gated Tier 3 reference
  (references/method-object.md), loaded only when data_flow analysis
  proves data trampolining.
