### PR TITLE
refactor(skill): refine 3-tier rubric per empirical feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.2.2+2
+
+- Refine the skill's 3-Tier Decomposition Rubric per empirical feedback
+  (#19):
+  - "Slice at natural seams" rule: enlarge slices to whole loops/state
+    machines before classifying; solves coupled 2-variable state
+    (`queue` + `visited`) without weakening the Tier 3 gate (stays at >= 3
+    with recorded evidence).
+  - Named records for private/file-local slices at any output count;
+    dedicated `Result` dataclasses reserved for public API boundaries
+    (aligns the rubric with the `data_flow` signature synthesizer).
+  - Pattern E: loop-body extraction with explicit signal returns
+    (`enum`/sealed) instead of boolean control-flow flags; ordered
+    dispositions for control-flow escapes.
+  - Domain-modeling exit: promoting coupled state to a real named, tested
+    domain class is out of rubric scope — the gate bans `_Runner` facades,
+    not real abstractions.
+- No library or CLI code changes.
+
 ## 0.2.2+1
 
 - Update the `dart-cognitive-complexity` agent skill: anti-goodhart 3-tier

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cognitive_complexity
 description: Algorithmic Cognitive Complexity calculation and Data-Flow analysis library and CLI tools for Dart and Flutter.
-version: 0.2.2+1
+version: 0.2.2+2
 repository: https://github.com/kevmoo/cognitive_complexity.dart
 
 executables:

--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -106,7 +106,7 @@ Output a ranked Markdown **Complexity Triage Report** directly in chat (or to an
 artifact for extensive findings) containing:
 * Flagged function name and clickable file local path.
 * Current complexity score versus operational ceiling.
-* Recommended refactoring strategy (Pattern A, B, D, or a Pattern C tier) and unit test status.
+* Recommended refactoring strategy (Pattern A, B, D, E, or a Pattern C tier) and unit test status.
 
 ### Stage 2: Interactive User Selection (Confirmation Gate)
 Pause execution and prompt the user (via interactive choice or chat) to select
@@ -244,33 +244,53 @@ dart run cognitive_complexity:data_flow@ lib/src/my_file.dart:45-80
 ```
 
 Its report (`inputs`, `mutations`, live `outputs`, control-flow escapes, and
-a synthesized Dart 3 record signature) selects the tier. These bullets are
-the ONLY selection rules:
+a synthesized Dart 3 record signature) selects the tier.
+
+**Slice at natural seams first.** If a slice reports control-flow escapes or
+a tightly coupled pair of mutable variables (`queue` + `visited`,
+`buffer` + `cursor`), the usual culprit is the slice boundary, not the code.
+Enlarge the slice to the whole loop or state machine and re-run `data_flow`:
+escapes targeting a loop inside the slice stop being escapes, coupled state
+becomes interior, and the enlarged slice usually extracts cleanly as
+Tier 1/2.
+
+These bullets are the ONLY selection rules:
 
 * **Cleanly extractable, ≤ 1 live output, ≤ 3 inputs** → Tier 2: extract a
   standard private helper returning that value.
-* **Cleanly extractable, 2–3 live outputs** → Tier 1: extract a static or
-  top-level function and use the synthesized record signature verbatim.
-* **4+ live outputs** → Tier 1 with a dedicated `Result` dataclass instead of
-  a wide record.
-* **Control-flow escapes** → not extractable as-is. For `return`, `break`,
-  or `continue` targeting outer scopes, restructure with guard clauses
-  (Pattern B) and re-run the analysis. For `yield`, restructure the
-  generator before attempting any extraction.
+* **Cleanly extractable, 2+ live outputs** → Tier 1: extract a static or
+  top-level function and use the synthesized named record signature
+  verbatim. Private, file-local slices use named records at ANY output
+  count — do NOT mint single-use `_XxxResult` dataclasses for them. Reserve
+  a dedicated `Result` dataclass for values that cross a public API or
+  library boundary, or that need methods or invariants. *Advisory*: 5+ live
+  outputs usually means the slice is cut at the wrong seam — try a
+  different boundary before shipping a wide record.
+* **Control-flow escapes** → apply in preference order:
+  1. Enlarge the slice to include the whole loop (natural seams, above) and
+     re-run the analysis.
+  2. If the loop *body* is itself the hotspot, extract it with an explicit
+     signal return (Pattern E) — never a `shouldBreak` boolean flag.
+  3. Use guard-clause inversion (Pattern B) when the escape exists only to
+     skip nested conditions — it fixes nesting, not escapes.
+  `yield` is none of these: restructure the generator before attempting any
+  extraction.
 * **Tier 3 gate (mutation-web check)** → Tier 3 requires recorded evidence,
   not judgment. Run `data_flow` on at least two distinct candidate slices of
   the function. Tier 3 is permitted ONLY if the intersection of their
   `mutations` variable names contains 3 or more entries — i.e. the same
   mutable variables thread through every candidate extraction. Paste the
   JSON reports into the Triage Report as evidence; without that evidence,
-  stay in Tier 1/2.
+  stay in Tier 1/2. A recurring 2-variable coupling never qualifies:
+  enlarge the slice, or take the domain-modeling exit (below).
 
 When choosing how to reduce complexity on a large Dart function, follow this **3-Tier Decision Hierarchy**:
 
 1. **Tier 1 — Pure Functional Decomposition (first choice)**: static or
-   top-level functions returning Dart 3 records
-   (`final (:data, :errors) = _stepOne(input);`), or a dedicated `Result` /
-   `Response` dataclass when the selection rules mandate one.
+   top-level functions returning Dart 3 named records
+   (`final (:data, :errors) = _stepOne(input);`); a dedicated `Result` /
+   `Response` dataclass only where the value crosses a public API or
+   library boundary or needs methods/invariants.
 2. **Tier 2 — Standard Extract Method (second choice)**: standard private
    helper methods taking <= 3 arguments.
 3. **Tier 3 — Encapsulated Method Object (last resort)**: permitted only
@@ -278,6 +298,14 @@ When choosing how to reduce complexity on a large Dart function, follow this **3
    read [references/method-object.md](references/method-object.md) for the
    extraction mechanics and mandatory idioms. Do not load or apply it
    speculatively.
+
+**Domain-modeling exit**: when the same tightly coupled mutable state keeps
+resurfacing across a function (a parser's `buffer` + `cursor`, a traversal's
+`queue` + `visited`), the code may be asking to become a real, cohesively
+*named* domain class (`Parser`, `GraphTraversal`) with a public, unit-tested
+API. That is domain modeling, not complexity remediation — it exits this
+rubric entirely and is not subject to the Tier 3 gate. The gate exists to
+ban single-use `_XxxRunner` facades, not real abstractions.
 
 ---
 
@@ -305,6 +333,44 @@ for (final raw in rawTasks) {
   _applyTask(raw);
 }
 ```
+
+---
+
+### Pattern E: Loop-Body Extraction with Signal Returns
+
+When a loop body must be extracted but contains `break`/`continue` targeting
+the loop, never smuggle the control flow through boolean flags
+(`shouldBreak` soup) — that raises cognitive load and hides termination
+conditions. Return an explicit signal and keep the loop keywords at the loop
+site:
+
+```dart
+enum _ScanAction { proceed, skip, halt }
+
+// Pure, independently testable helper.
+_ScanAction _classify(Entry entry, Set<String> seen) {
+  if (seen.contains(entry.id)) return _ScanAction.skip;
+  if (entry.isTerminal) return _ScanAction.halt;
+  return _ScanAction.proceed;
+}
+
+outer:
+for (final entry in entries) {
+  switch (_classify(entry, seen)) {
+    case _ScanAction.skip:
+      continue;
+    case _ScanAction.halt:
+      break outer;
+    case _ScanAction.proceed:
+      process(entry);
+  }
+}
+```
+
+Use a sealed class instead of an enum when the signal must carry a payload.
+The exhaustive `switch` keeps every termination path visible at the loop
+site. Prefer extracting the *entire loop* when `data_flow` shows it forms a
+natural seam; use Pattern E when the loop body alone is the hotspot.
 
 ---
 

--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -305,7 +305,12 @@ resurfacing across a function (a parser's `buffer` + `cursor`, a traversal's
 *named* domain class (`Parser`, `GraphTraversal`) with a public, unit-tested
 API. That is domain modeling, not complexity remediation — it exits this
 rubric entirely and is not subject to the Tier 3 gate. The gate exists to
-ban single-use `_XxxRunner` facades, not real abstractions.
+ban single-use `_XxxRunner` facades, not real abstractions. To qualify for
+the exit, the class MUST have cohesive entity state, more than one public
+behavior, and its own dedicated test suite. A single-use private class with
+a constructor and one `run()` method is a runner no matter what it is
+renamed to (`_ScanEngine`, `_BatchProcessor`) and remains subject to the
+gate.
 
 ---
 
@@ -368,9 +373,11 @@ for (final entry in entries) {
 ```
 
 Use a sealed class instead of an enum when the signal must carry a payload.
-The exhaustive `switch` keeps every termination path visible at the loop
-site. Prefer extracting the *entire loop* when `data_flow` shows it forms a
-natural seam; use Pattern E when the loop body alone is the hotspot.
+Asynchronous classification works identically:
+`switch (await _classify(entry, seen))`. The exhaustive `switch` keeps
+every termination path visible at the loop site. Prefer extracting the
+*entire loop* when `data_flow` shows it forms a natural seam; use Pattern E
+when the loop body alone is the hotspot.
 
 ---
 

--- a/skills/dart-cognitive-complexity/references/method-object.md
+++ b/skills/dart-cognitive-complexity/references/method-object.md
@@ -5,7 +5,10 @@
 > passed with recorded evidence: `data_flow` reports on at least two distinct
 > candidate slices whose `mutations` variable names intersect in 3 or more
 > entries. If Tier 1 (records / `Result` dataclass) or Tier 2 (standard
-> private helpers) can express the extraction, use those instead.
+> private helpers) can express the extraction, use those instead. A
+> recurring 2-variable coupling (`queue` + `visited`, `buffer` + `cursor`)
+> never qualifies — enlarge the slice to the natural seam, or take the
+> domain-modeling exit in SKILL.md (a real named class, not a runner).
 
 This is a Dart-specific variation of Martin Fowler's classic refactoring
 **"Replace Method with Method Object"**.
@@ -14,6 +17,10 @@ This is a Dart-specific variation of Martin Fowler's classic refactoring
 
 * **The gate did not pass**: fewer than 3 shared mutable variables in the
   intersection, or only a single candidate slice was analyzed.
+* **A domain object is trying to be born**: if the coupled state has a
+  coherent domain identity (`Parser`, `GraphTraversal`, `Cursor`), model a
+  real named class with a public, unit-tested API instead of a private
+  runner — see the domain-modeling exit in SKILL.md.
 * **Simpler refactoring suffices**: state can be cleanly passed via
   parameters without bloating signatures — use standard private helpers.
 * **Sequential pipelines & transformations**: never convert pure linear


### PR DESCRIPTION
Addresses #19 with a critical evaluation of its three proposals:

1. REJECTED AS WRITTEN: relaxing the Tier 3 mutation-web gate to >=2
   'if the variables represent a state machine' — that qualifier is
   unverifiable prose judgment, exactly what the evidence-based gate
   eliminated. The gate stays at >=3 with JSON receipts. The underlying
   pain (queue+visited, buffer+cursor) is solved deterministically
   instead: a 'slice at natural seams' rule (enlarge the slice to the
   whole loop/state machine and re-run data_flow) plus a domain-modeling
   exit (a real named, tested class like Parser/GraphTraversal is out of
   rubric scope; the gate bans _Runner facades, not real abstractions).

2. ACCEPTED: private/file-local slices use Dart 3 named records at any
   output count; single-use _XxxResult dataclasses are nominal bloat.
   Dedicated dataclasses reserved for public API/library boundaries or
   values needing methods/invariants. This also aligns the rubric with
   the data_flow signature synthesizer, which already emits records
   unconditionally. Soft advisory retained: 5+ live outputs usually
   means a wrong seam.

3. ACCEPTED WITH ORDERING: control-flow escapes get ordered
   dispositions — (1) enlarge slice to the whole loop, (2) Pattern E
   signal returns (enum/sealed, ControlFlow-style) when the loop body is
   the hotspot, (3) guard clauses for nesting only. Boolean shouldBreak
   flags explicitly banned. yield still requires generator
   restructuring.

Bump to 0.2.2+2 (docs-only) to republish the skill to pub.dev.

Fixes #19
