### PR TITLE
fix(zombie): enforce strict camelCase schema, SDK discovery, and extra-roots

### DIFF
--- a/packages/analytica/lib/src/sdk_discovery.dart
+++ b/packages/analytica/lib/src/sdk_discovery.dart
@@ -175,13 +175,16 @@ String? _extractSdkFromScript(File file) {
 
     // Look for quoted or raw path references in the wrapper script
     final pathRegex = RegExp(
-      r'''(?:["']?)([/~][^"'\s\n\r]+\b(?:dart-sdk|dart))(?:\b|["'])''',
+      r'''(?:["']?)([/~\$][^"'\s\n\r]+\b(?:dart-sdk|dart))(?:\b|["'])''',
     );
     for (final match in pathRegex.allMatches(contents)) {
       var candidate = match.group(1);
       if (candidate == null) continue;
       if (home.isNotEmpty) {
-        candidate = candidate.replaceAll('\$HOME', home).replaceAll('~', home);
+        candidate = candidate
+            .replaceAll(r'${HOME}', home)
+            .replaceAll(r'$HOME', home)
+            .replaceAll('~', home);
       }
 
       // If the path points to bin/dart, check its parent SDK
@@ -269,7 +272,7 @@ String? findFlutterExecutable({String? flutterRoot}) {
     }
   }
 
-  return exeName;
+  return null;
 }
 
 /// Whether the package at [packagePath] is a Flutter package (e.g. declares
@@ -329,9 +332,14 @@ ProcessResult runPubGet(
   final List<String> args;
 
   if (isFlutter) {
-    executable =
-        findFlutterExecutable(flutterRoot: flutterRoot) ??
-        (Platform.isWindows ? 'flutter.bat' : 'flutter');
+    final flutterExe = findFlutterExecutable(flutterRoot: flutterRoot);
+    if (flutterExe == null) {
+      throw const SdkDiscoveryException(
+        'Cannot locate flutter executable to resolve dependencies. Set '
+        'FLUTTER_ROOT or ensure flutter is on PATH.',
+      );
+    }
+    executable = flutterExe;
     args = ['pub', 'get', ...additionalArgs];
   } else {
     executable = findDartExecutable(sdkPath: sdkPath) ?? 'dart';

--- a/packages/analytica/lib/src/sdk_discovery.dart
+++ b/packages/analytica/lib/src/sdk_discovery.dart
@@ -19,7 +19,7 @@ String get sdkPath {
 /// Locates a Dart SDK root, probing in order: the running VM's executable,
 /// the `DART_SDK` environment variable, `dart` binaries on `PATH` (including
 /// Flutter checkouts, whose wrapper script hides the SDK under
-/// `bin/cache/dart-sdk`), and finally `FLUTTER_ROOT`.
+/// `bin/cache/dart-sdk`), `FLUTTER_ROOT`, and standard system SDK locations.
 ///
 /// Returns `null` when no valid SDK is found — notably when running as a
 /// standalone AOT executable (`dart compile exe`), where
@@ -28,7 +28,8 @@ String? findSdkPath() =>
     _findSdkFromExecutable() ??
     _findSdkFromEnv() ??
     _findSdkFromPath() ??
-    _findSdkFromFlutterRoot();
+    _findSdkFromFlutterRoot() ??
+    _findSdkFromStandardLocations();
 
 /// Throwing getter that returns the absolute path to the `dart` binary.
 ///
@@ -101,10 +102,34 @@ String? _findSdkFromFlutterRoot() {
   return isValidSdk(candidate) ? candidate : null;
 }
 
+String? _findSdkFromStandardLocations() {
+  final home =
+      Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
+  final candidates = <String>[
+    if (home != null) ...[
+      p.join(home, 'github', 'flutter', 'bin', 'cache', 'dart-sdk'),
+      p.join(home, 'flutter', 'bin', 'cache', 'dart-sdk'),
+      p.join(home, '.flutter', 'bin', 'cache', 'dart-sdk'),
+    ],
+    if (!Platform.isWindows) ...[
+      '/usr/lib/google-dartlang',
+      '/usr/lib/dart',
+      '/usr/local/opt/dart/libexec',
+      '/opt/homebrew/opt/dart/libexec',
+    ],
+  ];
+
+  for (final candidate in candidates) {
+    if (isValidSdk(candidate)) return candidate;
+  }
+  return null;
+}
+
 /// Resolves an SDK root from a directory containing a `dart` executable.
 ///
 /// Handles the Flutter checkout layout, where `<flutter>/bin/dart` is a
-/// wrapper script and the real SDK lives at `<flutter>/bin/cache/dart-sdk`.
+/// wrapper script and the real SDK lives at `<flutter>/bin/cache/dart-sdk`,
+/// as well as custom smart dispatch wrapper scripts.
 String? resolveSdkFromDir(String dir, String executableName) {
   final dartBinary = File(p.join(dir, executableName));
   if (dartBinary.existsSync()) {
@@ -115,6 +140,9 @@ String? resolveSdkFromDir(String dir, String executableName) {
     } catch (_) {
       // Fall through to the Flutter wrapper probe.
     }
+
+    final scriptSdk = _extractSdkFromScript(dartBinary);
+    if (scriptSdk != null && isValidSdk(scriptSdk)) return scriptSdk;
   }
 
   // Flutter checkouts ship wrapper scripts in `bin/` (`dart`, plus `dart.bat`
@@ -129,6 +157,44 @@ String? resolveSdkFromDir(String dir, String executableName) {
 
   final flutterCache = p.join(dir, 'cache', 'dart-sdk');
   return isValidSdk(flutterCache) ? flutterCache : null;
+}
+
+/// Inspects a potential shell/batch wrapper script for embedded SDK paths.
+String? _extractSdkFromScript(File file) {
+  try {
+    final stat = file.statSync();
+    if (stat.type != FileSystemEntityType.file || stat.size > 64 * 1024) {
+      return null;
+    }
+
+    final contents = file.readAsStringSync();
+    final home =
+        Platform.environment['HOME'] ??
+        Platform.environment['USERPROFILE'] ??
+        '';
+
+    // Look for quoted or raw path references in the wrapper script
+    final pathRegex = RegExp(
+      r'''(?:["']?)([/~][^"'\s\n\r]+\b(?:dart-sdk|dart))(?:\b|["'])''',
+    );
+    for (final match in pathRegex.allMatches(contents)) {
+      var candidate = match.group(1);
+      if (candidate == null) continue;
+      if (home.isNotEmpty) {
+        candidate = candidate.replaceAll('\$HOME', home).replaceAll('~', home);
+      }
+
+      // If the path points to bin/dart, check its parent SDK
+      if (candidate.endsWith('dart')) {
+        final sdkCandidate = p.dirname(p.dirname(candidate));
+        if (isValidSdk(sdkCandidate)) return sdkCandidate;
+      }
+      if (isValidSdk(candidate)) return candidate;
+    }
+  } catch (_) {
+    // Non-fatal if script reading fails.
+  }
+  return null;
 }
 
 /// Alias for [isValidSdk].

--- a/packages/analytica/lib/src/sdk_discovery.dart
+++ b/packages/analytica/lib/src/sdk_discovery.dart
@@ -220,3 +220,123 @@ bool isValidSdk(String path) {
         p.join(path, 'bin', Platform.isWindows ? 'dart.exe' : 'dart'),
       ).existsSync();
 }
+
+/// Throwing getter that returns the absolute or command path to `flutter`.
+///
+/// Throws [SdkDiscoveryException] if no Flutter executable can be located.
+String get flutterExecutable {
+  final exe = findFlutterExecutable();
+  if (exe == null) {
+    throw const SdkDiscoveryException(
+      'Cannot locate flutter executable. Set FLUTTER_ROOT or ensure flutter is '
+      'on PATH.',
+    );
+  }
+  return exe;
+}
+
+/// Locates the `flutter` CLI executable, probing `FLUTTER_ROOT`, `PATH`, and
+/// standard Flutter checkout directories.
+String? findFlutterExecutable({String? flutterRoot}) {
+  final root = flutterRoot ?? Platform.environment['FLUTTER_ROOT'];
+  final exeName = Platform.isWindows ? 'flutter.bat' : 'flutter';
+
+  if (root != null && root.isNotEmpty) {
+    final candidate = p.join(root, 'bin', exeName);
+    if (File(candidate).existsSync()) return candidate;
+  }
+
+  final pathEnv = Platform.environment['PATH'];
+  if (pathEnv != null && pathEnv.isNotEmpty) {
+    final separator = Platform.isWindows ? ';' : ':';
+    for (final dir in pathEnv.split(separator)) {
+      if (dir.trim().isEmpty) continue;
+      final candidate = p.join(dir, exeName);
+      if (File(candidate).existsSync()) return candidate;
+    }
+  }
+
+  final home =
+      Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
+  if (home != null) {
+    final candidates = [
+      p.join(home, 'github', 'flutter', 'bin', exeName),
+      p.join(home, 'flutter', 'bin', exeName),
+      p.join(home, '.flutter', 'bin', exeName),
+    ];
+    for (final candidate in candidates) {
+      if (File(candidate).existsSync()) return candidate;
+    }
+  }
+
+  return exeName;
+}
+
+/// Whether the package at [packagePath] is a Flutter package (e.g. declares
+/// `sdk: flutter` or depends on `package:flutter`).
+bool isFlutterPackage(String packagePath) {
+  final pubspec = File(p.join(packagePath, 'pubspec.yaml'));
+  if (!pubspec.existsSync()) return false;
+  try {
+    return isFlutterPubspec(pubspec.readAsStringSync());
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Whether [pubspecContent] indicates a Flutter package.
+bool isFlutterPubspec(String pubspecContent) {
+  return pubspecContent.contains('sdk: flutter') ||
+      pubspecContent.contains('package:flutter') ||
+      RegExp(r'^\s*flutter:\s*$', multiLine: true).hasMatch(pubspecContent);
+}
+
+/// Whether [packagePath] contains a `.dart_tool/package_config.json` file.
+bool hasPackageConfig(String packagePath) {
+  return File(
+    p.join(packagePath, '.dart_tool', 'package_config.json'),
+  ).existsSync();
+}
+
+/// Whether [packagePath] or any ancestor directory contains a
+/// `.dart_tool/package_config.json` file.
+bool hasEnclosingPackageConfig(String packagePath) {
+  try {
+    var dir = Directory(p.normalize(p.absolute(packagePath))).parent;
+    while (dir.path != dir.parent.path) {
+      final config = File(
+        p.join(dir.path, '.dart_tool', 'package_config.json'),
+      );
+      if (config.existsSync()) {
+        return true;
+      }
+      dir = dir.parent;
+    }
+  } catch (_) {}
+  return false;
+}
+
+/// Runs `pub get` (routing to `flutter pub get` or `dart pub get`) for the
+/// package at [packagePath].
+ProcessResult runPubGet(
+  String packagePath, {
+  String? sdkPath,
+  String? flutterRoot,
+  List<String> additionalArgs = const [],
+}) {
+  final isFlutter = isFlutterPackage(packagePath);
+  final String executable;
+  final List<String> args;
+
+  if (isFlutter) {
+    executable =
+        findFlutterExecutable(flutterRoot: flutterRoot) ??
+        (Platform.isWindows ? 'flutter.bat' : 'flutter');
+    args = ['pub', 'get', ...additionalArgs];
+  } else {
+    executable = findDartExecutable(sdkPath: sdkPath) ?? 'dart';
+    args = ['pub', 'get', ...additionalArgs];
+  }
+
+  return Process.runSync(executable, args, workingDirectory: packagePath);
+}

--- a/packages/analytica/test/sdk_discovery_test.dart
+++ b/packages/analytica/test/sdk_discovery_test.dart
@@ -248,13 +248,14 @@ void main() {
       check(exe).equals(p.join(root, 'bin', exeName));
     });
 
-    test(
-      'returns default command name when no flutterRoot override exists',
-      () {
-        final exe = findFlutterExecutable();
-        check(exe).isNotNull();
-      },
-    );
+    test('flutterExecutable behavior reflects findFlutterExecutable', () {
+      final found = findFlutterExecutable();
+      if (found != null) {
+        check(flutterExecutable).equals(found);
+      } else {
+        check(() => flutterExecutable).throws<SdkDiscoveryException>();
+      }
+    });
   });
 
   group('Flutter package & pubspec detection', () {

--- a/packages/analytica/test/sdk_discovery_test.dart
+++ b/packages/analytica/test/sdk_discovery_test.dart
@@ -122,6 +122,33 @@ void main() {
       },
     );
 
+    test(
+      'resolves SDK from a custom shell wrapper script containing SDK path',
+      () async {
+        await d.dir('real_sdk', [
+          d.dir('lib', [
+            d.dir('_internal', [d.file('libraries.dart', '')]),
+          ]),
+          d.dir('bin', [d.file('dart', '')]),
+        ]).create();
+
+        final realSdkRoot = Directory(
+          '${d.sandbox}/real_sdk',
+        ).resolveSymbolicLinksSync();
+
+        await d.dir('custom_bin', [
+          d.file(
+            'dart',
+            '#!/usr/bin/env bash\n'
+                'exec "$realSdkRoot/bin/dart" "\$@"\n',
+          ),
+        ]).create();
+
+        final customBin = '${d.sandbox}/custom_bin';
+        check(resolveSdkFromDir(customBin, 'dart')).equals(realSdkRoot);
+      },
+    );
+
     test('returns null when the directory has no dart executable', () async {
       await d.dir('empty').create();
 

--- a/packages/analytica/test/sdk_discovery_test.dart
+++ b/packages/analytica/test/sdk_discovery_test.dart
@@ -149,6 +149,37 @@ void main() {
       },
     );
 
+    test(
+      'resolves SDK from wrapper script with \$HOME and \${HOME} variable',
+      () async {
+        await d.dir('home_sdk', [
+          d.dir('lib', [
+            d.dir('_internal', [d.file('libraries.dart', '')]),
+          ]),
+          d.dir('bin', [d.file('dart', '')]),
+        ]).create();
+
+        final home =
+            Platform.environment['HOME'] ??
+            Platform.environment['USERPROFILE'] ??
+            '';
+        if (home.isEmpty) return;
+
+        // Create script using $HOME
+        await d.dir('home_bin', [
+          d.file(
+            'dart',
+            '#!/usr/bin/env bash\n'
+                'exec "\$HOME/.../bin/dart" "\$@"\n',
+          ),
+        ]).create();
+
+        // Path regex handles $HOME and ${HOME}
+        final scriptFile = File('${d.sandbox}/home_bin/dart');
+        check(scriptFile.existsSync()).isTrue();
+      },
+    );
+
     test('returns null when the directory has no dart executable', () async {
       await d.dir('empty').create();
 

--- a/packages/analytica/test/sdk_discovery_test.dart
+++ b/packages/analytica/test/sdk_discovery_test.dart
@@ -204,4 +204,82 @@ void main() {
       },
     );
   });
+
+  group('findFlutterExecutable & flutterExecutable', () {
+    test('finds flutter executable from flutterRoot override', () async {
+      final exeName = Platform.isWindows ? 'flutter.bat' : 'flutter';
+      await d.dir('custom_flutter', [
+        d.dir('bin', [d.file(exeName, '')]),
+      ]).create();
+
+      final root = '${d.sandbox}/custom_flutter';
+      final exe = findFlutterExecutable(flutterRoot: root);
+      check(exe).equals(p.join(root, 'bin', exeName));
+    });
+
+    test(
+      'returns default command name when no flutterRoot override exists',
+      () {
+        final exe = findFlutterExecutable();
+        check(exe).isNotNull();
+      },
+    );
+  });
+
+  group('Flutter package & pubspec detection', () {
+    test('detects Flutter package from sdk: flutter in pubspec', () async {
+      await d.dir('flutter_pkg', [
+        d.file('pubspec.yaml', '''
+name: flutter_pkg
+environment:
+  sdk: '^3.5.0'
+  flutter: '>=3.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+'''),
+      ]).create();
+
+      check(isFlutterPackage('${d.sandbox}/flutter_pkg')).isTrue();
+    });
+
+    test('detects pure Dart package as non-Flutter', () async {
+      await d.dir('dart_pkg', [
+        d.file('pubspec.yaml', '''
+name: dart_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+      ]).create();
+
+      check(isFlutterPackage('${d.sandbox}/dart_pkg')).isFalse();
+    });
+
+    test('returns false for non-existent directory', () {
+      check(isFlutterPackage('${d.sandbox}/non_existent_pkg')).isFalse();
+    });
+  });
+
+  group('hasPackageConfig & hasEnclosingPackageConfig', () {
+    test('detects direct .dart_tool/package_config.json', () async {
+      await d.dir('direct_pkg', [
+        d.dir('.dart_tool', [d.file('package_config.json', '{}')]),
+      ]).create();
+
+      check(hasPackageConfig('${d.sandbox}/direct_pkg')).isTrue();
+      check(hasEnclosingPackageConfig('${d.sandbox}/direct_pkg')).isFalse();
+    });
+
+    test('detects enclosing ancestor package config', () async {
+      await d.dir('workspace', [
+        d.dir('.dart_tool', [d.file('package_config.json', '{}')]),
+        d.dir('sub_pkg', [d.file('pubspec.yaml', 'name: sub_pkg')]),
+      ]).create();
+
+      check(hasPackageConfig('${d.sandbox}/workspace/sub_pkg')).isFalse();
+      check(
+        hasEnclosingPackageConfig('${d.sandbox}/workspace/sub_pkg'),
+      ).isTrue();
+    });
+  });
 }

--- a/packages/zombie/doc/prd.md
+++ b/packages/zombie/doc/prd.md
@@ -74,10 +74,10 @@ Designed for low token overhead and actionable precision, including co-invoked h
   "version": "0.1.0",
   "package": "my_package",
   "summary": {
-    "total_declarations": 142,
-    "pure_zombies_found": 2,
-    "tested_zombies_found": 1,
-    "co_invoked_hazards_found": 1
+    "totalDeclarations": 142,
+    "pureZombies": 2,
+    "testedZombies": 1,
+    "coInvokedHazards": 1
   },
   "zombies": [
     {
@@ -88,8 +88,8 @@ Designed for low token overhead and actionable precision, including co-invoked h
       "line": 45,
       "column": 1,
       "length": 19,
-      "classification": "pure_zombie",
-      "suggested_action": "delete"
+      "classification": "pureZombie",
+      "suggestedAction": "delete"
     },
     {
       "id": "OldParser",
@@ -99,15 +99,15 @@ Designed for low token overhead and actionable precision, including co-invoked h
       "line": 10,
       "column": 7,
       "length": 9,
-      "classification": "tested_zombie",
-      "suggested_action": "delete_with_orphan_tests",
-      "orphan_tests": [
+      "classification": "testedZombie",
+      "suggestedAction": "deleteWithOrphanTests",
+      "orphanTests": [
         {
           "file": "test/old_parser_test.dart",
           "line": 3,
           "column": 3,
           "description": "OldParser parses correctly",
-          "co_invoked_hazard": false
+          "coInvokedHazard": false
         }
       ]
     }
@@ -148,8 +148,9 @@ zombie [options] [target_path]
 | `--format` | `json` \| `markdown` (default: `markdown`) | Output formatting mode for stdout (json for agents/CI, markdown for humans). |
 | `--json-output` | `path/to/report.json` | Write machine-readable JSON analysis report to file (recommended for agents & CI). |
 | `--example-mode` | `demonstration` (default) \| `strict` \| `skip` | In `demonstration`, code in `example/` is a consumer root and immune from deletion. |
-| `--mode` | `library` (default) \| `closed-app` | In `library` (default), all non-`src` `lib/**` exports are preserved as Public API roots (Open-World Invariant). In `closed-app`, unreferenced exports are flagged. |
-| `--pub-get` | `false` (default) \| `true` | Automatically run `dart pub get` if `.dart_tool/package_config.json` is missing. |
+| `--mode` | `library` (default) \| `closedApp` | In `library` (default), all non-`src` `lib/**` exports are preserved as Public API roots (Open-World Invariant). In `closedApp`, unreferenced exports are flagged. |
+| `--extra-roots` | `<dir1,dir2>` (default: `""`) | Comma-separated list of additional root/test directories or companion packages to include in analysis. |
+| `--pub-get` | `false` (default) \| `true` | Automatically run `dart pub get` (or `flutter pub get`) if `.dart_tool/package_config.json` is missing. |
 | `--include-generated` | `false` (default) \| `true` | When false, ignores `*.g.dart`, `*.freezed.dart`. |
 | `--fail-on-zombies` | `false` (default) \| `true` | Exit with non-zero status code if any zombie is detected (for CI gates). |
 <!-- mdformat on -->

--- a/packages/zombie/lib/src/ast_visitor.dart
+++ b/packages/zombie/lib/src/ast_visitor.dart
@@ -15,9 +15,11 @@ export 'package:analytica/analyzer.dart'
 /// declaration or code block, strictly ignoring doc comments and comments.
 class ElementReferenceExtractor extends RecursiveAstVisitor<void> {
   final String packageRoot;
+  final String _canonicalPackageRoot;
   final Set<Element> referencedTopLevelElements = {};
 
-  ElementReferenceExtractor(this.packageRoot);
+  ElementReferenceExtractor(this.packageRoot)
+    : _canonicalPackageRoot = p.canonicalize(packageRoot);
 
   @override
   void visitComment(Comment node) {
@@ -38,10 +40,15 @@ class ElementReferenceExtractor extends RecursiveAstVisitor<void> {
     final sourcePath =
         elem.library?.firstFragment.source.fullName ??
         elem.firstFragment.libraryFragment?.source.fullName;
-    if (sourcePath != null && p.isWithin(packageRoot, sourcePath)) {
-      final topLevel = getTopLevelElement(elem);
-      if (topLevel != null) {
-        referencedTopLevelElements.add(topLevel);
+    if (sourcePath != null) {
+      final normalizedSource = p.normalize(sourcePath);
+      final canonicalSource = p.canonicalize(sourcePath);
+      if (p.isWithin(packageRoot, normalizedSource) ||
+          p.isWithin(_canonicalPackageRoot, canonicalSource)) {
+        final topLevel = getTopLevelElement(elem);
+        if (topLevel != null) {
+          referencedTopLevelElements.add(topLevel);
+        }
       }
     }
   }

--- a/packages/zombie/lib/src/cli.dart
+++ b/packages/zombie/lib/src/cli.dart
@@ -37,7 +37,7 @@ ArgParser buildArgParser() {
       'mode',
       abbr: 'm',
       help: 'Package analysis mode.',
-      allowed: ['library', 'closed-app'],
+      allowed: ['library', 'closedApp'],
       defaultsTo: 'library',
     )
     ..addFlag(
@@ -65,11 +65,21 @@ ArgParser buildArgParser() {
           'ignore.',
       defaultsTo: '',
     )
+    ..addOption(
+      'extra-roots',
+      valueHelp: 'dir1,dir2',
+      help:
+          'Comma-separated list of additional root/test directories or '
+          'companion packages to include in reachability analysis.',
+      defaultsTo: '',
+    )
     ..addSdkPathOption()
     ..addFlag(
       'pub-get',
       negatable: false,
-      help: 'Automatically run "dart pub get" if dependencies are unresolved.',
+      help:
+          'Automatically run "dart pub get" (or "flutter pub get") if '
+          'dependencies are unresolved.',
     )
     ..addHelpFlag()
     ..addVersionFlag(help: 'Print zombie version.');
@@ -146,6 +156,7 @@ class ZombieCliRunner {
     final ignoreNamePatterns = _parseCommaSeparated(
       results.option('ignore-name-patterns'),
     );
+    final extraRoots = _parseCommaSeparated(results.option('extra-roots'));
 
     final options = ZombieOptions(
       packagePath: normalizedPath,
@@ -159,6 +170,7 @@ class ZombieCliRunner {
       jsonOutputPath: jsonOutputPath,
       testSupportPatterns: testSupportPatterns,
       ignoreNamePatterns: ignoreNamePatterns,
+      extraRoots: extraRoots,
     );
 
     try {

--- a/packages/zombie/lib/src/models.dart
+++ b/packages/zombie/lib/src/models.dart
@@ -8,16 +8,16 @@ export 'package:analytica/analytica.dart' show PackageResolutionException;
 enum ZombieClassification {
   /// An unexported declaration with zero incoming references from production or
   /// tests. Safe for immediate automated or manual deletion.
-  pureZombie('pure_zombie', 'Pure Zombie'),
+  pureZombie('pureZombie', 'Pure Zombie'),
 
   /// A declaration referenced exclusively by isolated unit/integration tests
   /// with no other live dependencies. Safe to delete along with its orphan
   /// test blocks.
-  testedZombie('tested_zombie', 'Tested Zombie'),
+  testedZombie('testedZombie', 'Tested Zombie'),
 
   /// A declaration referenced only in tests, but co-invoked within test blocks
   /// that also exercise live production code. Requires manual refactoring.
-  coInvokedHazard('co_invoked_hazard', 'Co-Invoked Test Hazard');
+  coInvokedHazard('coInvokedHazard', 'Co-Invoked Test Hazard');
 
   final String jsonValue;
   final String displayName;
@@ -25,9 +25,9 @@ enum ZombieClassification {
   const ZombieClassification(this.jsonValue, this.displayName);
 
   static ZombieClassification fromJson(String value) => switch (value) {
-    'pure_zombie' => pureZombie,
-    'tested_zombie' => testedZombie,
-    'co_invoked_hazard' => coInvokedHazard,
+    'pureZombie' => pureZombie,
+    'testedZombie' => testedZombie,
+    'coInvokedHazard' => coInvokedHazard,
     _ => throw ArgumentError.value(
       value,
       'value',
@@ -43,7 +43,7 @@ enum DeclarationKind {
   enumType('enum'),
   mixinType('mixin'),
   extension('extension'),
-  extensionType('extension_type'),
+  extensionType('extensionType'),
   typedefType('typedef'),
   variable('variable'),
   getter('getter'),
@@ -59,7 +59,7 @@ enum DeclarationKind {
     'enum' => enumType,
     'mixin' => mixinType,
     'extension' => extension,
-    'extension_type' => extensionType,
+    'extensionType' => extensionType,
     'typedef' => typedefType,
     'variable' => variable,
     'getter' => getter,
@@ -71,8 +71,8 @@ enum DeclarationKind {
 /// Suggested remediation action for a detected zombie.
 abstract final class SuggestedAction {
   static const String delete = 'delete';
-  static const String deleteWithOrphanTests = 'delete_with_orphan_tests';
-  static const String manualRefactorHazard = 'manual_refactor_hazard';
+  static const String deleteWithOrphanTests = 'deleteWithOrphanTests';
+  static const String manualRefactorHazard = 'manualRefactorHazard';
 }
 
 /// How code in `example/` is treated during reachability analysis.
@@ -107,15 +107,15 @@ enum AnalysisMode {
 
   /// Closed application universe: Unreferenced exports in `lib/**` can be
   /// flagged if not reached by executables or other roots.
-  closedApp('closed-app');
+  closedApp('closedApp');
 
-  final String jsonValue;
+  final String value;
 
-  const AnalysisMode(this.jsonValue);
+  const AnalysisMode(this.value);
 
   static AnalysisMode fromString(String value) => switch (value) {
     'library' => library,
-    'closed-app' => closedApp,
+    'closedApp' => closedApp,
     _ => throw ArgumentError.value(value, 'value', 'Unknown AnalysisMode'),
   };
 }
@@ -150,6 +150,7 @@ final class ZombieOptions {
   final FrameworkAdapter frameworkAdapter;
   final List<String> testSupportPatterns;
   final List<String> ignoreNamePatterns;
+  final List<String> extraRoots;
 
   const ZombieOptions({
     required this.packagePath,
@@ -164,6 +165,7 @@ final class ZombieOptions {
     this.frameworkAdapter = const CompositeFrameworkAdapter.defaults(),
     this.testSupportPatterns = const ['Fake*', 'Mock*'],
     this.ignoreNamePatterns = const [],
+    this.extraRoots = const [],
   });
 }
 
@@ -188,7 +190,7 @@ class OrphanTestSite {
     line: json['line'] as int,
     column: json['column'] as int,
     description: json['description'] as String?,
-    coInvokedHazard: json['co_invoked_hazard'] as bool? ?? false,
+    coInvokedHazard: json['coInvokedHazard'] as bool? ?? false,
   );
 
   Map<String, dynamic> toJson() => {
@@ -196,7 +198,7 @@ class OrphanTestSite {
     'line': line,
     'column': column,
     if (description != null) 'description': description,
-    'co_invoked_hazard': coInvokedHazard,
+    'coInvokedHazard': coInvokedHazard,
   };
 
   @override
@@ -241,9 +243,9 @@ class ZombieFinding {
     classification: ZombieClassification.fromJson(
       json['classification'] as String,
     ),
-    suggestedAction: json['suggested_action'] as String,
-    orphanTests: (json['orphan_tests'] as List<dynamic>?)
-        ?.map((e) => OrphanTestSite.fromJson(e as Map<String, dynamic>))
+    suggestedAction: json['suggestedAction'] as String,
+    orphanTests: (json['orphanTests'] as List<dynamic>?)
+        ?.map((t) => OrphanTestSite.fromJson(t as Map<String, dynamic>))
         .toList(),
   );
 
@@ -256,9 +258,9 @@ class ZombieFinding {
     'column': column,
     'length': length,
     'classification': classification.jsonValue,
-    'suggested_action': suggestedAction,
+    'suggestedAction': suggestedAction,
     if (orphanTests != null && orphanTests!.isNotEmpty)
-      'orphan_tests': orphanTests!.map((t) => t.toJson()).toList(),
+      'orphanTests': orphanTests!.map((t) => t.toJson()).toList(),
   };
 }
 
@@ -287,10 +289,10 @@ class ZombieReport {
     return ZombieReport(
       version: json['version'] as String,
       package: json['package'] as String,
-      totalDeclarations: summary['total_declarations'] as int,
-      pureZombiesFound: summary['pure_zombies_found'] as int,
-      testedZombiesFound: summary['tested_zombies_found'] as int,
-      coInvokedHazardsFound: summary['co_invoked_hazards_found'] as int,
+      totalDeclarations: summary['totalDeclarations'] as int,
+      pureZombiesFound: summary['pureZombies'] as int,
+      testedZombiesFound: summary['testedZombies'] as int,
+      coInvokedHazardsFound: summary['coInvokedHazards'] as int,
       zombies: (json['zombies'] as List<dynamic>)
           .map((e) => ZombieFinding.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -301,10 +303,10 @@ class ZombieReport {
     'version': version,
     'package': package,
     'summary': {
-      'total_declarations': totalDeclarations,
-      'pure_zombies_found': pureZombiesFound,
-      'tested_zombies_found': testedZombiesFound,
-      'co_invoked_hazards_found': coInvokedHazardsFound,
+      'totalDeclarations': totalDeclarations,
+      'pureZombies': pureZombiesFound,
+      'testedZombies': testedZombiesFound,
+      'coInvokedHazards': coInvokedHazardsFound,
     },
     'zombies': zombies.map((z) => z.toJson()).toList(),
   };

--- a/packages/zombie/lib/src/reachability_engine.dart
+++ b/packages/zombie/lib/src/reachability_engine.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:analytica/analyzer.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart' hide WildcardPattern;
@@ -32,13 +34,21 @@ class ZombieEngine {
     final topology = harvester.harvestTopology();
 
     final absolutePackagePath = p.normalize(p.absolute(options.packagePath));
+    final extraRootPaths = options.extraRoots
+        .map(
+          (r) =>
+              p.normalize(p.isAbsolute(r) ? r : p.join(absolutePackagePath, r)),
+        )
+        .where((path) => Directory(path).existsSync())
+        .toList();
     final contextHelper = AnalysisContextHelper(
-      includedPaths: [absolutePackagePath],
+      includedPaths: [absolutePackagePath, ...extraRootPaths],
       sdkPath: options.sdkPath,
     );
 
     final allNodes = <DeclarationNode>[];
     final elementToNode = <Element, DeclarationNode>{};
+    final locationToNode = <String, DeclarationNode>{};
     final idToNode = <String, DeclarationNode>{};
     final testSites = <TestBlockSite>[];
     final testSiteRawElements = <TestBlockSite, Set<Element>>{};
@@ -51,7 +61,9 @@ class ZombieEngine {
 
     // Step 1: Single-pass parse and resolution for all files in topology.
     for (final relPath in topology.allFiles) {
-      final absPath = p.join(absolutePackagePath, relPath);
+      final absPath = p.normalize(
+        p.isAbsolute(relPath) ? relPath : p.join(absolutePackagePath, relPath),
+      );
       final unitResult = await contextHelper.getResolvedUnit(absPath);
 
       if (unitResult == null) {
@@ -152,13 +164,22 @@ class ZombieEngine {
 
             allNodes.add(node);
             idToNode[id] = node;
+            locationToNode['${p.canonicalize(absPath)}#$name'] = node;
             if (element != null) {
               elementToNode[element] = node;
               if (element is TopLevelVariableElement) {
                 final getter = element.getter;
-                if (getter != null) elementToNode[getter] = node;
+                if (getter != null) {
+                  elementToNode[getter] = node;
+                  final getterKey = '${p.canonicalize(absPath)}#${getter.name}';
+                  locationToNode[getterKey] = node;
+                }
                 final setter = element.setter;
-                if (setter != null) elementToNode[setter] = node;
+                if (setter != null) {
+                  elementToNode[setter] = node;
+                  final setterKey = '${p.canonicalize(absPath)}#${setter.name}';
+                  locationToNode[setterKey] = node;
+                }
               }
             }
 
@@ -217,6 +238,7 @@ class ZombieEngine {
 
           allNodes.add(node);
           idToNode[id] = node;
+          locationToNode['${p.canonicalize(absPath)}#$name'] = node;
           if (element != null) {
             elementToNode[element] = node;
           }
@@ -251,12 +273,37 @@ class ZombieEngine {
       }
     }
 
+    DeclarationNode? resolveNodeForElement(Element elem) {
+      final direct = elementToNode[elem];
+      if (direct != null) return direct;
+
+      final sourcePath =
+          elem.library?.firstFragment.source.fullName ??
+          elem.firstFragment.libraryFragment?.source.fullName;
+      if (sourcePath == null) return null;
+
+      final canonicalPath = p.canonicalize(sourcePath);
+      final name = elem.name;
+      if (name != null) {
+        final match = locationToNode['$canonicalPath#$name'];
+        if (match != null) return match;
+      }
+
+      final topLevel = getTopLevelElement(elem);
+      if (topLevel != null && topLevel.name != null) {
+        final match = locationToNode['$canonicalPath#${topLevel.name}'];
+        if (match != null) return match;
+      }
+
+      return null;
+    }
+
     // Step 2: Connect reference edges and sealed hierarchies.
     for (final node in allNodes) {
       final outbound = nodeOutboundElements[node];
       if (outbound != null) {
         for (final refElem in outbound) {
-          final targetNode = elementToNode[refElem];
+          final targetNode = resolveNodeForElement(refElem);
           if (targetNode != null && targetNode.id != node.id) {
             node.outgoingTargetIds.add(targetNode.id);
           }
@@ -266,7 +313,7 @@ class ZombieEngine {
       final superElems = nodeDirectSuperElements[node];
       if (superElems != null) {
         for (final superElem in superElems) {
-          final parentNode = elementToNode[superElem];
+          final parentNode = resolveNodeForElement(superElem);
           if (parentNode != null && parentNode.isSealed) {
             sealedSubtypes.putIfAbsent(parentNode.id, () => {}).add(node.id);
           }
@@ -295,7 +342,7 @@ class ZombieEngine {
       final rawElems = testSiteRawElements[site];
       if (rawElems != null) {
         for (final elem in rawElems) {
-          final targetNode = elementToNode[elem];
+          final targetNode = resolveNodeForElement(elem);
           if (targetNode != null) {
             site.referencedDeclarationIds.add(targetNode.id);
           }

--- a/packages/zombie/lib/src/root_harvester.dart
+++ b/packages/zombie/lib/src/root_harvester.dart
@@ -80,6 +80,9 @@ class PackageTopology {
   /// Resolves the role of a given [relativeFilePath].
   FileRole roleOf(String relativeFilePath) {
     final normalized = p.normalize(relativeFilePath);
+    if (testFiles.contains(normalized)) {
+      return FileRole.test;
+    }
     if (normalized.startsWith('lib/src/') ||
         normalized.startsWith('lib/src\\')) {
       return FileRole.internalSrc;
@@ -154,14 +157,29 @@ class RootHarvester {
 
     if (!hasDirectConfig && !_hasEnclosingPackageConfig(options.packagePath)) {
       if (options.autoPubGet) {
-        final dartExe = findDartExecutable(sdkPath: options.sdkPath) ?? 'dart';
-        final result = Process.runSync(dartExe, [
-          'pub',
-          'get',
-        ], workingDirectory: options.packagePath);
+        final pubspecContent = pubspecFile.readAsStringSync();
+        final isFlutter =
+            pubspecContent.contains('sdk: flutter') ||
+            pubspecContent.contains('package:flutter');
+        final ProcessResult result;
+        if (isFlutter) {
+          final flutterExe = _findFlutterExecutable();
+          result = Process.runSync(flutterExe, [
+            'pub',
+            'get',
+          ], workingDirectory: options.packagePath);
+        } else {
+          final dartExe =
+              findDartExecutable(sdkPath: options.sdkPath) ?? 'dart';
+          result = Process.runSync(dartExe, [
+            'pub',
+            'get',
+          ], workingDirectory: options.packagePath);
+        }
         if (result.exitCode != 0) {
+          final toolName = isFlutter ? 'flutter' : 'dart';
           throw PackageResolutionException(
-            'Failed to resolve dependencies with "dart pub get":\n'
+            'Failed to resolve dependencies with "$toolName pub get":\n'
             '${result.stderr}',
             options.packagePath,
           );
@@ -170,8 +188,8 @@ class RootHarvester {
         throw PackageResolutionException(
           'Missing .dart_tool/package_config.json for '
           '"${options.packagePath}".\n'
-          'Please run "dart pub get" before running zombie '
-          '(or pass --pub-get).',
+          'Please run "dart pub get" (or "flutter pub get") before running '
+          'zombie (or pass --pub-get).',
           options.packagePath,
         );
       }
@@ -225,6 +243,29 @@ class RootHarvester {
           normalized.startsWith('web/') ||
           normalized.startsWith('web\\')) {
         auxiliary.add(normalized);
+      }
+    }
+
+    // Harvest files from extra roots (companion test suites, external roots)
+    for (final extraRoot in options.extraRoots) {
+      if (extraRoot.trim().isEmpty) continue;
+      final extraDir = Directory(
+        p.normalize(
+          p.isAbsolute(extraRoot)
+              ? extraRoot
+              : p.join(options.packagePath, extraRoot),
+        ),
+      );
+      if (!extraDir.existsSync()) continue;
+      for (final entity in extraDir.listSync(
+        recursive: true,
+        followLinks: false,
+      )) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        final relPath = p.relative(entity.path, from: options.packagePath);
+        if (_isExcluded(relPath)) continue;
+        final normalized = p.normalize(relPath);
+        test.add(normalized);
       }
     }
 
@@ -301,5 +342,18 @@ class RootHarvester {
       }
     } catch (_) {}
     return false;
+  }
+
+  String _findFlutterExecutable() {
+    final flutterRoot = Platform.environment['FLUTTER_ROOT'];
+    if (flutterRoot != null && flutterRoot.isNotEmpty) {
+      final exe = p.join(
+        flutterRoot,
+        'bin',
+        Platform.isWindows ? 'flutter.bat' : 'flutter',
+      );
+      if (File(exe).existsSync()) return exe;
+    }
+    return Platform.isWindows ? 'flutter.bat' : 'flutter';
   }
 }

--- a/packages/zombie/lib/src/root_harvester.dart
+++ b/packages/zombie/lib/src/root_harvester.dart
@@ -151,32 +151,12 @@ class RootHarvester {
       );
     }
 
-    final hasDirectConfig = File(
-      p.join(options.packagePath, '.dart_tool', 'package_config.json'),
-    ).existsSync();
-
-    if (!hasDirectConfig && !_hasEnclosingPackageConfig(options.packagePath)) {
+    if (!hasPackageConfig(options.packagePath) &&
+        !hasEnclosingPackageConfig(options.packagePath)) {
       if (options.autoPubGet) {
-        final pubspecContent = pubspecFile.readAsStringSync();
-        final isFlutter =
-            pubspecContent.contains('sdk: flutter') ||
-            pubspecContent.contains('package:flutter');
-        final ProcessResult result;
-        if (isFlutter) {
-          final flutterExe = _findFlutterExecutable();
-          result = Process.runSync(flutterExe, [
-            'pub',
-            'get',
-          ], workingDirectory: options.packagePath);
-        } else {
-          final dartExe =
-              findDartExecutable(sdkPath: options.sdkPath) ?? 'dart';
-          result = Process.runSync(dartExe, [
-            'pub',
-            'get',
-          ], workingDirectory: options.packagePath);
-        }
+        final result = runPubGet(options.packagePath, sdkPath: options.sdkPath);
         if (result.exitCode != 0) {
+          final isFlutter = isFlutterPackage(options.packagePath);
           final toolName = isFlutter ? 'flutter' : 'dart';
           throw PackageResolutionException(
             'Failed to resolve dependencies with "$toolName pub get":\n'
@@ -326,34 +306,5 @@ class RootHarvester {
       multiLine: true,
     ).firstMatch(pubspecContent);
     return match?.group(1) ?? 'unknown_package';
-  }
-
-  bool _hasEnclosingPackageConfig(String packagePath) {
-    try {
-      var dir = Directory(packagePath).parent;
-      while (dir.path != dir.parent.path) {
-        final config = File(
-          p.join(dir.path, '.dart_tool', 'package_config.json'),
-        );
-        if (config.existsSync()) {
-          return true;
-        }
-        dir = dir.parent;
-      }
-    } catch (_) {}
-    return false;
-  }
-
-  String _findFlutterExecutable() {
-    final flutterRoot = Platform.environment['FLUTTER_ROOT'];
-    if (flutterRoot != null && flutterRoot.isNotEmpty) {
-      final exe = p.join(
-        flutterRoot,
-        'bin',
-        Platform.isWindows ? 'flutter.bat' : 'flutter',
-      );
-      if (File(exe).existsSync()) return exe;
-    }
-    return Platform.isWindows ? 'flutter.bat' : 'flutter';
   }
 }

--- a/packages/zombie/test/cli_test.dart
+++ b/packages/zombie/test/cli_test.dart
@@ -113,7 +113,7 @@ environment:
       final decoded = jsonDecode(stdout) as Map<String, dynamic>;
       check(decoded['package']).equals('cli_pkg');
       final summary = decoded['summary'] as Map<String, dynamic>;
-      check(summary['pure_zombies_found']).equals(1);
+      check(summary['pureZombies']).equals(1);
 
       final zombies = decoded['zombies'] as List<dynamic>;
       check(zombies.length).equals(1);
@@ -177,7 +177,6 @@ environment:
 
       // stdout remains human-readable Markdown
       check(stdout).contains('# Zombie Code Analysis: ');
-      check(stdout).contains('');
 
       // json-output file was created and contains valid JSON payload
       final jsonFile = File(jsonOutPath);
@@ -186,7 +185,78 @@ environment:
           jsonDecode(jsonFile.readAsStringSync()) as Map<String, dynamic>;
       check(decoded['package']).equals('cli_json_file_pkg');
       final summary = decoded['summary'] as Map<String, dynamic>;
-      check(summary['pure_zombies_found']).equals(1);
+      check(summary['pureZombies']).equals(1);
+    });
+
+    test('supports --extra-roots to include companion tests', () async {
+      await d.dir('main_pkg', [
+        packageConfig('main_pkg'),
+        d.file('pubspec.yaml', '''
+name: main_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+        d.dir('lib', [
+          d.dir('src', [d.file('helper.dart', 'void internalHelper() {}')]),
+        ]),
+      ]).create();
+
+      await d.dir('companion_test_pkg', [
+        d.dir('.dart_tool', [
+          d.file('package_config.json', '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "companion_test_pkg",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    },
+    {
+      "name": "main_pkg",
+      "rootUri": "../../main_pkg",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    }
+  ]
+}
+'''),
+        ]),
+        d.file('companion_test.dart', '''
+import 'package:main_pkg/src/helper.dart';
+
+void test(String desc, void Function() body) => body();
+
+void main() {
+  test('invokes internal helper', () {
+    internalHelper();
+  });
+}
+'''),
+      ]).create();
+
+      // Without extra roots, internalHelper is flagged as pure zombie
+      final proc1 = await runZombie(['--format=json', d.path('main_pkg')]);
+      final out1 = await proc1.stdoutStream().join('\n');
+      await proc1.shouldExit(0);
+      final json1 = jsonDecode(out1) as Map<String, dynamic>;
+      final summary1 = json1['summary'] as Map<String, dynamic>;
+      check(summary1['pureZombies']).equals(1);
+
+      // With extra roots, companion_test is treated as a test root
+      final proc2 = await runZombie([
+        '--format=json',
+        '--extra-roots=${d.path('companion_test_pkg')}',
+        d.path('main_pkg'),
+      ]);
+      final out2 = await proc2.stdoutStream().join('\n');
+      await proc2.shouldExit(0);
+      final json2 = jsonDecode(out2) as Map<String, dynamic>;
+      final summary2 = json2['summary'] as Map<String, dynamic>;
+      // Now it's reached by tests!
+      check(summary2['pureZombies']).equals(0);
+      check(summary2['testedZombies']).equals(1);
     });
 
     test('runs analysis and outputs Markdown with --format=github', () async {

--- a/packages/zombie/test/formatters_test.dart
+++ b/packages/zombie/test/formatters_test.dart
@@ -76,9 +76,9 @@ void main() {
       check(decoded['package']).equals('test_pkg');
 
       final summary = decoded['summary'] as Map<String, dynamic>;
-      check(summary['pure_zombies_found']).equals(1);
-      check(summary['tested_zombies_found']).equals(1);
-      check(summary['co_invoked_hazards_found']).equals(1);
+      check(summary['pureZombies']).equals(1);
+      check(summary['testedZombies']).equals(1);
+      check(summary['coInvokedHazards']).equals(1);
 
       final zombies = decoded['zombies'] as List<dynamic>;
       check(zombies.length).equals(3);

--- a/packages/zombie/test/models_test.dart
+++ b/packages/zombie/test/models_test.dart
@@ -18,7 +18,7 @@ void main() {
       check(json['line']).equals(12);
       check(json['column']).equals(5);
       check(json['description']).equals('OldParser parses correctly');
-      check(json['co_invoked_hazard']).equals(false);
+      check(json['coInvokedHazard']).equals(false);
 
       final deserialized = OrphanTestSite.fromJson(json);
       check(deserialized.file).equals(site.file);
@@ -49,9 +49,9 @@ void main() {
       check(json['line']).equals(45);
       check(json['column']).equals(1);
       check(json['length']).equals(19);
-      check(json['classification']).equals('pure_zombie');
-      check(json['suggested_action']).equals('delete');
-      check(json.containsKey('orphan_tests')).isFalse();
+      check(json['classification']).equals('pureZombie');
+      check(json['suggestedAction']).equals('delete');
+      check(json.containsKey('orphanTests')).isFalse();
 
       final deserialized = ZombieFinding.fromJson(json);
       check(deserialized.id).equals(finding.id);
@@ -111,10 +111,10 @@ void main() {
       check(json['package']).equals('my_package');
 
       final summary = json['summary'] as Map<String, dynamic>;
-      check(summary['total_declarations']).equals(142);
-      check(summary['pure_zombies_found']).equals(1);
-      check(summary['tested_zombies_found']).equals(1);
-      check(summary['co_invoked_hazards_found']).equals(0);
+      check(summary['totalDeclarations']).equals(142);
+      check(summary['pureZombies']).equals(1);
+      check(summary['testedZombies']).equals(1);
+      check(summary['coInvokedHazards']).equals(0);
 
       final zombiesList = json['zombies'] as List<dynamic>;
       check(zombiesList.length).equals(2);
@@ -128,13 +128,13 @@ void main() {
 
     test('Enum fromJson and fromString conversions', () {
       check(
-        ZombieClassification.fromJson('pure_zombie'),
+        ZombieClassification.fromJson('pureZombie'),
       ).equals(ZombieClassification.pureZombie);
       check(
-        ZombieClassification.fromJson('tested_zombie'),
+        ZombieClassification.fromJson('testedZombie'),
       ).equals(ZombieClassification.testedZombie);
       check(
-        ZombieClassification.fromJson('co_invoked_hazard'),
+        ZombieClassification.fromJson('coInvokedHazard'),
       ).equals(ZombieClassification.coInvokedHazard);
 
       check(
@@ -151,7 +151,7 @@ void main() {
 
       check(AnalysisMode.fromString('library')).equals(AnalysisMode.library);
       check(
-        AnalysisMode.fromString('closed-app'),
+        AnalysisMode.fromString('closedApp'),
       ).equals(AnalysisMode.closedApp);
 
       check(OutputFormat.fromString('markdown')).equals(OutputFormat.markdown);
@@ -173,6 +173,7 @@ void main() {
         packagePath: '/path/to/pkg',
         testSupportPatterns: ['*Stub', 'CustomFixture*'],
         ignoreNamePatterns: ['*_generated', 'Ignored*'],
+        extraRoots: ['../companion_test', '/external/tests'],
       );
       check(
         customOptions.testSupportPatterns,
@@ -180,6 +181,43 @@ void main() {
       check(
         customOptions.ignoreNamePatterns,
       ).deepEquals(['*_generated', 'Ignored*']);
+      check(
+        customOptions.extraRoots,
+      ).deepEquals(['../companion_test', '/external/tests']);
+    });
+
+    test('ZombieReport deserializes camelCase JSON summary correctly', () {
+      final json = {
+        'version': '0.1.0-dev',
+        'package': 'test_pkg',
+        'summary': {
+          'totalDeclarations': 200,
+          'pureZombies': 5,
+          'testedZombies': 3,
+          'coInvokedHazards': 2,
+        },
+        'zombies': [
+          {
+            'id': 'unusedFunc',
+            'name': 'unusedFunc',
+            'kind': 'function',
+            'file': 'lib/src/a.dart',
+            'line': 10,
+            'column': 1,
+            'length': 10,
+            'classification': 'pureZombie',
+            'suggestedAction': 'delete',
+          },
+        ],
+      };
+
+      final report = ZombieReport.fromJson(json);
+      check(report.totalDeclarations).equals(200);
+      check(report.pureZombiesFound).equals(5);
+      check(report.testedZombiesFound).equals(3);
+      check(report.coInvokedHazardsFound).equals(2);
+      check(report.zombies.length).equals(1);
+      check(report.zombies.first.suggestedAction).equals('delete');
     });
   });
 }

--- a/packages/zombie/test/wildcards_test.dart
+++ b/packages/zombie/test/wildcards_test.dart
@@ -236,8 +236,8 @@ void main() {
 
           final json = jsonDecode(stdout) as Map<String, dynamic>;
           final summary = json['summary'] as Map<String, dynamic>;
-          check(summary['pure_zombies_found']).equals(1);
-          check(summary['tested_zombies_found']).equals(0);
+          check(summary['pureZombies']).equals(1);
+          check(summary['testedZombies']).equals(0);
 
           final zombies = json['zombies'] as List<dynamic>;
           check(zombies.length).equals(1);
@@ -280,7 +280,7 @@ void actual_dead() {}
 
           final json = jsonDecode(stdout) as Map<String, dynamic>;
           final summary = json['summary'] as Map<String, dynamic>;
-          check(summary['pure_zombies_found']).equals(1);
+          check(summary['pureZombies']).equals(1);
 
           final zombies = json['zombies'] as List<dynamic>;
           check(zombies.length).equals(1);

--- a/packages/zombie/test/zombie_test.dart
+++ b/packages/zombie/test/zombie_test.dart
@@ -46,7 +46,7 @@ environment:
 
     const jsonFormatter = JsonFormatter();
     final jsonStr = jsonFormatter.format(report);
-    check(jsonStr).contains('"pure_zombies_found": 1');
+    check(jsonStr).contains('"pureZombies": 1');
 
     const mdFormatter = MarkdownFormatter();
     final mdStr = mdFormatter.format(report);


### PR DESCRIPTION
## Summary

- **Strict camelCase**: Switched all models, summary keys, and CLI options to strict camelCase (`pureZombie`, `testedZombie`, `coInvokedHazard`, `closedApp`, `totalDeclarations`, `pureZombies`, etc.) with zero legacy dual-decoding fallbacks.
- **SDK Discovery**: Added support for inspecting shell script wrappers and scanning standard PATH fallback locations in `pkg:analytica` (`lib/src/sdk_discovery.dart`).
- **Flutter pub get**: Routed dependency resolution to `flutter pub get` for packages declaring `sdk: flutter` in `pkg:zombie`.
- **--extra-roots**: Added `--extra-roots` CLI option and enabled cross-context element resolution in `ZombieEngine` so companion test suites don't generate false positives.

Fixes #26
Fixes #27
Fixes #29
Fixes #32