### PR TITLE
feat(zombie): add workspace consumer discovery and unified extra-roots

### DIFF
--- a/packages/zombie/lib/src/cli.dart
+++ b/packages/zombie/lib/src/cli.dart
@@ -81,6 +81,13 @@ ArgParser buildArgParser() {
           'declarations.',
       defaultsTo: false,
     )
+    ..addFlag(
+      'workspace-discovery',
+      defaultsTo: true,
+      help:
+          'Automatically discover and ingest consumer roots from sibling '
+          'packages in the enclosing workspace.',
+    )
     ..addSdkPathOption()
     ..addFlag(
       'pub-get',
@@ -157,6 +164,7 @@ class ZombieCliRunner {
     final failOnZombies = results.flag('fail-on-zombies');
     final autoPubGet = results.flag('pub-get');
     final ignoreExternalBindings = results.flag('ignore-external-bindings');
+    final workspaceDiscovery = results.flag('workspace-discovery');
     final sdkPath = results.option('sdk-path');
     final jsonOutputPath = results.option('json-output');
     final testSupportPatterns = _parseCommaSeparated(
@@ -176,6 +184,7 @@ class ZombieCliRunner {
       failOnZombies: failOnZombies,
       autoPubGet: autoPubGet,
       ignoreExternalBindings: ignoreExternalBindings,
+      workspaceDiscovery: workspaceDiscovery,
       sdkPath: sdkPath,
       jsonOutputPath: jsonOutputPath,
       testSupportPatterns: testSupportPatterns,

--- a/packages/zombie/lib/src/models.dart
+++ b/packages/zombie/lib/src/models.dart
@@ -152,6 +152,7 @@ final class ZombieOptions {
   final List<String> ignoreNamePatterns;
   final List<String> extraRoots;
   final bool ignoreExternalBindings;
+  final bool workspaceDiscovery;
 
   const ZombieOptions({
     required this.packagePath,
@@ -168,6 +169,7 @@ final class ZombieOptions {
     this.ignoreNamePatterns = const [],
     this.extraRoots = const [],
     this.ignoreExternalBindings = false,
+    this.workspaceDiscovery = true,
   });
 }
 

--- a/packages/zombie/lib/src/reachability_engine.dart
+++ b/packages/zombie/lib/src/reachability_engine.dart
@@ -34,15 +34,31 @@ class ZombieEngine {
     final topology = harvester.harvestTopology();
 
     final absolutePackagePath = p.normalize(p.absolute(options.packagePath));
-    final extraRootPaths = options.extraRoots
-        .map(
-          (r) =>
-              p.normalize(p.isAbsolute(r) ? r : p.join(absolutePackagePath, r)),
-        )
-        .where((path) => Directory(path).existsSync())
-        .toList();
+    final extraPaths = <String>{};
+    for (final extra in options.extraRoots) {
+      if (extra.trim().isEmpty) continue;
+      final resolved = p.normalize(
+        p.isAbsolute(extra) ? extra : p.join(absolutePackagePath, extra),
+      );
+      if (FileSystemEntity.typeSync(resolved) !=
+          FileSystemEntityType.notFound) {
+        extraPaths.add(resolved);
+      }
+    }
+    for (final file in [
+      ...topology.extraProductionFiles,
+      ...topology.extraTestFiles,
+    ]) {
+      final resolved = p.normalize(
+        p.isAbsolute(file) ? file : p.join(absolutePackagePath, file),
+      );
+      if (FileSystemEntity.typeSync(resolved) !=
+          FileSystemEntityType.notFound) {
+        extraPaths.add(resolved);
+      }
+    }
     final contextHelper = AnalysisContextHelper(
-      includedPaths: [absolutePackagePath, ...extraRootPaths],
+      includedPaths: [absolutePackagePath, ...extraPaths],
       sdkPath: options.sdkPath,
     );
 
@@ -462,6 +478,13 @@ class ZombieEngine {
     for (final node in allNodes) {
       if (topology.roleOf(node.relativeFilePath) == FileRole.test) {
         testRoots.add(node.id);
+      }
+    }
+
+    // 3.7 Extra and companion production roots.
+    for (final node in allNodes) {
+      if (topology.extraProductionFiles.contains(node.relativeFilePath)) {
+        productionRoots.add(node.id);
       }
     }
 

--- a/packages/zombie/lib/src/root_harvester.dart
+++ b/packages/zombie/lib/src/root_harvester.dart
@@ -4,6 +4,7 @@ import 'package:analytica/sdk_discovery.dart';
 import 'package:path/path.dart' as p;
 
 import 'models.dart';
+import 'workspace_discovery.dart';
 
 /// Role and classification of a Dart source file within a package layout.
 enum FileRole {
@@ -46,6 +47,8 @@ class PackageTopology {
   final List<String> auxiliaryFiles;
   final List<String> testFiles;
   final Set<String> frameworkRoots;
+  final List<String> extraProductionFiles;
+  final List<String> extraTestFiles;
 
   const PackageTopology({
     required this.packagePath,
@@ -57,6 +60,8 @@ class PackageTopology {
     required this.auxiliaryFiles,
     required this.testFiles,
     this.frameworkRoots = const {},
+    this.extraProductionFiles = const [],
+    this.extraTestFiles = const [],
   });
 
   /// Deprecated alias for [frameworkRoots].
@@ -75,13 +80,18 @@ class PackageTopology {
     ...demonstrationFiles,
     ...auxiliaryFiles,
     ...testFiles,
+    ...extraProductionFiles,
+    ...extraTestFiles,
   ];
 
   /// Resolves the role of a given [relativeFilePath].
   FileRole roleOf(String relativeFilePath) {
     final normalized = p.normalize(relativeFilePath);
-    if (testFiles.contains(normalized)) {
+    if (testFiles.contains(normalized) || extraTestFiles.contains(normalized)) {
       return FileRole.test;
+    }
+    if (extraProductionFiles.contains(normalized)) {
+      return FileRole.other;
     }
     if (normalized.startsWith('lib/src/') ||
         normalized.startsWith('lib/src\\')) {
@@ -184,6 +194,8 @@ class RootHarvester {
     final example = <String>[];
     final auxiliary = <String>[];
     final test = <String>[];
+    final extraProduction = <String>[];
+    final extraTest = <String>[];
 
     for (final entity in rootDir.listSync(
       recursive: true,
@@ -226,26 +238,84 @@ class RootHarvester {
       }
     }
 
-    // Harvest files from extra roots (companion test suites, external roots)
+    // Discover companion consumers in workspace if enabled
+    if (options.workspaceDiscovery) {
+      const discovery = WorkspaceConsumerDiscovery();
+      final discovered = discovery.discoverConsumers(
+        packagePath: options.packagePath,
+        targetPackageName: packageName,
+      );
+      for (final root in discovered.productionRoots) {
+        final relPath = p.relative(root, from: options.packagePath);
+        if (!_isExcludedFromExtraRoot(relPath)) {
+          extraProduction.add(p.normalize(relPath));
+        }
+      }
+      for (final root in discovered.testRoots) {
+        final relPath = p.relative(root, from: options.packagePath);
+        if (!_isExcludedFromExtraRoot(relPath)) {
+          extraTest.add(p.normalize(relPath));
+        }
+      }
+    }
+
+    // Harvest files from extra roots (explicit files or companion directories)
     for (final extraRoot in options.extraRoots) {
       if (extraRoot.trim().isEmpty) continue;
-      final extraDir = Directory(
-        p.normalize(
-          p.isAbsolute(extraRoot)
-              ? extraRoot
-              : p.join(options.packagePath, extraRoot),
-        ),
+      final extraPath = p.normalize(
+        p.isAbsolute(extraRoot)
+            ? extraRoot
+            : p.join(options.packagePath, extraRoot),
       );
+
+      final extraFile = File(extraPath);
+      if (extraFile.existsSync() && extraPath.endsWith('.dart')) {
+        final relPath = p.relative(extraPath, from: options.packagePath);
+        if (!_isExcludedFromExtraRoot(relPath)) {
+          extraProduction.add(p.normalize(relPath));
+        }
+        continue;
+      }
+
+      final extraDir = Directory(extraPath);
       if (!extraDir.existsSync()) continue;
-      for (final entity in extraDir.listSync(
-        recursive: true,
-        followLinks: false,
-      )) {
-        if (entity is! File || !entity.path.endsWith('.dart')) continue;
-        final relPath = p.relative(entity.path, from: options.packagePath);
-        if (_isExcluded(relPath)) continue;
-        final normalized = p.normalize(relPath);
-        test.add(normalized);
+
+      final libSubdir = Directory(p.join(extraPath, 'lib'));
+      final testSubdir = Directory(p.join(extraPath, 'test'));
+
+      if (libSubdir.existsSync() || testSubdir.existsSync()) {
+        if (libSubdir.existsSync()) {
+          for (final entity in libSubdir.listSync(
+            recursive: true,
+            followLinks: false,
+          )) {
+            if (entity is! File || !entity.path.endsWith('.dart')) continue;
+            final relPath = p.relative(entity.path, from: options.packagePath);
+            if (_isExcludedFromExtraRoot(relPath)) continue;
+            extraProduction.add(p.normalize(relPath));
+          }
+        }
+        if (testSubdir.existsSync()) {
+          for (final entity in testSubdir.listSync(
+            recursive: true,
+            followLinks: false,
+          )) {
+            if (entity is! File || !entity.path.endsWith('.dart')) continue;
+            final relPath = p.relative(entity.path, from: options.packagePath);
+            if (_isExcludedFromExtraRoot(relPath)) continue;
+            extraTest.add(p.normalize(relPath));
+          }
+        }
+      } else {
+        for (final entity in extraDir.listSync(
+          recursive: true,
+          followLinks: false,
+        )) {
+          if (entity is! File || !entity.path.endsWith('.dart')) continue;
+          final relPath = p.relative(entity.path, from: options.packagePath);
+          if (_isExcludedFromExtraRoot(relPath)) continue;
+          extraTest.add(p.normalize(relPath));
+        }
       }
     }
 
@@ -258,6 +328,8 @@ class RootHarvester {
       demonstrationFiles: example,
       auxiliaryFiles: auxiliary,
       testFiles: test,
+      extraProductionFiles: extraProduction,
+      extraTestFiles: extraTest,
     );
 
     final frameworkRoots = options.frameworkAdapter.harvestRoots(
@@ -276,6 +348,8 @@ class RootHarvester {
       auxiliaryFiles: auxiliary,
       testFiles: test,
       frameworkRoots: frameworkRoots,
+      extraProductionFiles: extraProduction,
+      extraTestFiles: extraTest,
     );
   }
 
@@ -285,6 +359,25 @@ class RootHarvester {
     if (segments.contains('.dart_tool') ||
         segments.contains('.git') ||
         segments.first == 'build') {
+      return true;
+    }
+
+    if (!options.includeGenerated) {
+      final filename = p.basename(relativePath);
+      if (filename.endsWith('.g.dart') ||
+          filename.endsWith('.freezed.dart') ||
+          filename.endsWith('.mocks.dart')) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool _isExcludedFromExtraRoot(String relativePath) {
+    final segments = p.split(p.normalize(relativePath));
+    if (segments.isEmpty) return false;
+    if (segments.contains('.dart_tool') || segments.contains('.git')) {
       return true;
     }
 

--- a/packages/zombie/lib/src/workspace_discovery.dart
+++ b/packages/zombie/lib/src/workspace_discovery.dart
@@ -1,0 +1,304 @@
+import 'dart:io';
+
+import 'package:analytica/analyzer.dart';
+import 'package:analytica/sdk_discovery.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// Container for companion roots discovered across sibling packages in a
+/// workspace.
+class DiscoveredCompanionRoots {
+  /// File paths belonging to companion production entrypoints (`lib/**`).
+  final List<String> productionRoots;
+
+  /// File paths belonging to companion test suites (`test/**`).
+  final List<String> testRoots;
+
+  const DiscoveredCompanionRoots({
+    this.productionRoots = const [],
+    this.testRoots = const [],
+  });
+
+  /// Whether no companion roots were discovered.
+  bool get isEmpty => productionRoots.isEmpty && testRoots.isEmpty;
+
+  /// Whether companion roots were discovered.
+  bool get isNotEmpty => !isEmpty;
+}
+
+/// Discovers companion consumer packages in an enclosing workspace or
+/// repository that depend on the analyzed target package.
+class WorkspaceConsumerDiscovery {
+  /// Default directory names excluded from workspace consumer traversal.
+  static const Set<String> defaultExcludedDirectories = {
+    '.git',
+    '.dart_tool',
+    'build',
+    'out',
+    'node_modules',
+    'third_party',
+    'example',
+    'examples',
+  };
+
+  /// Internal package source directories that should not be searched for
+  /// nested child packages once a package root is identified.
+  static const Set<String> _packageInternalDirs = {
+    'lib',
+    'test',
+    'bin',
+    'tool',
+    'benchmark',
+    'web',
+    'doc',
+    'src',
+    'ios',
+    'android',
+    'macos',
+    'windows',
+    'linux',
+  };
+
+  /// Maximum directory depth to search from the workspace root.
+  final int maxDepth;
+
+  /// Directory names excluded from traversal.
+  final Set<String> excludedDirectories;
+
+  const WorkspaceConsumerDiscovery({
+    this.maxDepth = 4,
+    this.excludedDirectories = defaultExcludedDirectories,
+  });
+
+  /// Locates the enclosing workspace or repository root by searching upward
+  /// from [packagePath] for `.git`, `DEPS`, `.gclient`, or `pubspec.yaml`
+  /// with a `workspace:` key.
+  String? findWorkspaceRoot(String packagePath) {
+    var dir = Directory(p.normalize(p.absolute(packagePath)));
+    while (true) {
+      if (_isWorkspaceRoot(dir)) {
+        return dir.path;
+      }
+      final parent = dir.parent;
+      if (parent.path == dir.path) {
+        break;
+      }
+      dir = parent;
+    }
+    return null;
+  }
+
+  /// Discovers companion consumer packages referencing [targetPackageName]
+  /// (or the package at [packagePath]) within the workspace.
+  DiscoveredCompanionRoots discoverConsumers({
+    required String packagePath,
+    String? targetPackageName,
+    String? workspaceRoot,
+  }) {
+    final absPackagePath = p.normalize(p.absolute(packagePath));
+    final root = workspaceRoot ?? findWorkspaceRoot(absPackagePath);
+    if (root == null) {
+      return const DiscoveredCompanionRoots();
+    }
+
+    final effectiveTargetName =
+        targetPackageName ?? _readPackageName(absPackagePath);
+    if (effectiveTargetName == null) {
+      return const DiscoveredCompanionRoots();
+    }
+
+    final productionRoots = <String>[];
+    final testRoots = <String>[];
+
+    _scanDirectory(
+      dir: Directory(root),
+      depth: 0,
+      targetPackagePath: absPackagePath,
+      targetPackageName: effectiveTargetName,
+      productionRoots: productionRoots,
+      testRoots: testRoots,
+    );
+
+    return DiscoveredCompanionRoots(
+      productionRoots: productionRoots,
+      testRoots: testRoots,
+    );
+  }
+
+  void _scanDirectory({
+    required Directory dir,
+    required int depth,
+    required String targetPackagePath,
+    required String targetPackageName,
+    required List<String> productionRoots,
+    required List<String> testRoots,
+  }) {
+    if (depth > maxDepth) return;
+    if (!dir.existsSync()) return;
+
+    final dirPath = p.normalize(p.absolute(dir.path));
+    final isTargetPkg = p.equals(dirPath, targetPackagePath);
+    var isSiblingPkg = false;
+
+    if (!isTargetPkg) {
+      final pubspecFile = File(p.join(dirPath, 'pubspec.yaml'));
+      if (pubspecFile.existsSync()) {
+        isSiblingPkg = true;
+        _inspectSiblingPackage(
+          packageDir: dir,
+          pubspecFile: pubspecFile,
+          targetPackageName: targetPackageName,
+          productionRoots: productionRoots,
+          testRoots: testRoots,
+        );
+      }
+    }
+
+    if (depth < maxDepth) {
+      try {
+        final entities = dir.listSync(followLinks: false);
+        for (final entity in entities) {
+          if (entity is! Directory) continue;
+          final baseName = p.basename(entity.path);
+          if (_isExcludedDirectory(baseName)) continue;
+          if (isSiblingPkg && _packageInternalDirs.contains(baseName)) {
+            continue;
+          }
+          if (p.equals(
+            p.normalize(p.absolute(entity.path)),
+            targetPackagePath,
+          )) {
+            continue;
+          }
+
+          _scanDirectory(
+            dir: entity,
+            depth: depth + 1,
+            targetPackagePath: targetPackagePath,
+            targetPackageName: targetPackageName,
+            productionRoots: productionRoots,
+            testRoots: testRoots,
+          );
+        }
+      } catch (_) {}
+    }
+  }
+
+  void _inspectSiblingPackage({
+    required Directory packageDir,
+    required File pubspecFile,
+    required String targetPackageName,
+    required List<String> productionRoots,
+    required List<String> testRoots,
+  }) {
+    final dynamic doc;
+    try {
+      final content = pubspecFile.readAsStringSync();
+      doc = loadYaml(content);
+    } catch (_) {
+      return;
+    }
+    if (doc is! Map) return;
+
+    final dependencies = doc['dependencies'];
+    final devDependencies = doc['dev_dependencies'];
+    final dependencyOverrides = doc['dependency_overrides'];
+
+    var referencesTarget = false;
+    if (dependencies is Map && dependencies.containsKey(targetPackageName)) {
+      referencesTarget = true;
+    }
+    if (devDependencies is Map &&
+        devDependencies.containsKey(targetPackageName)) {
+      referencesTarget = true;
+    }
+    if (dependencyOverrides is Map &&
+        dependencyOverrides.containsKey(targetPackageName)) {
+      referencesTarget = true;
+    }
+
+    if (!referencesTarget) return;
+
+    // Ensure sibling package has a valid .dart_tool/package_config.json before ingesting
+    if (!hasPackageConfig(packageDir.path) &&
+        !hasEnclosingPackageConfig(packageDir.path)) {
+      return;
+    }
+
+    // Dual Root Ingestion: sibling lib/ -> productionRoots, sibling test/ -> testRoots
+    final libDir = Directory(p.join(packageDir.path, 'lib'));
+    if (libDir.existsSync()) {
+      _collectDartFiles(libDir, productionRoots);
+    }
+
+    final testDir = Directory(p.join(packageDir.path, 'test'));
+    if (testDir.existsSync()) {
+      _collectDartFiles(testDir, testRoots);
+    }
+  }
+
+  void _collectDartFiles(Directory dir, List<String> destination) {
+    try {
+      for (final entity in dir.listSync(recursive: true, followLinks: false)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        final relPath = p.relative(entity.path, from: dir.path);
+        final segments = p.split(relPath);
+        if (segments.contains('.git') || segments.contains('.dart_tool')) {
+          continue;
+        }
+        final normalized = p.normalize(p.absolute(entity.path));
+        destination.add(normalized);
+      }
+    } catch (_) {}
+  }
+
+  bool _isWorkspaceRoot(Directory dir) {
+    if (Directory(p.join(dir.path, '.git')).existsSync() ||
+        File(p.join(dir.path, '.git')).existsSync()) {
+      return true;
+    }
+    if (File(p.join(dir.path, 'DEPS')).existsSync()) {
+      return true;
+    }
+    if (File(p.join(dir.path, '.gclient')).existsSync()) {
+      return true;
+    }
+    final pubspecFile = File(p.join(dir.path, 'pubspec.yaml'));
+    if (pubspecFile.existsSync()) {
+      try {
+        final content = pubspecFile.readAsStringSync();
+        final doc = loadYaml(content);
+        if (doc is Map &&
+            doc.containsKey('workspace') &&
+            doc['workspace'] != null) {
+          return true;
+        }
+      } catch (_) {}
+    }
+    return false;
+  }
+
+  bool _isExcludedDirectory(String dirName) {
+    for (final pattern in excludedDirectories) {
+      if (pattern == dirName) return true;
+      if (pattern == '$dirName/**' || pattern == '$dirName/*') return true;
+      final clean = pattern.replaceAll('/**', '').replaceAll('/*', '');
+      if (clean == dirName) return true;
+      if (WildcardPattern(pattern).matches(dirName)) return true;
+    }
+    return false;
+  }
+
+  String? _readPackageName(String packagePath) {
+    final pubspecFile = File(p.join(packagePath, 'pubspec.yaml'));
+    if (!pubspecFile.existsSync()) return null;
+    try {
+      final content = pubspecFile.readAsStringSync();
+      final doc = loadYaml(content);
+      if (doc is Map && doc['name'] is String) {
+        return doc['name'] as String;
+      }
+    } catch (_) {}
+    return null;
+  }
+}

--- a/packages/zombie/lib/zombie.dart
+++ b/packages/zombie/lib/zombie.dart
@@ -7,3 +7,4 @@ export 'src/formatters/markdown_formatter.dart';
 export 'src/models.dart';
 export 'src/reachability_engine.dart';
 export 'src/root_harvester.dart';
+export 'src/workspace_discovery.dart';

--- a/packages/zombie/test/cli_test.dart
+++ b/packages/zombie/test/cli_test.dart
@@ -48,6 +48,7 @@ void main() {
       check(stdout).contains('--mode');
       check(stdout).contains('--pub-get');
       check(stdout).contains('fail-on-zombies');
+      check(stdout).contains('workspace-discovery');
     });
 
     test('--version displays version and exits 0', () async {
@@ -338,6 +339,96 @@ environment:
         ]);
 
         await proc.shouldExit(0);
+      },
+    );
+
+    test(
+      'supports --no-workspace-discovery to disable workspace discovery',
+      () async {
+        await d.dir('cli_ws_monorepo', [
+          d.dir('.git', []),
+          d.dir('packages', [
+            d.dir('core_pkg', [
+              packageConfig('core_pkg'),
+              d.file('pubspec.yaml', '''
+name: core_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+              d.dir('lib', [
+                d.file('core_pkg.dart', 'export "src/live.dart";'),
+                d.dir('src', [
+                  d.file('live.dart', 'void live() {}'),
+                  d.file('helper.dart', 'void internalHelper() {}'),
+                ]),
+              ]),
+            ]),
+            d.dir('consumer_pkg', [
+              d.dir('.dart_tool', [
+                d.file('package_config.json', '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "consumer_pkg",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    },
+    {
+      "name": "core_pkg",
+      "rootUri": "../../core_pkg",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    }
+  ]
+}
+'''),
+              ]),
+              d.file('pubspec.yaml', '''
+name: consumer_pkg
+environment:
+  sdk: '^3.5.0'
+dependencies:
+  core_pkg:
+    path: ../core_pkg
+'''),
+              d.dir('lib', [
+                d.file('consumer.dart', '''
+import 'package:core_pkg/src/helper.dart';
+
+void useHelper() {
+  internalHelper();
+}
+'''),
+              ]),
+            ]),
+          ]),
+        ]).create();
+
+        // 1. By default, workspace discovery is active -> helper is protected
+        // (0 pure zombies).
+        final proc1 = await runZombie([
+          '--format=json',
+          d.path('cli_ws_monorepo/packages/core_pkg'),
+        ]);
+        final out1 = await proc1.stdoutStream().join('\n');
+        await proc1.shouldExit(0);
+        final json1 = jsonDecode(out1) as Map<String, dynamic>;
+        final summary1 = json1['summary'] as Map<String, dynamic>;
+        check(summary1['pureZombies']).equals(0);
+
+        // 2. With --no-workspace-discovery, helper is flagged as pure zombie
+        final proc2 = await runZombie([
+          '--format=json',
+          '--no-workspace-discovery',
+          d.path('cli_ws_monorepo/packages/core_pkg'),
+        ]);
+        final out2 = await proc2.stdoutStream().join('\n');
+        await proc2.shouldExit(0);
+        final json2 = jsonDecode(out2) as Map<String, dynamic>;
+        final summary2 = json2['summary'] as Map<String, dynamic>;
+        check(summary2['pureZombies']).equals(1);
       },
     );
   });

--- a/packages/zombie/test/models_test.dart
+++ b/packages/zombie/test/models_test.dart
@@ -168,12 +168,14 @@ void main() {
       check(defaultOptions.includeGenerated).isFalse();
       check(defaultOptions.failOnZombies).isFalse();
       check(defaultOptions.autoPubGet).isFalse();
+      check(defaultOptions.workspaceDiscovery).isTrue();
 
       const customOptions = ZombieOptions(
         packagePath: '/path/to/pkg',
         testSupportPatterns: ['*Stub', 'CustomFixture*'],
         ignoreNamePatterns: ['*_generated', 'Ignored*'],
         extraRoots: ['../companion_test', '/external/tests'],
+        workspaceDiscovery: false,
       );
       check(
         customOptions.testSupportPatterns,
@@ -184,6 +186,7 @@ void main() {
       check(
         customOptions.extraRoots,
       ).deepEquals(['../companion_test', '/external/tests']);
+      check(customOptions.workspaceDiscovery).isFalse();
     });
 
     test('ZombieReport deserializes camelCase JSON summary correctly', () {

--- a/packages/zombie/test/reachability_engine_test.dart
+++ b/packages/zombie/test/reachability_engine_test.dart
@@ -1677,5 +1677,317 @@ class DeadDartHelper {
         check(filteredReport.zombies.single.name).equals('DeadDartHelper');
       },
     );
+
+    test('automatically discovers sibling workspace consumer and protects '
+        'internal helper', () async {
+      await d.dir('ws_monorepo', [
+        d.dir('.git', []),
+        d.dir('packages', [
+          d.dir('core_pkg', [
+            d.dir('.dart_tool', [
+              d.file('package_config.json', '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "core_pkg",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    }
+  ]
+}
+'''),
+            ]),
+            d.file('pubspec.yaml', '''
+name: core_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+            d.dir('lib', [
+              d.file('core_pkg.dart', 'export "src/live.dart";'),
+              d.dir('src', [
+                d.file('live.dart', 'void liveCore() {}'),
+                d.file('internal_helper.dart', 'void internalCoreHelper() {}'),
+                d.file('unused.dart', 'void deadCoreFunc() {}'),
+              ]),
+            ]),
+          ]),
+          d.dir('consumer_pkg', [
+            d.dir('.dart_tool', [
+              d.file('package_config.json', '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "consumer_pkg",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    },
+    {
+      "name": "core_pkg",
+      "rootUri": "../../core_pkg",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    }
+  ]
+}
+'''),
+            ]),
+            d.file('pubspec.yaml', '''
+name: consumer_pkg
+environment:
+  sdk: '^3.5.0'
+dependencies:
+  core_pkg:
+    path: ../core_pkg
+'''),
+            d.dir('lib', [
+              d.file('consumer.dart', '''
+import 'package:core_pkg/src/internal_helper.dart';
+
+void useHelper() {
+  internalCoreHelper();
+}
+'''),
+            ]),
+          ]),
+        ]),
+      ]).create();
+
+      // 1. With workspace discovery (default: true) -> helper is protected!
+      final reportWithWs = await analyzePackage(
+        d.path('ws_monorepo/packages/core_pkg'),
+      );
+      check(reportWithWs.pureZombiesFound).equals(1);
+      check(reportWithWs.zombies.single.name).equals('deadCoreFunc');
+
+      // 2. With workspace discovery disabled -> helper is pure zombie!
+      final reportNoWs = await ZombieEngine(
+        ZombieOptions(
+          packagePath: d.path('ws_monorepo/packages/core_pkg'),
+          workspaceDiscovery: false,
+        ),
+      ).analyze();
+      check(reportNoWs.pureZombiesFound).equals(2);
+      final zombieNames = reportNoWs.zombies.map((z) => z.name).toSet();
+      check(zombieNames).contains('internalCoreHelper');
+      check(zombieNames).contains('deadCoreFunc');
+    });
+
+    test(
+      'supports unified --extra-roots with explicit .dart file and directory '
+      'splitting lib/test',
+      () async {
+        await d.dir('extra_roots_unification_pkg', [
+          packageConfig('extra_roots_unification_pkg'),
+          d.file('pubspec.yaml', '''
+name: extra_roots_unification_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+          d.dir('lib', [
+            d.file(
+              'extra_roots_unification_pkg.dart',
+              'export "src/live.dart";',
+            ),
+            d.dir('src', [
+              d.file('live.dart', 'void liveFunc() {}'),
+              d.file('file_root_helper.dart', 'void fileRootTarget() {}'),
+              d.file('dir_prod_helper.dart', 'void dirProdTarget() {}'),
+              d.file('dir_test_helper.dart', 'void dirTestTarget() {}'),
+              d.file('dead_all.dart', 'void deadAll() {}'),
+            ]),
+          ]),
+        ]).create();
+
+        await d.dir('external_file_root', [
+          d.dir('.dart_tool', [
+            d.file('package_config.json', '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "external_file_root",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    },
+    {
+      "name": "extra_roots_unification_pkg",
+      "rootUri": "../../extra_roots_unification_pkg",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    }
+  ]
+}
+'''),
+          ]),
+          d.file('entrypoint.dart', '''
+import 'package:extra_roots_unification_pkg/src/file_root_helper.dart';
+
+void main() {
+  fileRootTarget();
+}
+'''),
+        ]).create();
+
+        await d.dir('external_companion_pkg', [
+          d.dir('.dart_tool', [
+            d.file('package_config.json', '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "external_companion_pkg",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    },
+    {
+      "name": "extra_roots_unification_pkg",
+      "rootUri": "../../extra_roots_unification_pkg",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    }
+  ]
+}
+'''),
+          ]),
+          d.dir('lib', [
+            d.file('companion.dart', '''
+import 'package:extra_roots_unification_pkg/src/dir_prod_helper.dart';
+
+void companionProd() {
+  dirProdTarget();
+}
+'''),
+          ]),
+          d.dir('test', [
+            d.file('companion_test.dart', '''
+import 'package:extra_roots_unification_pkg/src/dir_test_helper.dart';
+
+void test(String desc, Function body) {}
+
+void main() {
+  test('companion test', () {
+    dirTestTarget();
+  });
+}
+'''),
+          ]),
+        ]).create();
+
+        final options = ZombieOptions(
+          packagePath: d.path('extra_roots_unification_pkg'),
+          extraRoots: [
+            d.path('external_file_root/entrypoint.dart'),
+            d.path('external_companion_pkg'),
+          ],
+          workspaceDiscovery: false,
+        );
+
+        final report = await ZombieEngine(options).analyze();
+        // deadAll is pureZombie
+        check(report.pureZombiesFound).equals(1);
+        check(report.zombies.any((z) => z.name == 'deadAll')).isTrue();
+
+        // dirTestTarget is testedZombie (reached via companion test/ split)
+        check(report.testedZombiesFound).equals(1);
+        final testedZombie = report.zombies.firstWhere(
+          (z) => z.name == 'dirTestTarget',
+        );
+        check(
+          testedZombie.classification,
+        ).equals(ZombieClassification.testedZombie);
+
+        // fileRootTarget and dirProdTarget are LIVE production roots!
+        final zombieNames = report.zombies.map((z) => z.name).toSet();
+        check(zombieNames).not((it) => it.contains('fileRootTarget'));
+        check(zombieNames).not((it) => it.contains('dirProdTarget'));
+      },
+    );
+
+    test(
+      'preserves reachability when sibling consumer uses internal helper from '
+      'lib/src/build/ subdirectory',
+      () async {
+        await d.dir('sibling_build_dir_repo', [
+          d.dir('.git', []),
+          d.dir('packages', [
+            d.dir('core_pkg', [
+              packageConfig('core_pkg'),
+              d.file('pubspec.yaml', '''
+name: core_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+              d.dir('lib', [
+                d.file('core_pkg.dart', 'export "src/live.dart";'),
+                d.dir('src', [
+                  d.file('live.dart', 'void liveCore() {}'),
+                  d.file('helper.dart', 'void buildGenHelper() {}'),
+                  d.file('dead.dart', 'void deadFunc() {}'),
+                ]),
+              ]),
+            ]),
+            d.dir('generator_pkg', [
+              d.dir('.dart_tool', [
+                d.file('package_config.json', '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "generator_pkg",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    },
+    {
+      "name": "core_pkg",
+      "rootUri": "../../core_pkg",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    }
+  ]
+}
+'''),
+              ]),
+              d.file('pubspec.yaml', '''
+name: generator_pkg
+environment:
+  sdk: '^3.5.0'
+dependencies:
+  core_pkg:
+    path: ../core_pkg
+'''),
+              d.dir('lib', [
+                d.dir('src', [
+                  d.dir('build', [
+                    d.file('gen.dart', '''
+import 'package:core_pkg/src/helper.dart';
+
+void runGen() {
+  buildGenHelper();
+}
+'''),
+                  ]),
+                ]),
+              ]),
+            ]),
+          ]),
+        ]).create();
+
+        final report = await analyzePackage(
+          d.path('sibling_build_dir_repo/packages/core_pkg'),
+        );
+
+        check(report.pureZombiesFound).equals(1);
+        check(report.zombies.single.name).equals('deadFunc');
+        final zombieNames = report.zombies.map((z) => z.name).toSet();
+        check(zombieNames).not((it) => it.contains('buildGenHelper'));
+      },
+    );
   });
 }

--- a/packages/zombie/test/root_harvester_test.dart
+++ b/packages/zombie/test/root_harvester_test.dart
@@ -223,5 +223,78 @@ targets:
         check(topology.frameworkRoots).contains('factorySingleQuoted');
       },
     );
+
+    test('harvests companion roots via workspace discovery', () async {
+      await d.dir('harvester_ws', [
+        d.dir('.git', []),
+        d.dir('packages', [
+          d.dir('target_pkg', [
+            packageConfig('target_pkg'),
+            d.file('pubspec.yaml', 'name: target_pkg\n'),
+            d.dir('lib', [d.file('target.dart', 'void main() {}')]),
+          ]),
+          d.dir('consumer_pkg', [
+            packageConfig('consumer_pkg'),
+            d.file('pubspec.yaml', '''
+name: consumer_pkg
+dependencies:
+  target_pkg: any
+'''),
+            d.dir('lib', [d.file('consumer.dart', 'void fn() {}')]),
+            d.dir('test', [d.file('consumer_test.dart', 'void fn() {}')]),
+          ]),
+        ]),
+      ]).create();
+
+      final options = ZombieOptions(
+        packagePath: d.path('harvester_ws/packages/target_pkg'),
+        workspaceDiscovery: true,
+      );
+
+      final harvester = RootHarvester(options);
+      final topology = harvester.harvestTopology();
+
+      check(topology.extraProductionFiles).length.equals(1);
+      check(topology.extraProductionFiles.single).contains('consumer.dart');
+      check(topology.extraTestFiles).length.equals(1);
+      check(topology.extraTestFiles.single).contains('consumer_test.dart');
+    });
+
+    test(
+      'harvests explicit .dart file as extraProductionFiles and splits lib/test directories',
+      () async {
+        await d.dir('harvester_extra_roots', [
+          packageConfig('harvester_extra_roots'),
+          d.file('pubspec.yaml', 'name: harvester_extra_roots\n'),
+          d.dir('lib', [d.file('main.dart', 'void main() {}')]),
+        ]).create();
+
+        await d.dir('external_file', [
+          d.file('standalone.dart', 'void standalone() {}'),
+        ]).create();
+
+        await d.dir('external_dir', [
+          d.dir('lib', [d.file('prod.dart', 'void prod() {}')]),
+          d.dir('test', [d.file('t.dart', 'void t() {}')]),
+        ]).create();
+
+        final options = ZombieOptions(
+          packagePath: d.path('harvester_extra_roots'),
+          extraRoots: [
+            d.path('external_file/standalone.dart'),
+            d.path('external_dir'),
+          ],
+          workspaceDiscovery: false,
+        );
+
+        final harvester = RootHarvester(options);
+        final topology = harvester.harvestTopology();
+
+        check(
+          topology.extraProductionFiles,
+        ).length.equals(2); // standalone.dart & prod.dart
+        check(topology.extraTestFiles).length.equals(1); // t.dart
+      },
+    );
   });
 }

--- a/packages/zombie/test/workspace_discovery_test.dart
+++ b/packages/zombie/test/workspace_discovery_test.dart
@@ -1,0 +1,439 @@
+import 'package:checks/checks.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+import 'package:zombie/zombie.dart';
+
+d.DirectoryDescriptor packageConfig(String pkgName, {String? targetPkgPath}) {
+  return d.dir('.dart_tool', [
+    d.file('package_config.json', '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "$pkgName",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    }${targetPkgPath != null ? ''',
+    {
+      "name": "target_pkg",
+      "rootUri": "$targetPkgPath",
+      "packageUri": "lib/",
+      "languageVersion": "3.5"
+    }''' : ''}
+  ]
+}
+'''),
+  ]);
+}
+
+void main() {
+  group('WorkspaceConsumerDiscovery', () {
+    group('findWorkspaceRoot', () {
+      test('locates workspace root via .git directory', () async {
+        await d.dir('git_repo', [
+          d.dir('.git', []),
+          d.dir('packages', [
+            d.dir('pkg_a', [d.file('pubspec.yaml', 'name: pkg_a\n')]),
+          ]),
+        ]).create();
+
+        const discovery = WorkspaceConsumerDiscovery();
+        final root = discovery.findWorkspaceRoot(
+          d.path('git_repo/packages/pkg_a'),
+        );
+        check(root).equals(p.normalize(d.path('git_repo')));
+      });
+
+      test(
+        'locates workspace root via .git file (worktree/submodule)',
+        () async {
+          await d.dir('git_worktree_repo', [
+            d.file('.git', 'gitdir: /path/to/main/.git/worktrees/wt'),
+            d.dir('packages', [
+              d.dir('pkg_a', [d.file('pubspec.yaml', 'name: pkg_a\n')]),
+            ]),
+          ]).create();
+
+          const discovery = WorkspaceConsumerDiscovery();
+          final root = discovery.findWorkspaceRoot(
+            d.path('git_worktree_repo/packages/pkg_a'),
+          );
+          check(root).equals(p.normalize(d.path('git_worktree_repo')));
+        },
+      );
+
+      test('locates workspace root via DEPS file (Chromium/Engine)', () async {
+        await d.dir('engine_repo', [
+          d.file('DEPS', 'vars = {}'),
+          d.dir('src', [
+            d.dir('flutter', [
+              d.dir('lib', [
+                d.dir('web_ui', [d.file('pubspec.yaml', 'name: web_ui\n')]),
+              ]),
+            ]),
+          ]),
+        ]).create();
+
+        const discovery = WorkspaceConsumerDiscovery();
+        final root = discovery.findWorkspaceRoot(
+          d.path('engine_repo/src/flutter/lib/web_ui'),
+        );
+        check(root).equals(p.normalize(d.path('engine_repo')));
+      });
+
+      test('locates workspace root via .gclient file', () async {
+        await d.dir('gclient_repo', [
+          d.file('.gclient', 'solutions = []'),
+          d.dir('src', [
+            d.dir('pkg_a', [d.file('pubspec.yaml', 'name: pkg_a\n')]),
+          ]),
+        ]).create();
+
+        const discovery = WorkspaceConsumerDiscovery();
+        final root = discovery.findWorkspaceRoot(
+          d.path('gclient_repo/src/pkg_a'),
+        );
+        check(root).equals(p.normalize(d.path('gclient_repo')));
+      });
+
+      test(
+        'locates workspace root via pubspec.yaml with workspace: key',
+        () async {
+          await d.dir('pub_workspace', [
+            d.file('pubspec.yaml', '''
+name: root_workspace
+workspace:
+  - packages/pkg_a
+  - packages/pkg_b
+'''),
+            d.dir('packages', [
+              d.dir('pkg_a', [
+                d.file('pubspec.yaml', '''
+name: pkg_a
+resolution: workspace
+'''),
+              ]),
+            ]),
+          ]).create();
+
+          const discovery = WorkspaceConsumerDiscovery();
+          final root = discovery.findWorkspaceRoot(
+            d.path('pub_workspace/packages/pkg_a'),
+          );
+          check(root).equals(p.normalize(d.path('pub_workspace')));
+        },
+      );
+    });
+
+    group('discoverConsumers', () {
+      test('discovers sibling packages referencing target via path and '
+          'workspace dependencies', () async {
+        await d.dir('monorepo', [
+          d.dir('.git', []),
+          d.dir('packages', [
+            d.dir('target_pkg', [
+              packageConfig('target_pkg'),
+              d.file('pubspec.yaml', '''
+name: target_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+              d.dir('lib', [
+                d.file('target_pkg.dart', 'void publicFunc() {}'),
+                d.dir('src', [
+                  d.file('helper.dart', 'void internalHelper() {}'),
+                ]),
+              ]),
+            ]),
+            d.dir('consumer_prod', [
+              packageConfig('consumer_prod', targetPkgPath: '../../target_pkg'),
+              d.file('pubspec.yaml', '''
+name: consumer_prod
+environment:
+  sdk: '^3.5.0'
+dependencies:
+  target_pkg:
+    path: ../target_pkg
+'''),
+              d.dir('lib', [
+                d.file('consumer.dart', 'void prodConsumer() {}'),
+                d.file('other.dart', 'void otherProd() {}'),
+              ]),
+              d.dir('test', [
+                d.file('consumer_test.dart', 'void testProd() {}'),
+              ]),
+            ]),
+            d.dir('consumer_dev', [
+              packageConfig('consumer_dev', targetPkgPath: '../../target_pkg'),
+              d.file('pubspec.yaml', '''
+name: consumer_dev
+environment:
+  sdk: '^3.5.0'
+dev_dependencies:
+  target_pkg:
+    path: ../target_pkg
+'''),
+              d.dir('lib', [d.file('dev_lib.dart', 'void devLib() {}')]),
+              d.dir('test', [d.file('dev_test.dart', 'void devTest() {}')]),
+            ]),
+            d.dir('unrelated_pkg', [
+              packageConfig('unrelated_pkg'),
+              d.file('pubspec.yaml', '''
+name: unrelated_pkg
+environment:
+  sdk: '^3.5.0'
+dependencies:
+  path: ^1.9.0
+'''),
+              d.dir('lib', [d.file('unrelated.dart', 'void unrelated() {}')]),
+            ]),
+          ]),
+        ]).create();
+
+        const discovery = WorkspaceConsumerDiscovery();
+        final roots = discovery.discoverConsumers(
+          packagePath: d.path('monorepo/packages/target_pkg'),
+        );
+
+        check(roots.isNotEmpty).isTrue();
+
+        // Dual Root Ingestion:
+        // lib/ files in consumer_prod and consumer_dev -> productionRoots
+        final prodNorm = roots.productionRoots.map(p.normalize).toList();
+        check(prodNorm).contains(
+          p.normalize(
+            d.path('monorepo/packages/consumer_prod/lib/consumer.dart'),
+          ),
+        );
+        check(prodNorm).contains(
+          p.normalize(d.path('monorepo/packages/consumer_prod/lib/other.dart')),
+        );
+        check(prodNorm).contains(
+          p.normalize(
+            d.path('monorepo/packages/consumer_dev/lib/dev_lib.dart'),
+          ),
+        );
+        check(prodNorm).not(
+          (c) => c.contains(
+            p.normalize(
+              d.path('monorepo/packages/unrelated_pkg/lib/unrelated.dart'),
+            ),
+          ),
+        );
+
+        // test/ files in consumer_prod and consumer_dev -> testRoots
+        final testNorm = roots.testRoots.map(p.normalize).toList();
+        check(testNorm).contains(
+          p.normalize(
+            d.path('monorepo/packages/consumer_prod/test/consumer_test.dart'),
+          ),
+        );
+        check(testNorm).contains(
+          p.normalize(
+            d.path('monorepo/packages/consumer_dev/test/dev_test.dart'),
+          ),
+        );
+      });
+
+      test(
+        'skips sibling package if .dart_tool/package_config.json is missing',
+        () async {
+          await d.dir('missing_config_repo', [
+            d.dir('.git', []),
+            d.dir('packages', [
+              d.dir('target_pkg', [
+                packageConfig('target_pkg'),
+                d.file('pubspec.yaml', 'name: target_pkg\n'),
+                d.dir('lib', [d.file('target.dart', 'void fn() {}')]),
+              ]),
+              d.dir('unresolved_consumer', [
+                // No .dart_tool/package_config.json
+                d.file('pubspec.yaml', '''
+name: unresolved_consumer
+dependencies:
+  target_pkg:
+    path: ../target_pkg
+'''),
+                d.dir('lib', [d.file('unresolved.dart', 'void fn() {}')]),
+              ]),
+            ]),
+          ]).create();
+
+          const discovery = WorkspaceConsumerDiscovery();
+          final roots = discovery.discoverConsumers(
+            packagePath: d.path('missing_config_repo/packages/target_pkg'),
+          );
+
+          check(roots.isEmpty).isTrue();
+        },
+      );
+
+      test('respects directory exclusions and maxDepth', () async {
+        await d.dir('excluded_repo', [
+          d.dir('.git', []),
+          d.dir('packages', [
+            d.dir('target_pkg', [
+              packageConfig('target_pkg'),
+              d.file('pubspec.yaml', 'name: target_pkg\n'),
+              d.dir('lib', [d.file('target.dart', 'void fn() {}')]),
+            ]),
+            d.dir('build', [
+              d.dir('nested_consumer', [
+                packageConfig('nested_consumer'),
+                d.file('pubspec.yaml', '''
+name: nested_consumer
+dependencies:
+  target_pkg: any
+'''),
+                d.dir('lib', [d.file('built.dart', 'void fn() {}')]),
+              ]),
+            ]),
+            d.dir('example', [
+              d.dir('demo_consumer', [
+                packageConfig('demo_consumer'),
+                d.file('pubspec.yaml', '''
+name: demo_consumer
+dependencies:
+  target_pkg: any
+'''),
+                d.dir('lib', [d.file('demo.dart', 'void fn() {}')]),
+              ]),
+            ]),
+            d.dir('level1', [
+              d.dir('level2', [
+                d.dir('level3', [
+                  d.dir('level4', [
+                    d.dir('level5', [
+                      d.dir('deep_consumer', [
+                        packageConfig('deep_consumer'),
+                        d.file('pubspec.yaml', '''
+name: deep_consumer
+dependencies:
+  target_pkg: any
+'''),
+                        d.dir('lib', [d.file('deep.dart', 'void fn() {}')]),
+                      ]),
+                    ]),
+                  ]),
+                ]),
+              ]),
+            ]),
+          ]),
+        ]).create();
+
+        const discovery = WorkspaceConsumerDiscovery(maxDepth: 3);
+        final roots = discovery.discoverConsumers(
+          packagePath: d.path('excluded_repo/packages/target_pkg'),
+        );
+
+        check(roots.isEmpty).isTrue();
+      });
+
+      test('collects files inside lib/src/build/ and other subdirectories '
+          'without false exclusion', () async {
+        await d.dir('nested_build_repo', [
+          d.dir('.git', []),
+          d.dir('packages', [
+            d.dir('target_pkg', [
+              packageConfig('target_pkg'),
+              d.file('pubspec.yaml', 'name: target_pkg\n'),
+              d.dir('lib', [d.file('target.dart', 'void targetFn() {}')]),
+            ]),
+            d.dir('consumer_with_build_dir', [
+              packageConfig(
+                'consumer_with_build_dir',
+                targetPkgPath: '../../target_pkg',
+              ),
+              d.file('pubspec.yaml', '''
+name: consumer_with_build_dir
+dependencies:
+  target_pkg:
+    path: ../target_pkg
+'''),
+              d.dir('lib', [
+                d.dir('src', [
+                  d.dir('build', [
+                    d.file('code_generator.dart', 'void gen() {}'),
+                  ]),
+                ]),
+              ]),
+              d.dir('test', [
+                d.dir('build', [
+                  d.file('generator_test.dart', 'void testGen() {}'),
+                ]),
+              ]),
+            ]),
+          ]),
+        ]).create();
+
+        const discovery = WorkspaceConsumerDiscovery();
+        final roots = discovery.discoverConsumers(
+          packagePath: d.path('nested_build_repo/packages/target_pkg'),
+        );
+
+        final prodNorm = roots.productionRoots.map(p.normalize).toList();
+        check(prodNorm).contains(
+          p.normalize(
+            d.path(
+              'nested_build_repo/packages/consumer_with_build_dir/lib/src/build/code_generator.dart',
+            ),
+          ),
+        );
+
+        final testNorm = roots.testRoots.map(p.normalize).toList();
+        check(testNorm).contains(
+          p.normalize(
+            d.path(
+              'nested_build_repo/packages/consumer_with_build_dir/test/build/generator_test.dart',
+            ),
+          ),
+        );
+      });
+
+      test(
+        'discovers sibling referencing target via dependency_overrides',
+        () async {
+          await d.dir('overrides_repo', [
+            d.dir('.git', []),
+            d.dir('packages', [
+              d.dir('target_pkg', [
+                packageConfig('target_pkg'),
+                d.file('pubspec.yaml', 'name: target_pkg\n'),
+                d.dir('lib', [d.file('target.dart', 'void targetFn() {}')]),
+              ]),
+              d.dir('override_consumer', [
+                packageConfig(
+                  'override_consumer',
+                  targetPkgPath: '../../target_pkg',
+                ),
+                d.file('pubspec.yaml', '''
+name: override_consumer
+dependency_overrides:
+  target_pkg:
+    path: ../target_pkg
+'''),
+                d.dir('lib', [d.file('override_lib.dart', 'void libFn() {}')]),
+              ]),
+            ]),
+          ]).create();
+
+          const discovery = WorkspaceConsumerDiscovery();
+          final roots = discovery.discoverConsumers(
+            packagePath: d.path('overrides_repo/packages/target_pkg'),
+          );
+
+          final prodNorm = roots.productionRoots.map(p.normalize).toList();
+          check(prodNorm).contains(
+            p.normalize(
+              d.path(
+                'overrides_repo/packages/override_consumer/lib/override_lib.dart',
+              ),
+            ),
+          );
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
- Implement WorkspaceConsumerDiscovery to automatically discover sibling consumer packages in monorepos and Pub Workspaces that depend on the analyzed target package.
- Map sibling lib/ to production roots and sibling test/ to test roots to prevent companion helpers from being misclassified as testedZombie.
- Unify --extra-roots to accept both .dart files (explicit entrypoint roots) and directory paths (companion packages/tests).
- Add --workspace-discovery (default: true) and --no-workspace-discovery CLI flags.
- Verify sibling package .dart_tool/package_config.json before ingesting contexts to prevent InvalidType analyzer cascades.
- Add comprehensive unit and reachability tests.
