### PR TITLE
fix(zombie): include read/write elements of prefix and postfix expressions in reachability graph

### DIFF
--- a/packages/zombie/lib/src/ast_visitor.dart
+++ b/packages/zombie/lib/src/ast_visitor.dart
@@ -97,12 +97,16 @@ class ElementReferenceExtractor extends RecursiveAstVisitor<void> {
   @override
   void visitPrefixExpression(PrefixExpression node) {
     _checkElement(node.element);
+    _checkElement(node.readElement);
+    _checkElement(node.writeElement);
     super.visitPrefixExpression(node);
   }
 
   @override
   void visitPostfixExpression(PostfixExpression node) {
     _checkElement(node.element);
+    _checkElement(node.readElement);
+    _checkElement(node.writeElement);
     super.visitPostfixExpression(node);
   }
 

--- a/packages/zombie/test/reachability_engine_test.dart
+++ b/packages/zombie/test/reachability_engine_test.dart
@@ -718,6 +718,54 @@ extension DeadOps on CustomNum {
     });
 
     test(
+      'reaches variables mutated via prefix and postfix operators',
+      () async {
+        await d.dir('prefix_postfix_pkg', [
+          packageConfig('prefix_postfix_pkg'),
+          d.file('pubspec.yaml', '''
+name: prefix_postfix_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+          d.dir('lib', [
+            d.file('prefix_postfix_pkg.dart', 'export "src/live.dart";'),
+            d.dir('src', [
+              d.file('live.dart', '''
+import 'vars.dart';
+
+class LiveContainer {
+  void mutatePrefix() {
+    ++prefixMutated;
+    --prefixMutated2;
+  }
+  void mutatePostfix() {
+    postfixMutated++;
+    postfixMutated2--;
+  }
+}
+'''),
+              d.file('vars.dart', '''
+int prefixMutated = 0;
+int prefixMutated2 = 0;
+int postfixMutated = 0;
+int postfixMutated2 = 0;
+int deadVar = 0;
+'''),
+            ]),
+          ]),
+        ]).create();
+
+        final report = await analyzePackage(d.path('prefix_postfix_pkg'));
+        final names = report.zombies.map((z) => z.name).toSet();
+        check(names).contains('deadVar');
+        check(names).not((it) => it.contains('prefixMutated'));
+        check(names).not((it) => it.contains('prefixMutated2'));
+        check(names).not((it) => it.contains('postfixMutated'));
+        check(names).not((it) => it.contains('postfixMutated2'));
+      },
+    );
+
+    test(
       'resolves same-package package: URIs in conditional imports',
       () async {
         await d.dir('package_uri_cond_pkg', [


### PR DESCRIPTION
Fixes a bug where variables mutated via `++id`, `id++`, `--id`, and `id--` were erroneously flagged as dead code because their read and write elements were not extracted by the AST visitor.
