### PR TITLE
fix: data_flow SDK discovery in AOT installs + threshold-gated --fail-on-increase (0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   - Add a `--sdk-path` option to the `data_flow` CLI (plumbed to the
     existing `DataFlowAnalyzer.sdkPath` parameter); invalid explicit paths
     are rejected with a clear error.
+- Fix `--fail-on-increase` ignoring `--fail-threshold`: when both are set,
+  an increase now only fails the run if the new score exceeds the
+  threshold. Sub-threshold increases are still reported (delta table, PR
+  comment) but no longer block healthy changes such as added error
+  handling. Without `--fail-threshold`, the strict any-increase ratchet is
+  unchanged.
 - Update the `dart-cognitive-complexity` agent skill:
   - Add explicit rule under Tier 1/2 prescribing that extracted private helper
     routines that do not read or mutate class instance state (`this`) must be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,24 @@
-## 0.2.2+3
+## 0.2.3
 
+- Fix `data_flow` crashing with `PathNotFoundException` when run as a
+  standalone AOT executable (`dart run cognitive_complexity:data_flow@` /
+  `dart install`), where SDK auto-discovery resolved to the app bundle
+  (#21):
+  - Fail fast with an actionable error (pass `--sdk-path`, set `DART_SDK`,
+    or put an SDK on `PATH`) instead of handing the analyzer an unresolved
+    SDK location.
+  - Teach `PATH`-based discovery the Flutter checkout layout: a
+    `flutter/bin/dart` wrapper script now resolves to
+    `flutter/bin/cache/dart-sdk`.
+  - Add a `FLUTTER_ROOT` discovery fallback.
+  - Add a `--sdk-path` option to the `data_flow` CLI (plumbed to the
+    existing `DataFlowAnalyzer.sdkPath` parameter); invalid explicit paths
+    are rejected with a clear error.
 - Update the `dart-cognitive-complexity` agent skill:
   - Add explicit rule under Tier 1/2 prescribing that extracted private helper
     routines that do not read or mutate class instance state (`this`) must be
     declared as private top-level functions (or `static` methods) rather than
     instance methods.
-- No library or CLI code changes.
 
 ## 0.2.2+2
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ cognitive_complexity [options] [targets]
 * `-d, --git-diff <git-ref>`: Compares current code against a git commit/ref,
   evaluating complexity deltas (Δ) on modified functions.
 * `--fail-on-increase`: When using `--git-diff`, exits with code `1` if any
-  modified function experienced a complexity score increase.
+  modified function experienced a complexity score increase. When
+  `--fail-threshold` is also set, only increases that exceed the threshold
+  fail — increases within budget are reported but do not block. Omit
+  `--fail-threshold` for a strict ratchet (any increase fails).
 * `--format <text|json|github>`: Report output formatting (default: `text`).
 
 ---
@@ -244,7 +247,8 @@ jobs:
 * `fail-threshold`: Max complexity ceiling (default: `15`).
 * `diff-base`: Git ref to compare against (e.g. `origin/main`). Leave empty
   to compare full repository files.
-* `fail-on-increase`: Set `true` to block PR merge if complexity increases.
+* `fail-on-increase`: Set `true` to block PR merge on complexity increases
+  that exceed `fail-threshold` (or on any increase when no threshold is set).
 * `format`: Summary format: `github` (GHA annotations + summary), `text`, or `json`.
 
 ### Permissions & Security

--- a/lib/src/complexity/cli.dart
+++ b/lib/src/complexity/cli.dart
@@ -55,7 +55,8 @@ Future<int> runCli(
       negatable: false,
       help:
           'When using --git-diff, exit with non-zero code if any function '
-          'increased in complexity.',
+          'increased in complexity. When --fail-threshold is also set, only '
+          'increases that exceed the threshold fail.',
     )
     ..addOption(
       'format',

--- a/lib/src/complexity/delta_analyzer.dart
+++ b/lib/src/complexity/delta_analyzer.dart
@@ -38,7 +38,14 @@ class ComplexityDelta {
   bool isViolation({int? failThreshold, bool failOnIncrease = false}) {
     // Newly added declarations have no baseline to "increase" from; they are
     // governed by [failThreshold] alone.
-    if (failOnIncrease && status == DeltaStatus.increased) {
+    //
+    // When both flags are supplied, [failThreshold] gates [failOnIncrease]:
+    // an increase that stays within the threshold budget is reported but is
+    // not a violation. Without a threshold, any increase is a violation
+    // (strict ratchet).
+    if (failOnIncrease &&
+        status == DeltaStatus.increased &&
+        (failThreshold == null || (newScore ?? 0) > failThreshold)) {
       return true;
     }
     if (failThreshold != null &&

--- a/lib/src/data_flow/cli.dart
+++ b/lib/src/data_flow/cli.dart
@@ -5,6 +5,7 @@ import 'package:io/io.dart';
 import 'package:path/path.dart' as p;
 import 'data_flow_analyzer.dart';
 import 'models.dart';
+import 'sdk_discovery.dart';
 
 /// Executes the Data-Flow CLI with [args] and returns the exit code.
 Future<int> runCli(
@@ -49,6 +50,7 @@ Future<int> runCli(
       linesString: linesString,
       methodName: argResults['name'] as String,
       format: argResults['format'] as String,
+      sdkPath: argResults['sdk-path'] as String?,
       stdoutSink: stdoutSink,
     );
 
@@ -60,6 +62,9 @@ Future<int> runCli(
   } on FileSystemException catch (e) {
     stderrSink.writeln('Error: ${e.message} (${e.path})');
     return ExitCode.noInput.code;
+  } on SdkDiscoveryException catch (e) {
+    stderrSink.writeln('Error: $e');
+    return ExitCode.config.code;
   } catch (e) {
     stderrSink.writeln('Fatal error: $e');
     return 1;
@@ -92,6 +97,13 @@ ArgParser _buildParser() => ArgParser()
     defaultsTo: 'json',
     allowed: ['json', 'text'],
     help: 'Output format.',
+  )
+  ..addOption(
+    'sdk-path',
+    help:
+        'Path to the Dart SDK root used for analysis. Defaults to '
+        'auto-discovery (running VM, DART_SDK environment variable, PATH, '
+        'FLUTTER_ROOT).',
   );
 
 ({String filePath, String? linesString}) _resolveTarget(ArgResults argResults) {
@@ -118,10 +130,11 @@ Future<void> _executeAnalysis({
   required String linesString,
   required String methodName,
   required String format,
+  required String? sdkPath,
   required StringSink stdoutSink,
 }) async {
   final lineBounds = _parseLineBounds(linesString);
-  const analyzer = DataFlowAnalyzer();
+  final analyzer = DataFlowAnalyzer(sdkPath: sdkPath);
   final result = await analyzer.analyzeFile(
     filePath: filePath,
     startLine: lineBounds.$1,

--- a/lib/src/data_flow/data_flow_analyzer.dart
+++ b/lib/src/data_flow/data_flow_analyzer.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:path/path.dart' as p;
 import 'models.dart';
+import 'sdk_discovery.dart';
 import 'signature_synthesizer.dart';
 import 'visitors/in_block_visitor.dart';
 import 'visitors/post_block_visitor.dart';
@@ -34,7 +35,26 @@ class DataFlowAnalyzer {
       throw FileSystemException('Target file does not exist', filePath);
     }
 
-    final effectiveSdkPath = sdkPath ?? _findSdkPath();
+    final provided = sdkPath;
+    if (provided != null && !isValidSdk(provided)) {
+      throw SdkDiscoveryException(
+        'The provided SDK path "$provided" does not point to a valid Dart '
+        'SDK root (missing lib/_internal).',
+      );
+    }
+
+    final effectiveSdkPath = provided ?? findSdkPath();
+    if (effectiveSdkPath == null) {
+      throw const SdkDiscoveryException(
+        'Cannot locate a Dart SDK for analysis. This happens when running as '
+        'a standalone AOT executable (e.g. '
+        '`dart run cognitive_complexity:data_flow@`), where the running '
+        'executable is not part of an SDK. Pass --sdk-path, set the DART_SDK '
+        'environment variable, or ensure a Dart SDK (or Flutter checkout) is '
+        'on PATH.',
+      );
+    }
+
     final collection = AnalysisContextCollection(
       includedPaths: [absPath],
       sdkPath: effectiveSdkPath,
@@ -320,71 +340,4 @@ class _EnclosingDeclarationVisitor extends RecursiveAstVisitor<void> {
     }
     super.visitConstructorDeclaration(node);
   }
-}
-
-// TODO: Replace manual SDK discovery helpers with package:cli_util once
-// https://github.com/dart-lang/tools/issues/2504 lands and is published.
-String? _findSdkPath() =>
-    _findSdkFromExecutable() ?? _findSdkFromEnv() ?? _findSdkFromPath();
-
-String? _findSdkFromExecutable() {
-  final exe = File(Platform.resolvedExecutable);
-  if (!exe.existsSync()) return null;
-
-  try {
-    final resolved = exe.resolveSymbolicLinksSync();
-    final candidate = p.dirname(p.dirname(resolved));
-    return _isValidSdk(candidate) ? candidate : null;
-  } catch (_) {
-    return null;
-  }
-}
-
-String? _findSdkFromEnv() {
-  final envSdk = Platform.environment['DART_SDK'];
-  if (envSdk != null && _isValidSdk(envSdk)) {
-    return envSdk;
-  }
-  return null;
-}
-
-String? _findSdkFromPath() {
-  final pathEnv = Platform.environment['PATH'];
-  if (pathEnv == null || pathEnv.isEmpty) return null;
-
-  final separator = Platform.isWindows ? ';' : ':';
-  final executableName = Platform.isWindows ? 'dart.exe' : 'dart';
-
-  for (final dir in pathEnv.split(separator)) {
-    if (dir.trim().isEmpty) continue;
-    final candidate = _resolveSdkFromDir(dir, executableName);
-    if (candidate != null) return candidate;
-  }
-
-  return null;
-}
-
-String? _resolveSdkFromDir(String dir, String executableName) {
-  final dartBinary = File(p.join(dir, executableName));
-  if (!dartBinary.existsSync()) return null;
-
-  try {
-    final resolved = dartBinary.resolveSymbolicLinksSync();
-    final candidate = p.dirname(p.dirname(resolved));
-    return _isValidSdk(candidate) ? candidate : null;
-  } catch (_) {
-    return null;
-  }
-}
-
-bool _isValidSdk(String path) {
-  final internal = Directory(p.join(path, 'lib', '_internal'));
-  if (!internal.existsSync()) return false;
-  return File(p.join(internal.path, 'libraries.dart')).existsSync() ||
-      File(
-        p.join(internal.path, 'sdk_library_metadata', 'lib', 'libraries.dart'),
-      ).existsSync() ||
-      File(
-        p.join(path, 'bin', Platform.isWindows ? 'dart.exe' : 'dart'),
-      ).existsSync();
 }

--- a/lib/src/data_flow/sdk_discovery.dart
+++ b/lib/src/data_flow/sdk_discovery.dart
@@ -82,15 +82,25 @@ String? _findSdkFromFlutterRoot() {
 /// wrapper script and the real SDK lives at `<flutter>/bin/cache/dart-sdk`.
 String? resolveSdkFromDir(String dir, String executableName) {
   final dartBinary = File(p.join(dir, executableName));
-  if (!dartBinary.existsSync()) return null;
-
-  try {
-    final resolved = dartBinary.resolveSymbolicLinksSync();
-    final candidate = p.dirname(p.dirname(resolved));
-    if (isValidSdk(candidate)) return candidate;
-  } catch (_) {
-    // Fall through to the Flutter wrapper probe.
+  if (dartBinary.existsSync()) {
+    try {
+      final resolved = dartBinary.resolveSymbolicLinksSync();
+      final candidate = p.dirname(p.dirname(resolved));
+      if (isValidSdk(candidate)) return candidate;
+    } catch (_) {
+      // Fall through to the Flutter wrapper probe.
+    }
   }
+
+  // Flutter checkouts ship wrapper scripts in `bin/` (`dart`, plus `dart.bat`
+  // on Windows — never `dart.exe`, which lives inside the cached SDK), so the
+  // exact executable probed above may be absent. Probe `cache/dart-sdk`
+  // whenever any Dart wrapper is present in the directory.
+  final hasDartWrapper =
+      dartBinary.existsSync() ||
+      File(p.join(dir, 'dart')).existsSync() ||
+      File(p.join(dir, 'dart.bat')).existsSync();
+  if (!hasDartWrapper) return null;
 
   final flutterCache = p.join(dir, 'cache', 'dart-sdk');
   return isValidSdk(flutterCache) ? flutterCache : null;

--- a/lib/src/data_flow/sdk_discovery.dart
+++ b/lib/src/data_flow/sdk_discovery.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+// Not exported from `lib/data_flow.dart`: this is an internal helper module,
+// public within `src` so unit tests can exercise the discovery logic.
+//
+// TODO: Replace manual SDK discovery helpers with package:cli_util once
+// https://github.com/dart-lang/tools/issues/2504 lands and is published.
+
+/// Thrown when a usable Dart SDK cannot be located or a provided SDK path
+/// is not a valid SDK root.
+class SdkDiscoveryException implements Exception {
+  final String message;
+
+  const SdkDiscoveryException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+/// Locates a Dart SDK root, probing in order: the running VM's executable,
+/// the `DART_SDK` environment variable, `dart` binaries on `PATH` (including
+/// Flutter checkouts, whose wrapper script hides the SDK under
+/// `bin/cache/dart-sdk`), and finally `FLUTTER_ROOT`.
+///
+/// Returns `null` when no valid SDK is found — notably when running as a
+/// standalone AOT executable (`dart run cognitive_complexity:data_flow@`),
+/// where `Platform.resolvedExecutable` is the tool binary itself.
+String? findSdkPath() =>
+    _findSdkFromExecutable() ??
+    _findSdkFromEnv() ??
+    _findSdkFromPath() ??
+    _findSdkFromFlutterRoot();
+
+String? _findSdkFromExecutable() {
+  final exe = File(Platform.resolvedExecutable);
+  if (!exe.existsSync()) return null;
+
+  try {
+    final resolved = exe.resolveSymbolicLinksSync();
+    final candidate = p.dirname(p.dirname(resolved));
+    return isValidSdk(candidate) ? candidate : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+String? _findSdkFromEnv() {
+  final envSdk = Platform.environment['DART_SDK'];
+  if (envSdk != null && isValidSdk(envSdk)) {
+    return envSdk;
+  }
+  return null;
+}
+
+String? _findSdkFromPath() {
+  final pathEnv = Platform.environment['PATH'];
+  if (pathEnv == null || pathEnv.isEmpty) return null;
+
+  final separator = Platform.isWindows ? ';' : ':';
+  final executableName = Platform.isWindows ? 'dart.exe' : 'dart';
+
+  for (final dir in pathEnv.split(separator)) {
+    if (dir.trim().isEmpty) continue;
+    final candidate = resolveSdkFromDir(dir, executableName);
+    if (candidate != null) return candidate;
+  }
+
+  return null;
+}
+
+String? _findSdkFromFlutterRoot() {
+  final flutterRoot = Platform.environment['FLUTTER_ROOT'];
+  if (flutterRoot == null || flutterRoot.isEmpty) return null;
+  final candidate = p.join(flutterRoot, 'bin', 'cache', 'dart-sdk');
+  return isValidSdk(candidate) ? candidate : null;
+}
+
+/// Resolves an SDK root from a directory containing a `dart` executable.
+///
+/// Handles the Flutter checkout layout, where `<flutter>/bin/dart` is a
+/// wrapper script and the real SDK lives at `<flutter>/bin/cache/dart-sdk`.
+String? resolveSdkFromDir(String dir, String executableName) {
+  final dartBinary = File(p.join(dir, executableName));
+  if (!dartBinary.existsSync()) return null;
+
+  try {
+    final resolved = dartBinary.resolveSymbolicLinksSync();
+    final candidate = p.dirname(p.dirname(resolved));
+    if (isValidSdk(candidate)) return candidate;
+  } catch (_) {
+    // Fall through to the Flutter wrapper probe.
+  }
+
+  final flutterCache = p.join(dir, 'cache', 'dart-sdk');
+  return isValidSdk(flutterCache) ? flutterCache : null;
+}
+
+/// Whether [path] looks like a Dart SDK root usable by the analyzer.
+bool isValidSdk(String path) {
+  final internal = Directory(p.join(path, 'lib', '_internal'));
+  if (!internal.existsSync()) return false;
+  return File(p.join(internal.path, 'libraries.dart')).existsSync() ||
+      File(
+        p.join(internal.path, 'sdk_library_metadata', 'lib', 'libraries.dart'),
+      ).existsSync() ||
+      File(
+        p.join(path, 'bin', Platform.isWindows ? 'dart.exe' : 'dart'),
+      ).existsSync();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cognitive_complexity
 description: Algorithmic Cognitive Complexity calculation and Data-Flow analysis library and CLI tools for Dart and Flutter.
-version: 0.2.2+3
+version: 0.2.3
 repository: https://github.com/kevmoo/cognitive_complexity.dart
 
 executables:

--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -61,8 +61,13 @@ When reviewing a feature branch, active commit stack, or PR, avoid full-project
 scanning. Isolate evaluation strictly to modified declarations against trunk:
 
 ```bash
-dart run cognitive_complexity@ --git-diff origin/main --fail-on-increase
+dart run cognitive_complexity@ --git-diff origin/main --fail-threshold 15 --fail-on-increase
 ```
+
+With both flags set, only increases that exceed the threshold fail — healthy
+sub-threshold increases (e.g. added error handling) are reported without
+blocking. Omit `--fail-threshold` only when a strict any-increase ratchet is
+explicitly desired.
 
 ### Scope 3: Whole-Project (Default Naked Invocation)
 When invoked without targeting parameters ("scan my project for complexity" or

--- a/test/data_flow/cli_test.dart
+++ b/test/data_flow/cli_test.dart
@@ -8,9 +8,12 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
 void main() {
+  // Pin subprocesses to the SDK running the tests rather than PATH's `dart`.
+  final dartExe = Platform.resolvedExecutable;
+
   group('DataFlow CLI Integration', () {
     test('Displays usage help and exits with code 0 on --help', () async {
-      final proc = await TestProcess.start('dart', [
+      final proc = await TestProcess.start(dartExe, [
         'run',
         'bin/data_flow.dart',
         '--help',
@@ -25,7 +28,7 @@ void main() {
     });
 
     test('Exits with code 64 when no target file is provided', () async {
-      final proc = await TestProcess.start('dart', [
+      final proc = await TestProcess.start(dartExe, [
         'run',
         'bin/data_flow.dart',
       ]);
@@ -50,7 +53,7 @@ void runFlow(String token) {
 '''),
       ]).create();
 
-      final proc = await TestProcess.start('dart', [
+      final proc = await TestProcess.start(dartExe, [
         'run',
         'bin/data_flow.dart',
         '${d.sandbox}/project/sample.dart:4-6',
@@ -83,7 +86,7 @@ void process(int a, int b) {
 '''),
         ]).create();
 
-        final proc = await TestProcess.start('dart', [
+        final proc = await TestProcess.start(dartExe, [
           'run',
           'bin/data_flow.dart',
           '--format=text',
@@ -120,7 +123,7 @@ void process(int a) {
 
       // Test with drive-like prefix pattern
       final samplePath = '${d.sandbox}/project3/sample3.dart';
-      final proc = await TestProcess.start('dart', [
+      final proc = await TestProcess.start(dartExe, [
         'run',
         'bin/data_flow.dart',
         '$samplePath:3-4',
@@ -138,7 +141,7 @@ void process(int a) {
 
   group('SDK path resolution', () {
     test('Documents --sdk-path and DART_SDK in help text', () async {
-      final proc = await TestProcess.start('dart', [
+      final proc = await TestProcess.start(dartExe, [
         'run',
         'bin/data_flow.dart',
         '--help',
@@ -154,7 +157,7 @@ void process(int a) {
     test('Exits with config error for an invalid --sdk-path', () async {
       await d.dir('proj', [d.file('sample.dart', 'void main() {}\n')]).create();
 
-      final proc = await TestProcess.start('dart', [
+      final proc = await TestProcess.start(dartExe, [
         'run',
         'bin/data_flow.dart',
         '--sdk-path',
@@ -180,7 +183,7 @@ void process(int a) {
       ]).create();
 
       final sdkRoot = p.dirname(p.dirname(Platform.resolvedExecutable));
-      final proc = await TestProcess.start('dart', [
+      final proc = await TestProcess.start(dartExe, [
         'run',
         'bin/data_flow.dart',
         '--sdk-path',

--- a/test/data_flow/cli_test.dart
+++ b/test/data_flow/cli_test.dart
@@ -1,5 +1,8 @@
 import 'dart:convert';
+import 'dart:io';
+
 import 'package:checks/checks.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/scaffolding.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
@@ -130,6 +133,67 @@ void process(int a) {
       check(jsonMap['enclosing']).equals('process');
       check(jsonMap['startLine']).equals(3);
       check(jsonMap['endLine']).equals(4);
+    });
+  });
+
+  group('SDK path resolution', () {
+    test('Documents --sdk-path and DART_SDK in help text', () async {
+      final proc = await TestProcess.start('dart', [
+        'run',
+        'bin/data_flow.dart',
+        '--help',
+      ]);
+
+      final stdout = await proc.stdoutStream().join('\n');
+      await proc.shouldExit(0);
+
+      check(stdout).contains('--sdk-path');
+      check(stdout).contains('DART_SDK');
+    });
+
+    test('Exits with config error for an invalid --sdk-path', () async {
+      await d.dir('proj', [d.file('sample.dart', 'void main() {}\n')]).create();
+
+      final proc = await TestProcess.start('dart', [
+        'run',
+        'bin/data_flow.dart',
+        '--sdk-path',
+        '${d.sandbox}/proj',
+        '${d.sandbox}/proj/sample.dart:1-1',
+      ]);
+
+      final stderr = await proc.stderrStream().join('\n');
+      await proc.shouldExit(78);
+
+      check(stderr).contains('does not point to a valid Dart SDK root');
+    });
+
+    test('Analyzes successfully with an explicit valid --sdk-path', () async {
+      await d.dir('proj2', [
+        d.file('sample.dart', '''
+void process(int a) {
+  // Line 3
+  final b = a * 10;
+  print(b);
+}
+'''),
+      ]).create();
+
+      final sdkRoot = p.dirname(p.dirname(Platform.resolvedExecutable));
+      final proc = await TestProcess.start('dart', [
+        'run',
+        'bin/data_flow.dart',
+        '--sdk-path',
+        sdkRoot,
+        '${d.sandbox}/proj2/sample.dart:3-3',
+      ]);
+
+      final stdout = await proc.stdoutStream().join('\n');
+      await proc.shouldExit(0);
+
+      final jsonMap = jsonDecode(stdout) as Map<String, dynamic>;
+      check(jsonMap['enclosing']).equals('process');
+      check(jsonMap['isCleanlyExtractable']).equals(true);
     });
   });
 }

--- a/test/data_flow/sdk_discovery_test.dart
+++ b/test/data_flow/sdk_discovery_test.dart
@@ -71,6 +71,31 @@ void main() {
       ).equals(p.join(binDir, 'cache', 'dart-sdk'));
     });
 
+    test(
+      'resolves a Windows-style Flutter checkout when probing dart.exe',
+      () async {
+        await d.dir('flutter_win', [
+          d.dir('bin', [
+            // Windows Flutter checkouts ship dart.bat, never bin/dart.exe.
+            d.file('dart.bat', '@echo off\r\n'),
+            d.dir('cache', [
+              d.dir('dart-sdk', [
+                d.dir('lib', [
+                  d.dir('_internal', [d.file('libraries.dart', '')]),
+                ]),
+                d.dir('bin', [d.file('dart.exe', '')]),
+              ]),
+            ]),
+          ]),
+        ]).create();
+
+        final binDir = '${d.sandbox}/flutter_win/bin';
+        check(
+          resolveSdkFromDir(binDir, 'dart.exe'),
+        ).equals(p.join(binDir, 'cache', 'dart-sdk'));
+      },
+    );
+
     test('returns null when the directory has no dart executable', () async {
       await d.dir('empty').create();
 

--- a/test/data_flow/sdk_discovery_test.dart
+++ b/test/data_flow/sdk_discovery_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:checks/checks.dart';
+import 'package:cognitive_complexity/src/data_flow/sdk_discovery.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/scaffolding.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+void main() {
+  group('isValidSdk', () {
+    test('accepts a root with lib/_internal/libraries.dart', () async {
+      await d.dir('sdk', [
+        d.dir('lib', [
+          d.dir('_internal', [d.file('libraries.dart', '')]),
+        ]),
+      ]).create();
+
+      check(isValidSdk('${d.sandbox}/sdk')).isTrue();
+    });
+
+    test('accepts a root with lib/_internal and bin/dart', () async {
+      await d.dir('sdk', [
+        d.dir('lib', [d.dir('_internal')]),
+        d.dir('bin', [d.file('dart', '')]),
+      ]).create();
+
+      check(isValidSdk('${d.sandbox}/sdk')).isTrue();
+    });
+
+    test('rejects an AOT app bundle (bin only, no lib/_internal)', () async {
+      await d.dir('bundle', [
+        d.dir('bin', [d.file('data_flow', '')]),
+      ]).create();
+
+      check(isValidSdk('${d.sandbox}/bundle')).isFalse();
+    });
+  });
+
+  group('resolveSdkFromDir', () {
+    test('resolves a standard SDK layout from its bin directory', () async {
+      await d.dir('sdk', [
+        d.dir('lib', [
+          d.dir('_internal', [d.file('libraries.dart', '')]),
+        ]),
+        d.dir('bin', [d.file('dart', '')]),
+      ]).create();
+
+      final sdkRoot = Directory('${d.sandbox}/sdk').resolveSymbolicLinksSync();
+      check(resolveSdkFromDir(p.join(sdkRoot, 'bin'), 'dart')).equals(sdkRoot);
+    });
+
+    test('resolves a Flutter checkout via bin/cache/dart-sdk', () async {
+      await d.dir('flutter', [
+        d.dir('bin', [
+          // Wrapper shell script, not a symlink into an SDK.
+          d.file('dart', '#!/bin/sh\n'),
+          d.dir('cache', [
+            d.dir('dart-sdk', [
+              d.dir('lib', [
+                d.dir('_internal', [d.file('libraries.dart', '')]),
+              ]),
+              d.dir('bin', [d.file('dart', '')]),
+            ]),
+          ]),
+        ]),
+      ]).create();
+
+      final binDir = '${d.sandbox}/flutter/bin';
+      check(
+        resolveSdkFromDir(binDir, 'dart'),
+      ).equals(p.join(binDir, 'cache', 'dart-sdk'));
+    });
+
+    test('returns null when the directory has no dart executable', () async {
+      await d.dir('empty').create();
+
+      check(resolveSdkFromDir('${d.sandbox}/empty', 'dart')).isNull();
+    });
+
+    test('returns null for a dart binary outside any SDK', () async {
+      await d.dir('stray', [d.file('dart', '')]).create();
+
+      check(resolveSdkFromDir('${d.sandbox}/stray', 'dart')).isNull();
+    });
+  });
+}

--- a/test/delta_analyzer_test.dart
+++ b/test/delta_analyzer_test.dart
@@ -59,6 +59,26 @@ void main() {
       check(d.isViolation(failOnIncrease: true)).isTrue();
     });
 
+    test('Threshold gates fail-on-increase when both are supplied', () {
+      const oldCode = 'void foo() { print("clean"); }';
+      const newCode = '''
+        void foo() {
+          if (a) {
+            if (b) print("worse");
+          }
+        }
+      ''';
+
+      final d = analyzer.computeDeltaForCode(oldCode, newCode).first;
+      check(d.newScore).isNotNull().equals(3);
+      // Within budget: the increase is reported but is not a violation.
+      check(d.isViolation(failOnIncrease: true, failThreshold: 15)).isFalse();
+      // Over budget: the increase is a violation.
+      check(d.isViolation(failOnIncrease: true, failThreshold: 2)).isTrue();
+      // No threshold: strict any-increase ratchet.
+      check(d.isViolation(failOnIncrease: true)).isTrue();
+    });
+
     test('Identifies newly added and removed functions across diff', () {
       const oldCode = 'void deletedFunc(int a) { if (a > 0) print(a); }';
       const newCode = 'void addedFunc(bool b) { if (b) print(1); }';


### PR DESCRIPTION
## data_flow: SDK discovery when running as a standalone AOT executable

The on-demand form (`dart run cognitive_complexity:data_flow@`) crashed with `PathNotFoundException`: pub app-bundle installs contain only `bin/`, `Platform.resolvedExecutable` is the tool binary itself, and when every discovery tier missed, the null `sdkPath` fell through to the analyzer's unguarded auto-discovery, which derived the SDK from the bundle path.

- Extract SDK discovery into `lib/src/data_flow/sdk_discovery.dart` (internal module; unit-testable, not exported)
- Fail fast with an actionable `SdkDiscoveryException` (pass `--sdk-path`, set `DART_SDK`, or put an SDK on PATH) instead of handing the analyzer an unresolved SDK location; exit code 78 (config) in the CLI
- Teach PATH discovery the Flutter checkout layout: the real SDK lives at `flutter/bin/cache/dart-sdk` behind wrapper scripts. On Windows, `bin\` ships only `dart.bat`/`dart` wrappers (no `dart.exe`), so the probe fires whenever any Dart wrapper is present in the directory
- Add `FLUTTER_ROOT` fallback tier (matches dart-lang/tools#2504 design)
- Add `--sdk-path` CLI option plumbed to `DataFlowAnalyzer.sdkPath`; invalid explicit paths rejected with a clear error
- 9 new tests (discovery fixtures incl. POSIX + Windows Flutter layouts, CLI flag coverage); CLI subprocess tests pinned to `Platform.resolvedExecutable` for hermeticity; verified end-to-end with a compiled AOT binary: no-SDK env fails fast, Flutter-wrapper-only PATH discovers and analyzes

## Also: `--fail-on-increase` now composes with `--fail-threshold`

Previously the two flags did not compose: any +1 on a modified function failed the run even at scores far under the threshold — this PR's own audit went red for adding error handling (3→6, 9→10). With both flags set, an increase now only fails when the new score exceeds the threshold; sub-threshold increases are still reported (delta table, PR comment) without blocking. The strict any-increase ratchet is preserved when no threshold is set. README CLI docs, GitHub-action input docs, and the skill's Scope 2 guidance updated accordingly.

## Release

0.2.3 (replaces unreleased 0.2.2+3; its changelog entry is folded in).

Fixes #21