### PR TITLE
feat(zombie): add JsInteropAdapter and --ignore-external-bindings support

### DIFF
--- a/packages/zombie/lib/src/adapters/adapters.dart
+++ b/packages/zombie/lib/src/adapters/adapters.dart
@@ -6,4 +6,5 @@ export 'build_runner_adapter.dart';
 export 'composite_adapter.dart';
 export 'flutter_adapter.dart';
 export 'framework_adapter.dart';
+export 'js_interop_adapter.dart';
 export 'package_test_adapter.dart';

--- a/packages/zombie/lib/src/adapters/composite_adapter.dart
+++ b/packages/zombie/lib/src/adapters/composite_adapter.dart
@@ -7,6 +7,7 @@ import '../root_harvester.dart';
 import 'build_runner_adapter.dart';
 import 'flutter_adapter.dart';
 import 'framework_adapter.dart';
+import 'js_interop_adapter.dart';
 import 'package_test_adapter.dart';
 
 /// Composite adapter that aggregates multiple [FrameworkAdapter] instances.
@@ -16,12 +17,13 @@ class CompositeFrameworkAdapter implements FrameworkAdapter {
   const CompositeFrameworkAdapter(this.adapters);
 
   /// Default composite adapter configuring [FlutterAdapter],
-  /// [BuildRunnerAdapter], and [PackageTestAdapter].
+  /// [BuildRunnerAdapter], [PackageTestAdapter], and [JsInteropAdapter].
   const CompositeFrameworkAdapter.defaults()
     : adapters = const [
         FlutterAdapter(),
         BuildRunnerAdapter(),
         PackageTestAdapter(),
+        JsInteropAdapter(),
       ];
 
   @override
@@ -63,6 +65,14 @@ class CompositeFrameworkAdapter implements FrameworkAdapter {
   bool isFrameworkEntryPoint(AnnotatedNode node, Element? element) {
     for (final adapter in adapters) {
       if (adapter.isFrameworkEntryPoint(node, element)) return true;
+    }
+    return false;
+  }
+
+  @override
+  bool isExternalJsInterop(Declaration node, Element? element) {
+    for (final adapter in adapters) {
+      if (adapter.isExternalJsInterop(node, element)) return true;
     }
     return false;
   }

--- a/packages/zombie/lib/src/adapters/composite_adapter.dart
+++ b/packages/zombie/lib/src/adapters/composite_adapter.dart
@@ -70,9 +70,9 @@ class CompositeFrameworkAdapter implements FrameworkAdapter {
   }
 
   @override
-  bool isExternalJsInterop(Declaration node, Element? element) {
+  bool isExternalBinding(Declaration node, Element? element) {
     for (final adapter in adapters) {
-      if (adapter.isExternalJsInterop(node, element)) return true;
+      if (adapter.isExternalBinding(node, element)) return true;
     }
     return false;
   }

--- a/packages/zombie/lib/src/adapters/flutter_adapter.dart
+++ b/packages/zombie/lib/src/adapters/flutter_adapter.dart
@@ -111,36 +111,10 @@ class FlutterAdapter extends BaseFrameworkAdapter {
   @override
   bool isFrameworkEntryPoint(AnnotatedNode node, Element? element) {
     for (final meta in node.metadata) {
-      final rawName = meta.name.name;
-      final baseName = rawName.contains('.')
-          ? rawName.split('.').last
-          : rawName;
-      final constructorName = meta.constructorName?.name;
-      if (baseName == 'pragma' || constructorName == 'pragma') {
-        final args = meta.arguments?.arguments;
-        if (args != null && args.isNotEmpty) {
-          final firstArg = args.first;
-          String? pragmaName;
-          if (firstArg is SimpleStringLiteral) {
-            pragmaName = firstArg.value;
-          } else if (firstArg is StringLiteral) {
-            pragmaName = firstArg.stringValue;
-          } else {
-            for (final entity in firstArg.childEntities) {
-              if (entity is SimpleStringLiteral) {
-                pragmaName = entity.value;
-                break;
-              } else if (entity is StringLiteral) {
-                pragmaName = entity.stringValue;
-                break;
-              }
-            }
-          }
-          if (pragmaName != null &&
-              _flutterEntryPointPragmas.contains(pragmaName)) {
-            return true;
-          }
-        }
+      final pragmaName = extractPragmaName(meta);
+      if (pragmaName != null &&
+          _flutterEntryPointPragmas.contains(pragmaName)) {
+        return true;
       }
     }
     return false;

--- a/packages/zombie/lib/src/adapters/framework_adapter.dart
+++ b/packages/zombie/lib/src/adapters/framework_adapter.dart
@@ -58,3 +58,31 @@ abstract class BaseFrameworkAdapter implements FrameworkAdapter {
   @override
   bool isExternalBinding(Declaration node, Element? element) => false;
 }
+
+/// Extracts the first string argument of a `@pragma(...)` annotation, or `null`
+/// if [meta] is not a pragma or has no string argument.
+String? extractPragmaName(Annotation meta) {
+  final rawName = meta.name.name;
+  final baseName = rawName.contains('.') ? rawName.split('.').last : rawName;
+  final constructorName = meta.constructorName?.name;
+  if (baseName != 'pragma' && constructorName != 'pragma') return null;
+
+  final args = meta.arguments?.arguments;
+  if (args == null || args.isEmpty) return null;
+
+  final firstArg = args.first;
+  if (firstArg is SimpleStringLiteral) {
+    return firstArg.value;
+  } else if (firstArg is StringLiteral) {
+    return firstArg.stringValue;
+  } else {
+    for (final entity in firstArg.childEntities) {
+      if (entity is SimpleStringLiteral) {
+        return entity.value;
+      } else if (entity is StringLiteral) {
+        return entity.stringValue;
+      }
+    }
+  }
+  return null;
+}

--- a/packages/zombie/lib/src/adapters/framework_adapter.dart
+++ b/packages/zombie/lib/src/adapters/framework_adapter.dart
@@ -28,10 +28,10 @@ abstract interface class FrameworkAdapter {
   /// (e.g. `@pragma('vm:entry-point')`).
   bool isFrameworkEntryPoint(AnnotatedNode node, Element? element);
 
-  /// Whether [node] or [element] represents an external JavaScript or Wasm
-  /// interop declaration (e.g. extension type with external members or `@JS`
-  /// annotation).
-  bool isExternalJsInterop(Declaration node, Element? element);
+  /// Whether [node] or [element] represents an external platform binding or
+  /// FFI/interop facade declaration (e.g. `external` functions/variables,
+  /// JS interop extension types, `@Native` bindings).
+  bool isExternalBinding(Declaration node, Element? element);
 }
 
 /// Base adapter providing default no-op / false implementations of
@@ -56,5 +56,5 @@ abstract class BaseFrameworkAdapter implements FrameworkAdapter {
   bool isFrameworkEntryPoint(AnnotatedNode node, Element? element) => false;
 
   @override
-  bool isExternalJsInterop(Declaration node, Element? element) => false;
+  bool isExternalBinding(Declaration node, Element? element) => false;
 }

--- a/packages/zombie/lib/src/adapters/framework_adapter.dart
+++ b/packages/zombie/lib/src/adapters/framework_adapter.dart
@@ -27,6 +27,11 @@ abstract interface class FrameworkAdapter {
   /// Whether [node] or [element] is a framework-specific entrypoint
   /// (e.g. `@pragma('vm:entry-point')`).
   bool isFrameworkEntryPoint(AnnotatedNode node, Element? element);
+
+  /// Whether [node] or [element] represents an external JavaScript or Wasm
+  /// interop declaration (e.g. extension type with external members or `@JS`
+  /// annotation).
+  bool isExternalJsInterop(Declaration node, Element? element);
 }
 
 /// Base adapter providing default no-op / false implementations of
@@ -49,4 +54,7 @@ abstract class BaseFrameworkAdapter implements FrameworkAdapter {
 
   @override
   bool isFrameworkEntryPoint(AnnotatedNode node, Element? element) => false;
+
+  @override
+  bool isExternalJsInterop(Declaration node, Element? element) => false;
 }

--- a/packages/zombie/lib/src/adapters/js_interop_adapter.dart
+++ b/packages/zombie/lib/src/adapters/js_interop_adapter.dart
@@ -16,43 +16,42 @@ class JsInteropAdapter extends BaseFrameworkAdapter {
 
   static const _jsInteropAnnotations = {'JS', 'staticInterop', 'anonymous'};
 
+  static const _jsInteropTypeNames = {
+    'JSAny',
+    'JSObject',
+    'JSFunction',
+    'JSArray',
+    'JSString',
+    'JSNumber',
+    'JSBoolean',
+    'JSPromise',
+    'JSSymbol',
+    'JSBigInt',
+    'JSBoxedDartObject',
+    'JSTypedArray',
+    'JSUint8Array',
+    'JSInt8Array',
+    'JSUint8ClampedArray',
+    'JSInt16Array',
+    'JSUint16Array',
+    'JSInt32Array',
+    'JSUint32Array',
+    'JSFloat32Array',
+    'JSFloat64Array',
+    'JSArrayBuffer',
+    'JSDataView',
+    'JSExportedDartFunction',
+  };
+
   @override
   bool isFrameworkEntryPoint(AnnotatedNode node, Element? element) {
     for (final meta in node.metadata) {
-      final rawName = meta.name.name;
-      final baseName = rawName.contains('.')
-          ? rawName.split('.').last
-          : rawName;
-      final constructorName = meta.constructorName?.name;
-
-      if (baseName == 'pragma' || constructorName == 'pragma') {
-        final args = meta.arguments?.arguments;
-        if (args != null && args.isNotEmpty) {
-          final firstArg = args.first;
-          String? pragmaName;
-          if (firstArg is SimpleStringLiteral) {
-            pragmaName = firstArg.value;
-          } else if (firstArg is StringLiteral) {
-            pragmaName = firstArg.stringValue;
-          } else {
-            for (final entity in firstArg.childEntities) {
-              if (entity is SimpleStringLiteral) {
-                pragmaName = entity.value;
-                break;
-              } else if (entity is StringLiteral) {
-                pragmaName = entity.stringValue;
-                break;
-              }
-            }
-          }
-          final name = pragmaName;
-          if (name != null &&
-              _wasmEntryPointPragmas.any(
-                (p) => name == p || name.startsWith('$p:'),
-              )) {
-            return true;
-          }
-        }
+      final pragmaName = extractPragmaName(meta);
+      if (pragmaName != null &&
+          _wasmEntryPointPragmas.any(
+            (p) => pragmaName == p || pragmaName.startsWith('$p:'),
+          )) {
+        return true;
       }
     }
     return false;
@@ -81,44 +80,66 @@ class JsInteropAdapter extends BaseFrameworkAdapter {
       }
     }
 
-    // 3. Check for ExtensionTypeDeclaration or ClassDeclaration representing JS interop / having external members.
-    if (node is ExtensionTypeDeclaration || node is ClassDeclaration) {
-      var hasExternalMember = false;
-      var hasJsRepresentation = false;
-
-      void inspectEntities(Iterable<dynamic> entities) {
-        for (final entity in entities) {
-          if (entity is MethodDeclaration && entity.externalKeyword != null) {
-            hasExternalMember = true;
-          } else if (entity is FieldDeclaration &&
-              entity.externalKeyword != null) {
-            hasExternalMember = true;
-          } else if (entity is ConstructorDeclaration &&
-              entity.externalKeyword != null) {
-            hasExternalMember = true;
-          } else if (entity is FormalParameterList) {
-            final src = entity.toSource();
-            if (src.contains('JSObject') ||
-                src.contains('JSAny') ||
-                src.contains('JSString') ||
-                src.contains('JSNumber') ||
-                src.contains('JSBoolean') ||
-                src.contains('JSArray') ||
-                src.contains('JSPromise')) {
-              hasJsRepresentation = true;
-            }
-          } else if (entity is AstNode) {
-            inspectEntities(entity.childEntities);
-          }
+    // 3. ExtensionTypeDeclaration: Check direct representation or external
+    // members.
+    if (node is ExtensionTypeDeclaration) {
+      if (_hasExternalMember(node)) return true;
+      for (final child in node.childEntities) {
+        if (child is FormalParameterList) {
+          final src = child.toSource();
+          if (_hasJsRepresentationType(src)) return true;
+        } else if (child is AstNode &&
+            (child.runtimeType.toString().contains('Representation') ||
+                child.runtimeType.toString().contains('PrimaryConstructor'))) {
+          final src = child.toSource();
+          if (_hasJsRepresentationType(src)) return true;
         }
-      }
-
-      inspectEntities(node.childEntities);
-      if (hasJsRepresentation || hasExternalMember) {
-        return true;
       }
     }
 
+    // 4. ClassDeclaration, ExtensionDeclaration, MixinDeclaration,
+    // EnumDeclaration: Check direct external members.
+    if (node is ClassDeclaration ||
+        node is ExtensionDeclaration ||
+        node is MixinDeclaration ||
+        node is EnumDeclaration) {
+      if (_hasExternalMember(node)) return true;
+    }
+
+    return false;
+  }
+
+  static bool _hasJsRepresentationType(String src) {
+    for (final typeName in _jsInteropTypeNames) {
+      if (src.contains(typeName)) return true;
+    }
+    return false;
+  }
+
+  static bool _hasExternalMember(AstNode node) {
+    for (final child in node.childEntities) {
+      if (_isExternalMember(child)) return true;
+      if (child is AstNode &&
+          (child.runtimeType.toString().contains('Body') ||
+              child.runtimeType.toString().contains('Clause'))) {
+        for (final member in child.childEntities) {
+          if (_isExternalMember(member)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  static bool _isExternalMember(dynamic member) {
+    if (member is MethodDeclaration && member.externalKeyword != null) {
+      return true;
+    }
+    if (member is FieldDeclaration && member.externalKeyword != null) {
+      return true;
+    }
+    if (member is ConstructorDeclaration && member.externalKeyword != null) {
+      return true;
+    }
     return false;
   }
 }

--- a/packages/zombie/lib/src/adapters/js_interop_adapter.dart
+++ b/packages/zombie/lib/src/adapters/js_interop_adapter.dart
@@ -59,7 +59,7 @@ class JsInteropAdapter extends BaseFrameworkAdapter {
   }
 
   @override
-  bool isExternalJsInterop(Declaration node, Element? element) {
+  bool isExternalBinding(Declaration node, Element? element) {
     // 1. Check for external keyword on top-level function or variable.
     if (node is FunctionDeclaration && node.externalKeyword != null) {
       return true;

--- a/packages/zombie/lib/src/adapters/js_interop_adapter.dart
+++ b/packages/zombie/lib/src/adapters/js_interop_adapter.dart
@@ -1,0 +1,124 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+
+import 'framework_adapter.dart';
+
+/// Adapter for JavaScript and WebAssembly interop conventions, entrypoint
+/// pragmas, and `external` facade declarations.
+class JsInteropAdapter extends BaseFrameworkAdapter {
+  const JsInteropAdapter();
+
+  static const _wasmEntryPointPragmas = {
+    'wasm:export',
+    'wasm:entry-point',
+    'wasm:entrypoint',
+  };
+
+  static const _jsInteropAnnotations = {'JS', 'staticInterop', 'anonymous'};
+
+  @override
+  bool isFrameworkEntryPoint(AnnotatedNode node, Element? element) {
+    for (final meta in node.metadata) {
+      final rawName = meta.name.name;
+      final baseName = rawName.contains('.')
+          ? rawName.split('.').last
+          : rawName;
+      final constructorName = meta.constructorName?.name;
+
+      if (baseName == 'pragma' || constructorName == 'pragma') {
+        final args = meta.arguments?.arguments;
+        if (args != null && args.isNotEmpty) {
+          final firstArg = args.first;
+          String? pragmaName;
+          if (firstArg is SimpleStringLiteral) {
+            pragmaName = firstArg.value;
+          } else if (firstArg is StringLiteral) {
+            pragmaName = firstArg.stringValue;
+          } else {
+            for (final entity in firstArg.childEntities) {
+              if (entity is SimpleStringLiteral) {
+                pragmaName = entity.value;
+                break;
+              } else if (entity is StringLiteral) {
+                pragmaName = entity.stringValue;
+                break;
+              }
+            }
+          }
+          final name = pragmaName;
+          if (name != null &&
+              _wasmEntryPointPragmas.any(
+                (p) => name == p || name.startsWith('$p:'),
+              )) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  @override
+  bool isExternalJsInterop(Declaration node, Element? element) {
+    // 1. Check for external keyword on top-level function or variable.
+    if (node is FunctionDeclaration && node.externalKeyword != null) {
+      return true;
+    }
+    if (node is TopLevelVariableDeclaration && node.externalKeyword != null) {
+      return true;
+    }
+
+    // 2. Check for @JS, @staticInterop, @anonymous annotations.
+    for (final meta in node.metadata) {
+      final rawName = meta.name.name;
+      final baseName = rawName.contains('.')
+          ? rawName.split('.').last
+          : rawName;
+      final constructorName = meta.constructorName?.name;
+      if (_jsInteropAnnotations.contains(baseName) ||
+          _jsInteropAnnotations.contains(constructorName)) {
+        return true;
+      }
+    }
+
+    // 3. Check for ExtensionTypeDeclaration or ClassDeclaration representing JS interop / having external members.
+    if (node is ExtensionTypeDeclaration || node is ClassDeclaration) {
+      var hasExternalMember = false;
+      var hasJsRepresentation = false;
+
+      void inspectEntities(Iterable<dynamic> entities) {
+        for (final entity in entities) {
+          if (entity is MethodDeclaration && entity.externalKeyword != null) {
+            hasExternalMember = true;
+          } else if (entity is FieldDeclaration &&
+              entity.externalKeyword != null) {
+            hasExternalMember = true;
+          } else if (entity is ConstructorDeclaration &&
+              entity.externalKeyword != null) {
+            hasExternalMember = true;
+          } else if (entity is FormalParameterList) {
+            final src = entity.toSource();
+            if (src.contains('JSObject') ||
+                src.contains('JSAny') ||
+                src.contains('JSString') ||
+                src.contains('JSNumber') ||
+                src.contains('JSBoolean') ||
+                src.contains('JSArray') ||
+                src.contains('JSPromise')) {
+              hasJsRepresentation = true;
+            }
+          } else if (entity is AstNode) {
+            inspectEntities(entity.childEntities);
+          }
+        }
+      }
+
+      inspectEntities(node.childEntities);
+      if (hasJsRepresentation || hasExternalMember) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/packages/zombie/lib/src/cli.dart
+++ b/packages/zombie/lib/src/cli.dart
@@ -73,6 +73,13 @@ ArgParser buildArgParser() {
           'companion packages to include in reachability analysis.',
       defaultsTo: '',
     )
+    ..addFlag(
+      'ignore-external-interop',
+      help:
+          'Ignore unreferenced external JavaScript and Wasm interop '
+          'declarations.',
+      defaultsTo: false,
+    )
     ..addSdkPathOption()
     ..addFlag(
       'pub-get',
@@ -148,6 +155,7 @@ class ZombieCliRunner {
     final includeGenerated = results.flag('include-generated');
     final failOnZombies = results.flag('fail-on-zombies');
     final autoPubGet = results.flag('pub-get');
+    final ignoreExternalInterop = results.flag('ignore-external-interop');
     final sdkPath = results.option('sdk-path');
     final jsonOutputPath = results.option('json-output');
     final testSupportPatterns = _parseCommaSeparated(
@@ -166,6 +174,7 @@ class ZombieCliRunner {
       includeGenerated: includeGenerated,
       failOnZombies: failOnZombies,
       autoPubGet: autoPubGet,
+      ignoreExternalInterop: ignoreExternalInterop,
       sdkPath: sdkPath,
       jsonOutputPath: jsonOutputPath,
       testSupportPatterns: testSupportPatterns,

--- a/packages/zombie/lib/src/cli.dart
+++ b/packages/zombie/lib/src/cli.dart
@@ -74,9 +74,10 @@ ArgParser buildArgParser() {
       defaultsTo: '',
     )
     ..addFlag(
-      'ignore-external-interop',
+      'ignore-external-bindings',
+      aliases: ['ignore-external-interop'],
       help:
-          'Ignore unreferenced external JavaScript and Wasm interop '
+          'Ignore unreferenced external platform and FFI/interop facade '
           'declarations.',
       defaultsTo: false,
     )
@@ -155,7 +156,7 @@ class ZombieCliRunner {
     final includeGenerated = results.flag('include-generated');
     final failOnZombies = results.flag('fail-on-zombies');
     final autoPubGet = results.flag('pub-get');
-    final ignoreExternalInterop = results.flag('ignore-external-interop');
+    final ignoreExternalBindings = results.flag('ignore-external-bindings');
     final sdkPath = results.option('sdk-path');
     final jsonOutputPath = results.option('json-output');
     final testSupportPatterns = _parseCommaSeparated(
@@ -174,7 +175,7 @@ class ZombieCliRunner {
       includeGenerated: includeGenerated,
       failOnZombies: failOnZombies,
       autoPubGet: autoPubGet,
-      ignoreExternalInterop: ignoreExternalInterop,
+      ignoreExternalBindings: ignoreExternalBindings,
       sdkPath: sdkPath,
       jsonOutputPath: jsonOutputPath,
       testSupportPatterns: testSupportPatterns,

--- a/packages/zombie/lib/src/models.dart
+++ b/packages/zombie/lib/src/models.dart
@@ -151,7 +151,7 @@ final class ZombieOptions {
   final List<String> testSupportPatterns;
   final List<String> ignoreNamePatterns;
   final List<String> extraRoots;
-  final bool ignoreExternalInterop;
+  final bool ignoreExternalBindings;
 
   const ZombieOptions({
     required this.packagePath,
@@ -167,7 +167,7 @@ final class ZombieOptions {
     this.testSupportPatterns = const ['Fake*', 'Mock*'],
     this.ignoreNamePatterns = const [],
     this.extraRoots = const [],
-    this.ignoreExternalInterop = false,
+    this.ignoreExternalBindings = false,
   });
 }
 
@@ -220,7 +220,7 @@ class ZombieFinding {
   final ZombieClassification classification;
   final String suggestedAction;
   final List<OrphanTestSite>? orphanTests;
-  final bool isExternalJsInterop;
+  final bool isExternalBinding;
 
   const ZombieFinding({
     required this.id,
@@ -233,7 +233,7 @@ class ZombieFinding {
     required this.classification,
     required this.suggestedAction,
     this.orphanTests,
-    this.isExternalJsInterop = false,
+    this.isExternalBinding = false,
   });
 
   factory ZombieFinding.fromJson(Map<String, dynamic> json) => ZombieFinding(
@@ -251,7 +251,10 @@ class ZombieFinding {
     orphanTests: (json['orphanTests'] as List<dynamic>?)
         ?.map((t) => OrphanTestSite.fromJson(t as Map<String, dynamic>))
         .toList(),
-    isExternalJsInterop: json['isExternalJsInterop'] as bool? ?? false,
+    isExternalBinding:
+        json['isExternalBinding'] as bool? ??
+        json['isExternalJsInterop'] as bool? ??
+        false,
   );
 
   Map<String, dynamic> toJson() => {
@@ -264,7 +267,7 @@ class ZombieFinding {
     'length': length,
     'classification': classification.jsonValue,
     'suggestedAction': suggestedAction,
-    if (isExternalJsInterop) 'isExternalJsInterop': true,
+    if (isExternalBinding) 'isExternalBinding': true,
     if (orphanTests != null && orphanTests!.isNotEmpty)
       'orphanTests': orphanTests!.map((t) => t.toJson()).toList(),
   };
@@ -335,7 +338,7 @@ class DeclarationNode {
   final bool isTestSupport;
   final bool isSealed;
   final bool isNativeRoot;
-  final bool isExternalJsInterop;
+  final bool isExternalBinding;
   final String? sealedSuperclassName;
   final Element? sealedSuperclassElement;
   final Set<String> outgoingTargetIds;
@@ -355,7 +358,7 @@ class DeclarationNode {
     this.isTestSupport = false,
     this.isSealed = false,
     this.isNativeRoot = false,
-    this.isExternalJsInterop = false,
+    this.isExternalBinding = false,
     this.sealedSuperclassName,
     this.sealedSuperclassElement,
     Set<String>? outgoingTargetIds,

--- a/packages/zombie/lib/src/models.dart
+++ b/packages/zombie/lib/src/models.dart
@@ -151,6 +151,7 @@ final class ZombieOptions {
   final List<String> testSupportPatterns;
   final List<String> ignoreNamePatterns;
   final List<String> extraRoots;
+  final bool ignoreExternalInterop;
 
   const ZombieOptions({
     required this.packagePath,
@@ -166,6 +167,7 @@ final class ZombieOptions {
     this.testSupportPatterns = const ['Fake*', 'Mock*'],
     this.ignoreNamePatterns = const [],
     this.extraRoots = const [],
+    this.ignoreExternalInterop = false,
   });
 }
 
@@ -218,6 +220,7 @@ class ZombieFinding {
   final ZombieClassification classification;
   final String suggestedAction;
   final List<OrphanTestSite>? orphanTests;
+  final bool isExternalJsInterop;
 
   const ZombieFinding({
     required this.id,
@@ -230,6 +233,7 @@ class ZombieFinding {
     required this.classification,
     required this.suggestedAction,
     this.orphanTests,
+    this.isExternalJsInterop = false,
   });
 
   factory ZombieFinding.fromJson(Map<String, dynamic> json) => ZombieFinding(
@@ -247,6 +251,7 @@ class ZombieFinding {
     orphanTests: (json['orphanTests'] as List<dynamic>?)
         ?.map((t) => OrphanTestSite.fromJson(t as Map<String, dynamic>))
         .toList(),
+    isExternalJsInterop: json['isExternalJsInterop'] as bool? ?? false,
   );
 
   Map<String, dynamic> toJson() => {
@@ -259,6 +264,7 @@ class ZombieFinding {
     'length': length,
     'classification': classification.jsonValue,
     'suggestedAction': suggestedAction,
+    if (isExternalJsInterop) 'isExternalJsInterop': true,
     if (orphanTests != null && orphanTests!.isNotEmpty)
       'orphanTests': orphanTests!.map((t) => t.toJson()).toList(),
   };
@@ -329,6 +335,7 @@ class DeclarationNode {
   final bool isTestSupport;
   final bool isSealed;
   final bool isNativeRoot;
+  final bool isExternalJsInterop;
   final String? sealedSuperclassName;
   final Element? sealedSuperclassElement;
   final Set<String> outgoingTargetIds;
@@ -348,6 +355,7 @@ class DeclarationNode {
     this.isTestSupport = false,
     this.isSealed = false,
     this.isNativeRoot = false,
+    this.isExternalJsInterop = false,
     this.sealedSuperclassName,
     this.sealedSuperclassElement,
     Set<String>? outgoingTargetIds,

--- a/packages/zombie/lib/src/reachability_engine.dart
+++ b/packages/zombie/lib/src/reachability_engine.dart
@@ -129,8 +129,10 @@ class ZombieEngine {
             isFileIgnored || CommentParser.isDeclarationIgnored(decl);
 
         if (decl is TopLevelVariableDeclaration) {
-          final isExternalJsInterop = options.frameworkAdapter
-              .isExternalJsInterop(decl, null);
+          final isExternalBinding = options.frameworkAdapter.isExternalBinding(
+            decl,
+            null,
+          );
           final isNativeRoot =
               isNativeOrEntryPoint(decl) ||
               options.frameworkAdapter.isFrameworkEntryPoint(decl, null);
@@ -159,9 +161,9 @@ class ZombieEngine {
               element: element,
               isIgnored: isVarIgnored,
               isTestSupport: isTestSupport,
-              isExternalJsInterop:
-                  isExternalJsInterop ||
-                  options.frameworkAdapter.isExternalJsInterop(decl, element),
+              isExternalBinding:
+                  isExternalBinding ||
+                  options.frameworkAdapter.isExternalBinding(decl, element),
               isNativeRoot:
                   isNativeRoot ||
                   options.frameworkAdapter.isFrameworkEntryPoint(decl, element),
@@ -209,8 +211,10 @@ class ZombieEngine {
           final lineInfo = unitResult.lineInfo.getLocation(decl.offset);
           final element = decl.declaredFragment?.element;
           final isTestSupport = isTestSupportDeclaration(decl, name);
-          final isExternalJsInterop = options.frameworkAdapter
-              .isExternalJsInterop(decl, element);
+          final isExternalBinding = options.frameworkAdapter.isExternalBinding(
+            decl,
+            element,
+          );
           final isNativeRoot =
               isNativeOrEntryPoint(decl) ||
               options.frameworkAdapter.isFrameworkEntryPoint(decl, element);
@@ -240,7 +244,7 @@ class ZombieEngine {
             isIgnored: isDeclIgnored,
             isTestSupport: isTestSupport,
             isSealed: isSealed,
-            isExternalJsInterop: isExternalJsInterop,
+            isExternalBinding: isExternalBinding,
             isNativeRoot: isNativeRoot,
           );
 
@@ -498,7 +502,7 @@ class ZombieEngine {
 
       if (!isCandidate) continue;
       if (node.isIgnored) continue;
-      if (options.ignoreExternalInterop && node.isExternalJsInterop) continue;
+      if (options.ignoreExternalBindings && node.isExternalBinding) continue;
       if (WildcardPattern.anyMatch(_ignoreNameWildcards, node.name)) continue;
       if (productionLive.contains(node.id)) continue;
 
@@ -535,7 +539,7 @@ class ZombieEngine {
             length: node.length,
             classification: ZombieClassification.pureZombie,
             suggestedAction: SuggestedAction.delete,
-            isExternalJsInterop: node.isExternalJsInterop,
+            isExternalBinding: node.isExternalBinding,
           ),
         );
       } else {
@@ -590,7 +594,7 @@ class ZombieEngine {
               classification: ZombieClassification.coInvokedHazard,
               suggestedAction: SuggestedAction.manualRefactorHazard,
               orphanTests: orphanSites.isNotEmpty ? orphanSites : null,
-              isExternalJsInterop: node.isExternalJsInterop,
+              isExternalBinding: node.isExternalBinding,
             ),
           );
         } else {
@@ -607,7 +611,7 @@ class ZombieEngine {
               classification: ZombieClassification.testedZombie,
               suggestedAction: SuggestedAction.deleteWithOrphanTests,
               orphanTests: orphanSites.isNotEmpty ? orphanSites : null,
-              isExternalJsInterop: node.isExternalJsInterop,
+              isExternalBinding: node.isExternalBinding,
             ),
           );
         }

--- a/packages/zombie/lib/src/reachability_engine.dart
+++ b/packages/zombie/lib/src/reachability_engine.dart
@@ -129,6 +129,8 @@ class ZombieEngine {
             isFileIgnored || CommentParser.isDeclarationIgnored(decl);
 
         if (decl is TopLevelVariableDeclaration) {
+          final isExternalJsInterop = options.frameworkAdapter
+              .isExternalJsInterop(decl, null);
           final isNativeRoot =
               isNativeOrEntryPoint(decl) ||
               options.frameworkAdapter.isFrameworkEntryPoint(decl, null);
@@ -157,6 +159,9 @@ class ZombieEngine {
               element: element,
               isIgnored: isVarIgnored,
               isTestSupport: isTestSupport,
+              isExternalJsInterop:
+                  isExternalJsInterop ||
+                  options.frameworkAdapter.isExternalJsInterop(decl, element),
               isNativeRoot:
                   isNativeRoot ||
                   options.frameworkAdapter.isFrameworkEntryPoint(decl, element),
@@ -204,6 +209,8 @@ class ZombieEngine {
           final lineInfo = unitResult.lineInfo.getLocation(decl.offset);
           final element = decl.declaredFragment?.element;
           final isTestSupport = isTestSupportDeclaration(decl, name);
+          final isExternalJsInterop = options.frameworkAdapter
+              .isExternalJsInterop(decl, element);
           final isNativeRoot =
               isNativeOrEntryPoint(decl) ||
               options.frameworkAdapter.isFrameworkEntryPoint(decl, element);
@@ -233,6 +240,7 @@ class ZombieEngine {
             isIgnored: isDeclIgnored,
             isTestSupport: isTestSupport,
             isSealed: isSealed,
+            isExternalJsInterop: isExternalJsInterop,
             isNativeRoot: isNativeRoot,
           );
 
@@ -490,6 +498,7 @@ class ZombieEngine {
 
       if (!isCandidate) continue;
       if (node.isIgnored) continue;
+      if (options.ignoreExternalInterop && node.isExternalJsInterop) continue;
       if (WildcardPattern.anyMatch(_ignoreNameWildcards, node.name)) continue;
       if (productionLive.contains(node.id)) continue;
 
@@ -526,6 +535,7 @@ class ZombieEngine {
             length: node.length,
             classification: ZombieClassification.pureZombie,
             suggestedAction: SuggestedAction.delete,
+            isExternalJsInterop: node.isExternalJsInterop,
           ),
         );
       } else {
@@ -580,6 +590,7 @@ class ZombieEngine {
               classification: ZombieClassification.coInvokedHazard,
               suggestedAction: SuggestedAction.manualRefactorHazard,
               orphanTests: orphanSites.isNotEmpty ? orphanSites : null,
+              isExternalJsInterop: node.isExternalJsInterop,
             ),
           );
         } else {
@@ -596,6 +607,7 @@ class ZombieEngine {
               classification: ZombieClassification.testedZombie,
               suggestedAction: SuggestedAction.deleteWithOrphanTests,
               orphanTests: orphanSites.isNotEmpty ? orphanSites : null,
+              isExternalJsInterop: node.isExternalJsInterop,
             ),
           );
         }

--- a/packages/zombie/test/adapters/composite_adapter_test.dart
+++ b/packages/zombie/test/adapters/composite_adapter_test.dart
@@ -29,7 +29,7 @@ void main() {
   group('CompositeFrameworkAdapter', () {
     test('defaults() constructor includes default standard adapters', () {
       const composite = CompositeFrameworkAdapter.defaults();
-      check(composite.adapters.length).equals(3);
+      check(composite.adapters.length).equals(4);
       check(composite.adapters.whereType<FlutterAdapter>().length).equals(1);
       check(
         composite.adapters.whereType<BuildRunnerAdapter>().length,
@@ -37,6 +37,7 @@ void main() {
       check(
         composite.adapters.whereType<PackageTestAdapter>().length,
       ).equals(1);
+      check(composite.adapters.whereType<JsInteropAdapter>().length).equals(1);
     });
 
     group('harvestRoots', () {

--- a/packages/zombie/test/adapters/js_interop_adapter_test.dart
+++ b/packages/zombie/test/adapters/js_interop_adapter_test.dart
@@ -42,7 +42,7 @@ void normalFunc() {}
       });
     });
 
-    group('isExternalJsInterop', () {
+    group('isExternalBinding', () {
       test('matches external functions and top-level variables', () {
         final result = parseString(
           content: '''
@@ -58,10 +58,10 @@ int regularVar = 10;
 
         final declarations = result.unit.declarations;
 
-        check(adapter.isExternalJsInterop(declarations[0], null)).isTrue();
-        check(adapter.isExternalJsInterop(declarations[1], null)).isTrue();
-        check(adapter.isExternalJsInterop(declarations[2], null)).isFalse();
-        check(adapter.isExternalJsInterop(declarations[3], null)).isFalse();
+        check(adapter.isExternalBinding(declarations[0], null)).isTrue();
+        check(adapter.isExternalBinding(declarations[1], null)).isTrue();
+        check(adapter.isExternalBinding(declarations[2], null)).isFalse();
+        check(adapter.isExternalBinding(declarations[3], null)).isFalse();
       });
 
       test('matches JS extension types and classes with external members', () {
@@ -92,21 +92,21 @@ class ClassWithExternalMember {
         final declarations = result.unit.declarations;
 
         // DomHTMLCanvasElement
-        check(adapter.isExternalJsInterop(declarations[0], null)).isTrue();
+        check(adapter.isExternalBinding(declarations[0], null)).isTrue();
         // JSAnyExtension
-        check(adapter.isExternalJsInterop(declarations[1], null)).isTrue();
+        check(adapter.isExternalBinding(declarations[1], null)).isTrue();
         // StandardStringExtension (non-JS)
-        check(adapter.isExternalJsInterop(declarations[2], null)).isFalse();
+        check(adapter.isExternalBinding(declarations[2], null)).isFalse();
         // NormalClass
-        check(adapter.isExternalJsInterop(declarations[3], null)).isFalse();
+        check(adapter.isExternalBinding(declarations[3], null)).isFalse();
         // ClassWithExternalMember
-        check(adapter.isExternalJsInterop(declarations[4], null)).isTrue();
+        check(adapter.isExternalBinding(declarations[4], null)).isTrue();
       });
     });
   });
 
   group('CompositeFrameworkAdapter with JsInteropAdapter', () {
-    test('defaults() delegates isExternalJsInterop', () {
+    test('defaults() delegates isExternalBinding', () {
       const composite = CompositeFrameworkAdapter.defaults();
       final result = parseString(
         content: '''
@@ -116,8 +116,8 @@ void myDartFunction() {}
       );
 
       final decls = result.unit.declarations;
-      check(composite.isExternalJsInterop(decls[0], null)).isTrue();
-      check(composite.isExternalJsInterop(decls[1], null)).isFalse();
+      check(composite.isExternalBinding(decls[0], null)).isTrue();
+      check(composite.isExternalBinding(decls[1], null)).isFalse();
     });
   });
 }

--- a/packages/zombie/test/adapters/js_interop_adapter_test.dart
+++ b/packages/zombie/test/adapters/js_interop_adapter_test.dart
@@ -75,6 +75,8 @@ extension type DomHTMLCanvasElement(JSObject _) {
 
 extension type JSAnyExtension(JSAny _) {}
 
+extension type JSUint8ArrayExtension(JSUint8Array _) {}
+
 extension type StandardStringExtension(String value) {
   int get len => value.length;
 }
@@ -86,6 +88,26 @@ class NormalClass {
 class ClassWithExternalMember {
   external void callJs();
 }
+
+class ClassWithJsParam {
+  void handle(JSObject event) {}
+}
+
+class ClassWithJsParamName {
+  void find(String JSStringKey) {}
+}
+
+extension type PureDartExtWithJsParam(String s) {
+  void log(JSObject e) {}
+}
+
+extension CanvasExtWithExternal on DomHTMLCanvasElement {
+  external void draw();
+}
+
+extension PureDartExt on String {
+  void customTrim() {}
+}
 ''',
         );
 
@@ -95,12 +117,24 @@ class ClassWithExternalMember {
         check(adapter.isExternalBinding(declarations[0], null)).isTrue();
         // JSAnyExtension
         check(adapter.isExternalBinding(declarations[1], null)).isTrue();
+        // JSUint8ArrayExtension
+        check(adapter.isExternalBinding(declarations[2], null)).isTrue();
         // StandardStringExtension (non-JS)
-        check(adapter.isExternalBinding(declarations[2], null)).isFalse();
-        // NormalClass
         check(adapter.isExternalBinding(declarations[3], null)).isFalse();
+        // NormalClass
+        check(adapter.isExternalBinding(declarations[4], null)).isFalse();
         // ClassWithExternalMember
-        check(adapter.isExternalBinding(declarations[4], null)).isTrue();
+        check(adapter.isExternalBinding(declarations[5], null)).isTrue();
+        // ClassWithJsParam (must NOT be treated as external binding)
+        check(adapter.isExternalBinding(declarations[6], null)).isFalse();
+        // ClassWithJsParamName (must NOT be treated as external binding)
+        check(adapter.isExternalBinding(declarations[7], null)).isFalse();
+        // PureDartExtWithJsParam (must NOT be treated as external binding)
+        check(adapter.isExternalBinding(declarations[8], null)).isFalse();
+        // CanvasExtWithExternal (has external member)
+        check(adapter.isExternalBinding(declarations[9], null)).isTrue();
+        // PureDartExt (normal extension)
+        check(adapter.isExternalBinding(declarations[10], null)).isFalse();
       });
     });
   });

--- a/packages/zombie/test/adapters/js_interop_adapter_test.dart
+++ b/packages/zombie/test/adapters/js_interop_adapter_test.dart
@@ -1,0 +1,123 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:checks/checks.dart';
+import 'package:test/test.dart';
+import 'package:zombie/zombie.dart';
+
+void main() {
+  group('JsInteropAdapter', () {
+    const adapter = JsInteropAdapter();
+
+    group('isFrameworkEntryPoint', () {
+      test('matches Wasm export/entrypoint pragmas', () {
+        final result = parseString(
+          content: '''
+@pragma('wasm:export')
+void wasmExported() {}
+
+@pragma('wasm:export', 'my_func')
+void wasmNamedExported() {}
+
+@pragma('wasm:entry-point')
+void wasmEntryPoint() {}
+
+@pragma('dart2js:tryInline')
+void inlineFunc() {}
+
+void normalFunc() {}
+''',
+        );
+
+        final declarations = result.unit.declarations;
+
+        // wasm:export
+        check(adapter.isFrameworkEntryPoint(declarations[0], null)).isTrue();
+        // wasm:export named
+        check(adapter.isFrameworkEntryPoint(declarations[1], null)).isTrue();
+        // wasm:entry-point
+        check(adapter.isFrameworkEntryPoint(declarations[2], null)).isTrue();
+        // dart2js:tryInline
+        check(adapter.isFrameworkEntryPoint(declarations[3], null)).isFalse();
+        // normal
+        check(adapter.isFrameworkEntryPoint(declarations[4], null)).isFalse();
+      });
+    });
+
+    group('isExternalJsInterop', () {
+      test('matches external functions and top-level variables', () {
+        final result = parseString(
+          content: '''
+external void externalTopLevel();
+
+external int externalVar;
+
+void regularFunc() {}
+
+int regularVar = 10;
+''',
+        );
+
+        final declarations = result.unit.declarations;
+
+        check(adapter.isExternalJsInterop(declarations[0], null)).isTrue();
+        check(adapter.isExternalJsInterop(declarations[1], null)).isTrue();
+        check(adapter.isExternalJsInterop(declarations[2], null)).isFalse();
+        check(adapter.isExternalJsInterop(declarations[3], null)).isFalse();
+      });
+
+      test('matches JS extension types and classes with external members', () {
+        final result = parseString(
+          content: '''
+@JS('HTMLCanvasElement')
+extension type DomHTMLCanvasElement(JSObject _) {
+  external int get width;
+  external set width(int value);
+}
+
+extension type JSAnyExtension(JSAny _) {}
+
+extension type StandardStringExtension(String value) {
+  int get len => value.length;
+}
+
+class NormalClass {
+  void doSomething() {}
+}
+
+class ClassWithExternalMember {
+  external void callJs();
+}
+''',
+        );
+
+        final declarations = result.unit.declarations;
+
+        // DomHTMLCanvasElement
+        check(adapter.isExternalJsInterop(declarations[0], null)).isTrue();
+        // JSAnyExtension
+        check(adapter.isExternalJsInterop(declarations[1], null)).isTrue();
+        // StandardStringExtension (non-JS)
+        check(adapter.isExternalJsInterop(declarations[2], null)).isFalse();
+        // NormalClass
+        check(adapter.isExternalJsInterop(declarations[3], null)).isFalse();
+        // ClassWithExternalMember
+        check(adapter.isExternalJsInterop(declarations[4], null)).isTrue();
+      });
+    });
+  });
+
+  group('CompositeFrameworkAdapter with JsInteropAdapter', () {
+    test('defaults() delegates isExternalJsInterop', () {
+      const composite = CompositeFrameworkAdapter.defaults();
+      final result = parseString(
+        content: '''
+external void myExternalFunction();
+void myDartFunction() {}
+''',
+      );
+
+      final decls = result.unit.declarations;
+      check(composite.isExternalJsInterop(decls[0], null)).isTrue();
+      check(composite.isExternalJsInterop(decls[1], null)).isFalse();
+    });
+  });
+}

--- a/packages/zombie/test/reachability_engine_test.dart
+++ b/packages/zombie/test/reachability_engine_test.dart
@@ -1618,7 +1618,7 @@ class DeadInternalService {}
     });
 
     test(
-      'identifies isExternalJsInterop and filters with ignoreExternalInterop',
+      'identifies isExternalBinding and filters with ignoreExternalBindings',
       () async {
         await d.dir('js_interop_pkg', [
           packageConfig('js_interop_pkg'),
@@ -1650,27 +1650,27 @@ class DeadDartHelper {
         ]).create();
 
         // 1. Default run: flags both JS interop and DeadDartHelper, but
-        // marks isExternalJsInterop.
+        // marks isExternalBinding.
         final defaultReport = await analyzePackage(d.path('js_interop_pkg'));
         final canvasZombie = defaultReport.zombies.firstWhere(
           (z) => z.name == 'DomCanvas',
         );
-        check(canvasZombie.isExternalJsInterop).isTrue();
+        check(canvasZombie.isExternalBinding).isTrue();
 
         final funcZombie = defaultReport.zombies.firstWhere(
           (z) => z.name == 'topLevelJsFunc',
         );
-        check(funcZombie.isExternalJsInterop).isTrue();
+        check(funcZombie.isExternalBinding).isTrue();
 
         final dartZombie = defaultReport.zombies.firstWhere(
           (z) => z.name == 'DeadDartHelper',
         );
-        check(dartZombie.isExternalJsInterop).isFalse();
+        check(dartZombie.isExternalBinding).isFalse();
 
-        // 2. Run with ignoreExternalInterop: true.
+        // 2. Run with ignoreExternalBindings: true.
         final options = ZombieOptions(
           packagePath: d.path('js_interop_pkg'),
-          ignoreExternalInterop: true,
+          ignoreExternalBindings: true,
         );
         final filteredReport = await ZombieEngine(options).analyze();
         check(filteredReport.pureZombiesFound).equals(1);

--- a/packages/zombie/test/reachability_engine_test.dart
+++ b/packages/zombie/test/reachability_engine_test.dart
@@ -1616,5 +1616,66 @@ class DeadInternalService {}
       check(deadNames).not((it) => it.contains('CallerService'));
       check(deadNames).not((it) => it.contains('PlatformService'));
     });
+
+    test(
+      'identifies isExternalJsInterop and filters with ignoreExternalInterop',
+      () async {
+        await d.dir('js_interop_pkg', [
+          packageConfig('js_interop_pkg'),
+          d.file('pubspec.yaml', '''
+name: js_interop_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+          d.dir('lib', [
+            d.file('js_interop_pkg.dart', 'export "src/live.dart";'),
+            d.dir('src', [
+              d.file('live.dart', 'class LiveService {}'),
+              d.file('dom_bindings.dart', '''
+import 'dart:js_interop';
+
+@JS('HTMLCanvasElement')
+extension type DomCanvas(JSObject _) {
+  external int get width;
+}
+
+external void topLevelJsFunc();
+
+class DeadDartHelper {
+  void unused() {}
+}
+'''),
+            ]),
+          ]),
+        ]).create();
+
+        // 1. Default run: flags both JS interop and DeadDartHelper, but
+        // marks isExternalJsInterop.
+        final defaultReport = await analyzePackage(d.path('js_interop_pkg'));
+        final canvasZombie = defaultReport.zombies.firstWhere(
+          (z) => z.name == 'DomCanvas',
+        );
+        check(canvasZombie.isExternalJsInterop).isTrue();
+
+        final funcZombie = defaultReport.zombies.firstWhere(
+          (z) => z.name == 'topLevelJsFunc',
+        );
+        check(funcZombie.isExternalJsInterop).isTrue();
+
+        final dartZombie = defaultReport.zombies.firstWhere(
+          (z) => z.name == 'DeadDartHelper',
+        );
+        check(dartZombie.isExternalJsInterop).isFalse();
+
+        // 2. Run with ignoreExternalInterop: true.
+        final options = ZombieOptions(
+          packagePath: d.path('js_interop_pkg'),
+          ignoreExternalInterop: true,
+        );
+        final filteredReport = await ZombieEngine(options).analyze();
+        check(filteredReport.pureZombiesFound).equals(1);
+        check(filteredReport.zombies.single.name).equals('DeadDartHelper');
+      },
+    );
   });
 }


### PR DESCRIPTION
- Introduce JsInteropAdapter implementing FrameworkAdapter to detect @JS, @staticInterop, @anonymous, and Wasm entrypoints.
- Detect external JavaScript / Wasm facade declarations and extension types.
- Add isExternalJsInterop property to ZombieFinding and DeclarationNode.
- Add --ignore-external-interop CLI flag and ignoreExternalInterop option in ZombieOptions.
- Include JsInteropAdapter in CompositeFrameworkAdapter.defaults().
- Add comprehensive adapter and reachability engine tests.
