### PR TITLE
docs: streamline README and extract deep-dive doc/ structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.2.3+2
+
+- Streamline `README.md` into a focused, scannable TL;DR.
+- Extract deep-dive reference documentation into modular guides under `doc/`:
+  - `doc/scoring.md`: Scoring matrix, nesting multipliers, and Dart 3 AST rules.
+  - `doc/cli.md`: Command-line options, git diff delta evaluation, and CI ratcheting.
+  - `doc/data_flow.md`: Statement data-flow analysis, method extraction theory, and programmatic API.
+  - `doc/github_actions.md`: Complete GitHub Action workflow setup, parameters, and fork security permissions.
+
 ## 0.2.3+1
 
 - Add an example.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-A deterministic, zero-token Cognitive Complexity calculation library, CLI tool,
-and GitHub Action for Dart and Flutter repositories.
+Long, complex functions are hard for humans (and AI agents) to understand.
+Asking an agent to "refactor the code to make it cleaner" is poorly defined and
+leaves the agent to make arbitrary decisions.
 
-Unlike Cyclomatic Complexity (which measures control flow branch density),
-Cognitive Complexity measures how difficult code is for a human engineer to read
-and understand, following the [SonarSource whitepaper][whitepaper] by G. Ann
-Campbell.
+This Dart package, GitHub Action, and AI agent skill make finding and fixing
+overly complex logic easy, reliable, and repeatable.
 
 ## ✨ Features
 
@@ -89,5 +88,3 @@ Explore in-depth documentation in the [`doc/`](doc/) directory:
   variable lifecycles, and automated method extraction helper.
 - 🤖 [GitHub Actions Guide](doc/github_actions.md): PR workflow setup,
   parameters reference, and fork security permissions.
-
-[whitepaper]: https://www.sonarsource.com/docs/CognitiveComplexity.pdf

--- a/README.md
+++ b/README.md
@@ -1,133 +1,48 @@
-A deterministic, zero-token Cognitive Complexity calculation library, CLI
-tool, and GitHub Action for Dart and Flutter repositories.
+A deterministic, zero-token Cognitive Complexity calculation library, CLI tool,
+and GitHub Action for Dart and Flutter repositories.
 
 Unlike Cyclomatic Complexity (which measures control flow branch density),
-Cognitive Complexity measures how difficult a method is for a human engineer
-to read and understand, following the whitepaper specification by G. Ann
+Cognitive Complexity measures how difficult code is for a human engineer to read
+and understand, following the [SonarSource whitepaper][whitepaper] by G. Ann
 Campbell.
 
----
+## ✨ Features
 
-## Features
-
-* **Modern Dart 3 AST Support**: Natively parses switch expressions, pattern
+- **Modern Dart 3 AST Support**: Natively parses switch expressions, pattern
   guards (`when` clauses), and collection control flow structures.
-* **Deterministic Engine**: Calculates complexity algorithmically without invoking
-  LLM calls or external network requests.
-* **Statement Data-Flow Analysis**: Inspects reaching definitions (inputs),
-  variable mutations, and downstream live reads (outputs) for arbitrary statement
-  slices to power automated method extraction.
-* **Git Diff Analysis**: Compares current workspace declarations against a target
-  base ref to isolate complexity deltas (Δ) in modified functions.
-* **Lightweight GitHub Action**: Exposes workflow annotations and step summaries
-  for CI check integration.
+- **Deterministic Engine**: Calculates complexity algorithmically without LLM
+  calls, external network requests, or token latency.
+- **Statement Data-Flow Analysis**: Evaluates variable inputs, mutations, and
+  downstream live outputs for arbitrary statement slices to power automated
+  method extraction.
+- **Git Diff Analysis & Ratchet**: Compares working copy changes against a
+  target base ref to isolate complexity deltas (Δ) in modified functions.
+- **Lightweight GitHub Action**: Exposes workflow annotations and markdown
+  summary tables for automated CI quality gates.
 
----
+## ⚡ Quick Start
 
-## Scoring Model
+### CLI (On-Demand)
 
-Scores follow the [SonarSource Cognitive Complexity whitepaper][whitepaper]
-(G. Ann Campbell, v1.7):
-
-| Construct / Syntax | Base Cost | Nesting Multiplier | Deepens Nesting? | Notes |
-| :--- | :---: | :---: | :---: | :--- |
-| **`if`, `for`, `while`, `do-while`, `catch` / `on`** | `+1` | `+D` (Current Depth) | **Yes** | Standard flow-breaking structures |
-| **`switch` Statements & Expressions** | `+1` | `+D` (Current Depth) | **Yes** | Entire block costs `+1` regardless of arm count |
-| **`else` / `else if`** | `+1` | `+0` (Flat penalty) | **No** | Branch contents sit one level below head `if` |
-| **Logical Operators (`&&`, `\|\|`)** | `+1` | `+0` (Flat penalty) | **No** | `+1` per sequence; `+1` for each alternation |
-| **Pattern `when` Guards** | `+1` | `+0` (Flat penalty) | **No** | Dart 3 specific interpretation |
-| **Lambdas & Local Functions** | `+0` | `+0` | **Yes** | Deepens nesting depth for enclosed bodies |
-| **Null-Aware (`??`, `?.`, `??=`), `assert`, `try` / `finally`** | `+0` | `+0` | **No** | Benign syntax; completely free |
-| **Switch Case Labels & Pattern Combinators** | `+0` | `+0` | **No** | Stacked arms / or-patterns (`1 \|\| 2`) are free |
-
-Dart-specific interpretations of the spec:
-
-* Pattern `when` guards add +1 (a guard is an extra condition to evaluate).
-* Pattern-level combinators (`case 1 || 2:`, `case > 0 && < 10`) are free —
-  an or-pattern is the modern spelling of stacked case labels, which the
-  spec scores at zero.
-* The whitepaper's "+1 for each method in a recursion cycle" is not
-  implemented, matching SonarSource's own reference implementation
-  (sonar-java), which omits it as well.
-
-[whitepaper]: https://www.sonarsource.com/docs/CognitiveComplexity.pdf
-
----
-
-## 💻 CLI Usage
-
-You can run the scanner on-demand without installation, locally inside a project, or globally. *(Requires Dart SDK **3.12.0 or greater**)*.
-
-### On-Demand (Recommended)
-
-Run the scanner directly in any Dart or Flutter project root using the Dart SDK:
+Run the scanner directly in any Dart or Flutter project without prior
+installation:
 
 ```bash
-dart run cognitive_complexity@ [options] [targets]
+dart run cognitive_complexity@
 ```
 
-*(Note: The trailing `@` instructs the Dart VM to resolve and execute the latest published version of the package on-demand).*
+_(Requires Dart SDK **3.12.0 or greater**)_.
 
-### Project Dependency
+### Library API
 
-Add the package to your `dev_dependencies` in `pubspec.yaml`:
-
-```yaml
-dev_dependencies:
-  cognitive_complexity: ^0.2.2
-```
-
-And run:
-
-```bash
-dart run cognitive_complexity [options] [targets]
-```
-
-### Global Installation
-
-To install the scanner globally on your system:
-
-```bash
-dart install cognitive_complexity
-cognitive_complexity [options] [targets]
-```
-
-### Options
-
-* `-t, --threshold <value>`: Minimum score to display in the terminal (default: `0`).
-* `-f, --fail-threshold <value>`: Ceilings score. Exits with code `1` if any
-  declaration exceeds this value.
-* `-d, --git-diff <git-ref>`: Compares current code against a git commit/ref,
-  evaluating complexity deltas (Δ) on modified functions.
-* `--fail-on-increase`: When using `--git-diff`, exits with code `1` if any
-  modified function experienced a complexity score increase. When
-  `--fail-threshold` is also set, only increases that exceed the threshold
-  fail — increases within budget are reported but do not block. Omit
-  `--fail-threshold` for a strict ratchet (any increase fails).
-* `--format <text|json|github>`: Report output formatting (default: `text`).
-
----
-
-## 📦 Library API Usage
-
-Exposes programmatic analyzers for Dart and Flutter applications.
-
-Add to `pubspec.yaml`:
-```yaml
-dependencies:
-  cognitive_complexity: ^0.2.2
-```
-
-### Programmatic Scan Example
+Add `cognitive_complexity` to your `pubspec.yaml`:
 
 ```dart
 import 'package:cognitive_complexity/cognitive_complexity.dart';
 
 void main() {
   final analyzer = ComplexityAnalyzer();
-
-  // Scan a directory or file path
-  final results = analyzer.analyzePath('lib/src');
+  final results = analyzer.analyzePath('lib');
 
   for (final res in results) {
     print('${res.name}: score is ${res.score} (${res.filePath}:L${res.startLine})');
@@ -135,150 +50,44 @@ void main() {
 }
 ```
 
----
+### GitHub Actions
 
-## 🔄 Data-Flow Analysis (Extract Method Helper)
-
-In addition to complexity scoring, this package includes a **statement-level data-flow analyzer** and CLI tool (`data_flow`) designed to accelerate safe, automated refactoring (such as method extraction).
-
-Given a target Dart file and contiguous statement line slice, it extracts:
-* **Inputs**: Variables declared outside the slice that are read inside it.
-* **Mutations**: Variables declared outside the slice that are reassigned or mutated inside it.
-* **Outputs**: Variables declared or mutated inside the slice that remain live downstream.
-* **Control Flow Escapes**: Flags unextractable jumps (`return`, `break`, `continue`, `yield`) targeting outer scopes.
-* **Synthesized Signature**: Automatically generates an idiomatic Dart 3 Record return signature (e.g. `({String name, int count})`) when multiple variables are live downstream.
-
-### CLI Usage
-
-```bash
-# Run data-flow analysis on a target slice (JSON output by default)
-dart run cognitive_complexity:data_flow lib/src/my_file.dart:45-80
-
-# Output human-readable terminal report
-dart run cognitive_complexity:data_flow --format=text lib/src/my_file.dart:45-80
-
-# Specify proposed helper method name
-dart run cognitive_complexity:data_flow --name=_processItem lib/src/my_file.dart:45-80
-```
-
-Like the scanner, it also runs on-demand without a project dependency, and
-`dart install cognitive_complexity` puts a `data_flow` executable on your PATH:
-
-```bash
-# On-demand (resolves the latest published version)
-dart run cognitive_complexity:data_flow@ lib/src/my_file.dart:45-80
-
-# After global installation
-data_flow lib/src/my_file.dart:45-80
-```
-
-### Programmatic Data-Flow API
-
-```dart
-import 'package:cognitive_complexity/data_flow.dart';
-
-void main() async {
-  const analyzer = DataFlowAnalyzer();
-  final result = await analyzer.analyzeFile(
-    filePath: 'lib/src/service.dart',
-    startLine: 45,
-    endLine: 80,
-    methodName: '_processUser',
-  );
-
-  print('Cleanly extractable: ${result.isCleanlyExtractable}');
-  print('Inputs: ${result.inputs.map((u) => u.name).join(', ')}');
-  print('Outputs: ${result.outputs.map((u) => u.name).join(', ')}');
-  print('Proposed Signature: ${result.suggestedSignature}');
-}
-```
-
----
-
-## 🤖 GitHub Actions Integration
-
-You can run complexity checks automatically on pull requests using the
-integrated composite GitHub Action.
-
-### PR Delta Audit Workflow Example
-
-This workflow scans only the files and functions modified in the pull request. It
-injects inline code review warnings directly on modified PR lines and prints a
-beautiful markdown transition table to the workflow summary.
-
-Create `.github/workflows/complexity.yml`:
+Add automated complexity audits to `.github/workflows/complexity.yml`:
 
 ```yaml
-name: Cognitive Complexity Audit
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
 
-on:
-  pull_request:
-    branches: [ main ]
+- uses: dart-lang/setup-dart@v1
 
-jobs:
-  audit:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # Required to post/update sticky PR comments
-      contents: read       # Required for actions/checkout
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-        with:
-          # Fetch full history so merge-base comparison can locate common ancestor
-          fetch-depth: 0
-
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@v1
-
-      - name: Run Complexity Scanner
-        uses: kevmoo/cognitive_complexity.dart@main
-        with:
-          # Auto-configures pull request merge base comparison
-          diff-base: origin/${{ github.base_ref }}
-          fail-threshold: 15
-          fail-on-increase: true
+- uses: kevmoo/cognitive_complexity.dart@main
+  with:
+    diff-base: origin/${{ github.base_ref }}
+    fail-threshold: 15
+    fail-on-increase: true
 ```
 
-### Action Configuration Parameters (`with:`)
+## 🧠 AI Agent Integration
 
-* `targets`: Space-separated directories or files to scan (default: `lib`).
-* `threshold`: Minimum score to include in report tables (default: `0`).
-* `fail-threshold`: Max complexity ceiling (default: `15`).
-* `diff-base`: Git ref to compare against (e.g. `origin/main`). Leave empty
-  to compare full repository files.
-* `fail-on-increase`: Set `true` to block PR merge on complexity increases
-  that exceed `fail-threshold` (or on any increase when no threshold is set).
-* `format`: Summary format: `github` (GHA annotations + summary), `text`, or `json`.
-
-### Permissions & Security
-
-By default, GitHub Actions runs with read-only permissions. To enable posting and updating the sticky PR comment summary directly on the PR thread, you must explicitly grant write permissions to `pull-requests`:
-
-```yaml
-permissions:
-  pull-requests: write
-  contents: read
-```
-
-If write permissions are not granted, the scanner will execute normally, and output annotations and step summaries, but will skip posting the PR comment without failing the build.
-
-#### Fork PR Security Note
-Workflows triggered by pull requests from external forks are executed with restricted read-only permissions by GitHub. For security reasons, the action will gracefully skip posting PR comments on forks to prevent Remote Code Execution (RCE) risks, while still validating code complexity in GHA annotations and build status.
-
----
-
-## 🧠 AI Agent Integration (Skill)
-
-This repository packages an authoritative **Agent Skill** (`dart-cognitive-complexity`)
-designed to train LLMs and autonomous agents on Cognitive Complexity math,
-threshold boundaries, and structural Dart refactoring patterns (such as Dart 3
-switch expressions and guard clauses). *(Note: Executing automated skill scans via CLI requires Dart SDK version **3.12.0 or greater** in the agent runtime).*
-
-### Installing the Skill
-
-You can install this skill into your AI agent environment:
+This repository packages an agent skill (`dart-cognitive-complexity`) to train
+AI pair programmers on Cognitive Complexity scoring and refactoring patterns:
 
 ```bash
 npx skills add kevmoo/cognitive_complexity.dart --skill dart-cognitive-complexity
 ```
+
+## 📚 Documentation & Guides
+
+Explore in-depth documentation in the [`doc/`](doc/) directory:
+
+- 📐 [Scoring Model & Specification](doc/scoring.md): Complete scoring table,
+  nesting multipliers, and Dart 3 AST nuances.
+- 💻 [CLI Reference & CI Ratcheting](doc/cli.md): Command-line options, git diff
+  delta evaluation, and exit codes.
+- 🔄 [Statement Data-Flow Analysis](doc/data_flow.md): Statement slicing,
+  variable lifecycles, and automated method extraction helper.
+- 🤖 [GitHub Actions Guide](doc/github_actions.md): PR workflow setup,
+  parameters reference, and fork security permissions.
+
+[whitepaper]: https://www.sonarsource.com/docs/CognitiveComplexity.pdf

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Asking an agent to "refactor the code to make it cleaner" is poorly defined and
 leaves the agent to make arbitrary decisions.
 
 This Dart package, GitHub Action, and AI agent skill make finding and fixing
-overly complex logic easy, reliable, and repeatable.
+overly complex logic easy, reliable, and repeatable by implementing the
+[Cognitive Complexity principles][whitepaper] articulated by SonarSource.
 
 ## ✨ Features
 
@@ -88,3 +89,5 @@ Explore in-depth documentation in the [`doc/`](doc/) directory:
   variable lifecycles, and automated method extraction helper.
 - 🤖 [GitHub Actions Guide](doc/github_actions.md): PR workflow setup,
   parameters reference, and fork security permissions.
+
+[whitepaper]: https://www.sonarsource.com/docs/CognitiveComplexity.pdf

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1,0 +1,103 @@
+# Command-Line Interface (CLI)
+
+The `cognitive_complexity` package provides a high-performance, deterministic
+CLI scanner for measuring Cognitive Complexity across Dart and Flutter
+codebases.
+
+## Execution Modes
+
+Requires Dart SDK **3.12.0 or greater**.
+
+### 1. On-Demand (Zero Installation)
+
+Run the scanner directly in any Dart or Flutter project using the `@` syntax,
+which resolves and executes the latest published version:
+
+```bash
+dart run cognitive_complexity@ [options] [targets]
+```
+
+### 2. Project Dependency
+
+Add the package to `dev_dependencies` in `pubspec.yaml`:
+
+```yaml
+dev_dependencies:
+  cognitive_complexity: ^0.2.3
+```
+
+Execute locally:
+
+```bash
+dart run cognitive_complexity [options] [targets]
+```
+
+### 3. Global System Installation
+
+Install globally onto your system PATH:
+
+```bash
+dart install cognitive_complexity
+cognitive_complexity [options] [targets]
+```
+
+## Command Options & Flags
+
+<!-- mdformat off(prevent table wrapping) -->
+
+| Option / Flag                  | Type     | Default | Description                                                                                    |
+| :----------------------------- | :------- | :-----: | :--------------------------------------------------------------------------------------------- |
+| `-t, --threshold <value>`      | `int`    |   `0`   | Minimum score required to display a declaration in the report.                                 |
+| `-f, --fail-threshold <value>` | `int`    | _None_  | Ceilings score. Exits with code `1` if any declaration exceeds this value.                     |
+| `-d, --git-diff <git-ref>`     | `String` | _None_  | Compares current workspace declarations against `<git-ref>`, evaluating complexity deltas (Δ). |
+| `--fail-on-increase`           | `flag`   | `false` | When using `--git-diff`, fails if any modified function increases in complexity.               |
+| `--format <type>`              | `enum`   | `text`  | Output format: `text` (terminal), `json` (machine-readable), or `github` (GHA annotations).    |
+| `--sdk-path <path>`            | `String` | _Auto_  | Overrides automated Dart/Flutter SDK location discovery.                                       |
+
+<!-- mdformat on -->
+
+## Target Resolution
+
+Pass one or more file paths or directories as positional arguments:
+
+```bash
+# Scan specific directories
+dart run cognitive_complexity lib bin
+
+# Scan specific files
+dart run cognitive_complexity lib/src/analyzer.dart lib/src/visitor.dart
+
+# Scan current working directory (defaults to lib if omitted)
+dart run cognitive_complexity
+```
+
+## Git Diff & CI Ratcheting
+
+The `--git-diff` option compares declarations in the working copy against a base
+Git ref (such as `origin/main` or a feature branch base).
+
+### Pragmatic Budgeted Gate (Recommended)
+
+When `--fail-on-increase` is specified alongside `--fail-threshold`, a
+complexity increase does **not** fail the run as long as the total score remains
+below or equal to the `--fail-threshold`. This permits minor additions (e.g.
+input validation or error handlers) while enforcing an absolute ceiling:
+
+```bash
+dart run cognitive_complexity --git-diff=origin/main --fail-threshold=15 --fail-on-increase
+```
+
+### Strict Ratchet Gate
+
+When `--fail-on-increase` is specified **without** `--fail-threshold`, any
+complexity increase on a modified function immediately exits with code `1`:
+
+```bash
+dart run cognitive_complexity --git-diff=origin/main --fail-on-increase
+```
+
+## Exit Codes
+
+- `0`: Scan completed successfully; all thresholds and gates satisfied.
+- `1`: Complexity ceiling exceeded, unauthorized complexity increase detected,
+  or fatal analysis error.

--- a/doc/data_flow.md
+++ b/doc/data_flow.md
@@ -1,0 +1,83 @@
+# Statement Data-Flow Analysis
+
+The `data_flow` tool and library provide statement-level static data-flow
+analysis for Dart codebases. It is designed to evaluate contiguous statement
+slices for safe, automated refactoring (such as the Extract Method pattern).
+
+## Analysis Concepts
+
+Given a target Dart source file and contiguous line range (statement slice), the
+analyzer evaluates:
+
+- **Inputs**: Variables declared outside the slice that are read inside it
+  (preserving static type promotion at read sites).
+- **Mutations**: Variables declared outside the slice that are reassigned or
+  mutated within the slice.
+- **Outputs**: Variables declared or mutated inside the slice that remain live
+  and are read downstream.
+- **Control Flow Escapes**: Identifies out-of-scope jumps (`return`, labeled
+  `break` / `continue`, `yield`, unhandled `rethrow`, and escaping asynchronous
+  closure mutations).
+- **Synthesized Signature**: Automatically generates an idiomatic Dart 3 Record
+  return signature (e.g. `({String name, int count})`) when multiple variables
+  are live downstream.
+
+## CLI Usage
+
+The `data_flow` executable is included in the package.
+
+### 1. On-Demand Execution
+
+```bash
+# Default JSON output
+dart run cognitive_complexity:data_flow@ lib/src/my_file.dart:45-80
+
+# Human-readable terminal report
+dart run cognitive_complexity:data_flow@ --format=text lib/src/my_file.dart:45-80
+```
+
+### 2. Propose Helper Method Name
+
+Pass `--name` to customize the synthesized helper signature:
+
+```bash
+dart run cognitive_complexity:data_flow --name=_processItem lib/src/my_file.dart:45-80
+```
+
+### 3. Global Command
+
+If installed globally via `dart install cognitive_complexity`:
+
+```bash
+data_flow lib/src/my_file.dart:45-80
+```
+
+## Programmatic API
+
+Add `cognitive_complexity` to your dependencies in `pubspec.yaml`:
+
+```yaml
+dependencies:
+  cognitive_complexity: ^0.2.3
+```
+
+### Example
+
+```dart
+import 'package:cognitive_complexity/data_flow.dart';
+
+void main() async {
+  const analyzer = DataFlowAnalyzer();
+  final result = await analyzer.analyzeFile(
+    filePath: 'lib/src/service.dart',
+    startLine: 45,
+    endLine: 80,
+    methodName: '_processUser',
+  );
+
+  print('Cleanly extractable: ${result.isCleanlyExtractable}');
+  print('Inputs: ${result.inputs.map((u) => u.name).join(', ')}');
+  print('Outputs: ${result.outputs.map((u) => u.name).join(', ')}');
+  print('Proposed Signature: ${result.suggestedSignature}');
+}
+```

--- a/doc/github_actions.md
+++ b/doc/github_actions.md
@@ -1,0 +1,87 @@
+# GitHub Actions Integration
+
+The `cognitive_complexity` repository includes a composite GitHub Action that
+automatically evaluates Cognitive Complexity on pull requests and commits.
+
+It posts inline review annotations, generates markdown summary tables in
+workflow summaries, and optionally updates a sticky comment on pull requests.
+
+## PR Delta Audit Workflow Example
+
+This workflow scans files modified in a pull request against the base branch
+using `--git-diff`.
+
+Create `.github/workflows/complexity.yml`:
+
+```yaml
+name: Cognitive Complexity Audit
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Required to post/update sticky PR comments
+      contents: read # Required for actions/checkout
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history so merge-base comparison can locate common ancestor
+          fetch-depth: 0
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+
+      - name: Run Complexity Scanner
+        uses: kevmoo/cognitive_complexity.dart@main
+        with:
+          # Auto-configures pull request merge base comparison
+          diff-base: origin/${{ github.base_ref }}
+          fail-threshold: 15
+          fail-on-increase: true
+```
+
+## Action Parameters (`with:`)
+
+<!-- mdformat off(prevent table wrapping) -->
+
+| Parameter          | Default  | Description                                                                                                                  |
+| :----------------- | :------: | :--------------------------------------------------------------------------------------------------------------------------- |
+| `targets`          |  `lib`   | Space-separated list of directories or files to scan.                                                                        |
+| `threshold`        |   `0`    | Minimum score required to include a declaration in summary tables.                                                           |
+| `fail-threshold`   |   `15`   | Maximum complexity ceiling allowed before failing the build.                                                                 |
+| `diff-base`        | _Empty_  | Git ref to compare against (e.g. `origin/main`). When empty, scans entire files.                                             |
+| `fail-on-increase` | `false`  | When `true`, blocks PR merge on complexity increases exceeding `fail-threshold` (or on any increase if no threshold is set). |
+| `format`           | `github` | Summary format: `github` (GHA annotations + step summary), `text`, or `json`.                                                |
+
+<!-- mdformat on -->
+
+## Permissions & Security
+
+### PR Comment Permissions
+
+By default, GitHub Actions runs with read-only permissions. To enable posting
+and updating the sticky PR comment summary directly on the pull request thread,
+grant `pull-requests: write`:
+
+```yaml
+permissions:
+  pull-requests: write
+  contents: read
+```
+
+If write permissions are not granted, the action will still generate GitHub
+Annotations and Step Summaries, but will gracefully skip posting the sticky
+comment without failing the build.
+
+### Fork PR Security
+
+Workflows triggered by pull requests from external forks are executed with
+restricted read-only permissions by GitHub. For security reasons, the action
+automatically detects fork environments and skips posting PR comments to prevent
+permission errors and security risks, while continuing to validate complexity
+via check annotations.

--- a/doc/scoring.md
+++ b/doc/scoring.md
@@ -1,0 +1,56 @@
+# Scoring Model & Specification
+
+Cognitive Complexity measures how difficult a unit of code is for a human
+engineer to read, comprehend, and maintain. Unlike Cyclomatic Complexity—which
+measures the mathematical density of execution paths and test branch
+coverage—Cognitive Complexity penalizes structures that disrupt linear reading
+and deeply nested logic.
+
+Scoring follows the [SonarSource Cognitive Complexity whitepaper][whitepaper]
+(G. Ann Campbell, v1.7) adapted for modern Dart 3 syntax.
+
+## Scoring Rules & Multipliers
+
+Each construct contributes a **Base Cost** (flat penalty) and may also apply a
+**Nesting Multiplier** based on the current nesting depth ($D$).
+
+<!-- mdformat off(prevent table wrapping) -->
+
+| Construct / Syntax                                              | Base Cost |  Nesting Multiplier  | Deepens Nesting? | Notes                                            |
+| :-------------------------------------------------------------- | :-------: | :------------------: | :--------------: | :----------------------------------------------- |
+| **`if`, `for`, `while`, `do-while`, `catch` / `on`**            |   `+1`    | `+D` (Current Depth) |     **Yes**      | Standard flow-breaking structures                |
+| **`switch` Statements & Expressions**                           |   `+1`    | `+D` (Current Depth) |     **Yes**      | Entire block costs `+1` regardless of arm count  |
+| **`else` / `else if`**                                          |   `+1`    | `+0` (Flat penalty)  |      **No**      | Branch contents sit one level below head `if`    |
+| **Logical Operators (`&&`, `\|\|`)**                            |   `+1`    | `+0` (Flat penalty)  |      **No**      | `+1` per sequence; `+1` for each alternation     |
+| **Pattern `when` Guards**                                       |   `+1`    | `+0` (Flat penalty)  |      **No**      | Dart 3 specific interpretation                   |
+| **Lambdas & Local Functions**                                   |   `+0`    |         `+0`         |     **Yes**      | Deepens nesting depth for enclosed bodies        |
+| **Null-Aware (`??`, `?.`, `??=`), `assert`, `try` / `finally`** |   `+0`    |         `+0`         |      **No**      | Benign syntax; completely free                   |
+| **Switch Case Labels & Pattern Combinators**                    |   `+0`    |         `+0`         |      **No**      | Stacked arms / or-patterns (`1 \|\| 2`) are free |
+
+<!-- mdformat on -->
+
+## Dart-Specific Interpretations
+
+1. **Pattern `when` Guards**: Pattern guards (`case Pattern() when condition:`)
+   evaluate an additional boolean predicate beyond structural pattern matching.
+   Each `when` clause adds `+1` (flat penalty without nesting increment).
+
+2. **Pattern Combinators (`||`, `&&`)**: Pattern-level combinators (such as
+   `case 1 || 2:` or `case > 0 && < 10:`) are scored at `+0`. In Dart 3, an
+   or-pattern is the idiomatic representation of stacked case labels, which the
+   whitepaper scores at zero.
+
+3. **Switch Expressions & Statements**: A `switch` expression or statement adds
+   `+1` (plus nesting depth $D$). Individual `case` arms are free, encouraging
+   developers to replace cascading `if-else` chains with pattern-matching switch
+   expressions.
+
+4. **Recursion Cycles**: The whitepaper suggestion of "+1 for each method in a
+   recursion cycle" is omitted, matching SonarSource's reference implementation
+   (`sonar-java`).
+
+5. **Collection Control Flow (`if`, `for`)**: Collection literals containing
+   `if` or `for` elements are scored identically to their statement
+   counterparts.
+
+[whitepaper]: https://www.sonarsource.com/docs/CognitiveComplexity.pdf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cognitive_complexity
 description: Algorithmic Cognitive Complexity calculation and Data-Flow analysis library and CLI tools for Dart and Flutter.
-version: 0.2.3+1
+version: 0.2.3+2
 repository: https://github.com/kevmoo/cognitive_complexity.dart
 
 executables:


### PR DESCRIPTION
- Refactor README into a lightweight, scannable TL;DR following pub.dev guidelines.
- Extract deep-dive references into doc/ (scoring.md, cli.md, data_flow.md, github_actions.md).
- Cross-link modular guides and quick-start snippets.
