### PR TITLE
ci: support monorepo package-prefixed tags in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [ main ]
   push:
-    tags: [ '[a-zA-Z0-9_]+-v[0-9]+.[0-9]+.[0-9]+*' ]
+    tags:
+      - '*-v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,9 @@ on:
   pull_request:
     branches: [ main ]
   push:
-    tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
+    tags:
+      - '[a-zA-Z0-9_]+-v[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,9 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   push:
-    tags:
-      - '[a-zA-Z0-9_]+-v[0-9]+.[0-9]+.[0-9]+*'
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+    tags: [ '[a-zA-Z0-9_]+-v[0-9]+.[0-9]+.[0-9]+*' ]
 
 jobs:
   publish:


### PR DESCRIPTION
Update tag pattern in publish.yaml to trigger on <package>-v<version> tags in addition to root tags.
