### PR TITLE
feat(undead): detect private member candidates via --suggest-private

### DIFF
--- a/.github/workflows/complexity.yml
+++ b/.github/workflows/complexity.yml
@@ -27,3 +27,4 @@ jobs:
           diff-base: origin/${{ github.base_ref }}
           fail-threshold: 15
           fail-on-increase: true
+          targets: packages

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,12 @@ runs:
         cd "$ACTION_PATH"
         dart pub get >/dev/null
         
+        # Auto-detect monorepos when default 'lib' target does not exist
+        targets="$INPUT_TARGETS"
+        if [ "$targets" = "lib" ] && [ ! -d "lib" ] && [ -d "packages" ]; then
+          targets="packages"
+        fi
+        
         # Execute the scanner CLI tool and capture exit code
         set +e
         dart run cognitive_complexity \
@@ -87,7 +93,7 @@ runs:
           --format="$INPUT_FORMAT" \
           $DIFF_ARG \
           $fail_inc_arg \
-          $INPUT_TARGETS
+          $targets
         exit_code=$?
         set -e
 

--- a/packages/undead/CHANGELOG.md
+++ b/packages/undead/CHANGELOG.md
@@ -7,4 +7,6 @@
   (standalone/executables).
 - Custom suppression directives: `// undead:ignore` and
   `// undead:ignore_for_file`.
+- Support `--suggest-private` flag to detect unexported top-level declarations
+  that can be made library-private.
 

--- a/packages/undead/CHANGELOG.md
+++ b/packages/undead/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1-wip
+
+- Support `--suggest-private` flag to detect unexported top-level declarations
+  that can be made library-private.
+
 ## 0.1.0
 
 - Initial release of reachability and dead/unused declaration analyzer.
@@ -7,6 +12,4 @@
   (standalone/executables).
 - Custom suppression directives: `// undead:ignore` and
   `// undead:ignore_for_file`.
-- Support `--suggest-private` flag to detect unexported top-level declarations
-  that can be made library-private.
 

--- a/packages/undead/lib/src/cli.dart
+++ b/packages/undead/lib/src/cli.dart
@@ -9,7 +9,7 @@ import 'formatters/markdown_formatter.dart';
 import 'models.dart';
 import 'reachability_engine.dart';
 
-const String undeadVersion = '0.1.0';
+const String undeadVersion = '0.1.1-wip';
 
 /// Configures and parses CLI arguments for `pkg:undead`.
 ArgParser buildArgParser() {

--- a/packages/undead/lib/src/cli.dart
+++ b/packages/undead/lib/src/cli.dart
@@ -88,6 +88,13 @@ ArgParser buildArgParser() {
           'Automatically discover and ingest consumer roots from sibling '
           'packages in the enclosing workspace.',
     )
+    ..addFlag(
+      'suggest-private',
+      help:
+          'Detect and suggest making internal lib/src declarations private if '
+          'only used within their declaring library.',
+      defaultsTo: false,
+    )
     ..addSdkPathOption()
     ..addFlag(
       'pub-get',
@@ -165,6 +172,7 @@ class UndeadCliRunner {
     final autoPubGet = results.flag('pub-get');
     final ignoreExternalBindings = results.flag('ignore-external-bindings');
     final workspaceDiscovery = results.flag('workspace-discovery');
+    final suggestPrivate = results.flag('suggest-private');
     final sdkPath = results.option('sdk-path');
     final jsonOutputPath = results.option('json-output');
     final testSupportPatterns = _parseCommaSeparated(
@@ -185,6 +193,7 @@ class UndeadCliRunner {
       autoPubGet: autoPubGet,
       ignoreExternalBindings: ignoreExternalBindings,
       workspaceDiscovery: workspaceDiscovery,
+      suggestPrivate: suggestPrivate,
       sdkPath: sdkPath,
       jsonOutputPath: jsonOutputPath,
       testSupportPatterns: testSupportPatterns,

--- a/packages/undead/lib/src/formatters/markdown_formatter.dart
+++ b/packages/undead/lib/src/formatters/markdown_formatter.dart
@@ -7,12 +7,49 @@ class MarkdownFormatter {
 
   String format(UndeadReport report) {
     final buffer = StringBuffer();
-    buffer.writeln('# Undead Code Analysis: `${report.package}`');
-    buffer.writeln();
+    buffer.writeln('# Undead Code Analysis: `${report.package}`\n');
 
-    // Summary Section
-    buffer.writeln('### Summary');
-    buffer.writeln();
+    _writeSummary(buffer, report);
+
+    if (report.undead.isEmpty) {
+      buffer.writeln('🎉 **No undead declarations detected across package.**');
+      return buffer.toString();
+    }
+
+    _writePureUndead(
+      buffer,
+      report.undead
+          .where((z) => z.classification == UndeadClassification.pureUndead)
+          .toList(),
+    );
+    _writeTestedUndead(
+      buffer,
+      report.undead
+          .where((z) => z.classification == UndeadClassification.testedUndead)
+          .toList(),
+    );
+    _writeCoInvokedHazards(
+      buffer,
+      report.undead
+          .where(
+            (z) => z.classification == UndeadClassification.coInvokedHazard,
+          )
+          .toList(),
+    );
+    _writePrivateCandidates(
+      buffer,
+      report.undead
+          .where(
+            (z) => z.classification == UndeadClassification.privateCandidate,
+          )
+          .toList(),
+    );
+
+    return buffer.toString();
+  }
+
+  static void _writeSummary(StringBuffer buffer, UndeadReport report) {
+    buffer.writeln('### Summary\n');
     buffer.writeln('| Metric | Count |');
     buffer.writeln('| :--- | :--- |');
     buffer.writeln(
@@ -29,103 +66,95 @@ class MarkdownFormatter {
       );
     }
     buffer.writeln();
+  }
 
-    if (report.undead.isEmpty) {
-      buffer.writeln('🎉 **No undead declarations detected across package.**');
-      return buffer.toString();
-    }
-
-    final pureUndead = report.undead
-        .where((z) => z.classification == UndeadClassification.pureUndead)
-        .toList();
-    final testedUndead = report.undead
-        .where((z) => z.classification == UndeadClassification.testedUndead)
-        .toList();
-    final coInvokedHazards = report.undead
-        .where((z) => z.classification == UndeadClassification.coInvokedHazard)
-        .toList();
-    final privateCandidates = report.undead
-        .where((z) => z.classification == UndeadClassification.privateCandidate)
-        .toList();
-
-    if (pureUndead.isNotEmpty) {
-      buffer.writeln('## Pure Undead (Safe to Delete)');
-      buffer.writeln();
-      buffer.writeln('| Symbol | Kind | Location | Suggested Action |');
-      buffer.writeln('| :--- | :--- | :--- | :--- |');
-      for (final z in pureUndead) {
-        final loc = '${z.file}:${z.line}:${z.column}';
-        buffer.writeln(
-          '| `${z.name}` | ${z.kind.jsonValue} | `$loc` | Delete declaration |',
-        );
-      }
-      buffer.writeln();
-    }
-
-    if (testedUndead.isNotEmpty) {
-      buffer.writeln('## Tested Undead (Orphan Tests)');
-      buffer.writeln();
+  static void _writePureUndead(
+    StringBuffer buffer,
+    List<UndeadFinding> findings,
+  ) {
+    if (findings.isEmpty) return;
+    buffer.writeln('## Pure Undead (Safe to Delete)\n');
+    buffer.writeln('| Symbol | Kind | Location | Suggested Action |');
+    buffer.writeln('| :--- | :--- | :--- | :--- |');
+    for (final z in findings) {
+      final loc = '${z.file}:${z.line}:${z.column}';
       buffer.writeln(
-        '| Symbol | Kind | Location | Orphan Test Sites | Suggested Action |',
+        '| `${z.name}` | ${z.kind.jsonValue} | `$loc` | Delete declaration |',
       );
-      buffer.writeln('| :--- | :--- | :--- | :--- | :--- |');
-      for (final z in testedUndead) {
-        final loc = '${z.file}:${z.line}:${z.column}';
-        final testSites = (z.orphanTests ?? [])
-            .map((t) {
-              final desc = t.description != null ? ' ("${t.description}")' : '';
-              return '`${t.file}:${t.line}`$desc';
-            })
-            .join('<br>');
-        buffer.writeln(
-          '| `${z.name}` | ${z.kind.jsonValue} | `$loc` | $testSites | '
-          'Delete declaration + orphan test block |',
-        );
-      }
-      buffer.writeln();
     }
+    buffer.writeln();
+  }
 
-    if (coInvokedHazards.isNotEmpty) {
+  static void _writeTestedUndead(
+    StringBuffer buffer,
+    List<UndeadFinding> findings,
+  ) {
+    if (findings.isEmpty) return;
+    buffer.writeln('## Tested Undead (Orphan Tests)\n');
+    buffer.writeln(
+      '| Symbol | Kind | Location | Orphan Test Sites | Suggested Action |',
+    );
+    buffer.writeln('| :--- | :--- | :--- | :--- | :--- |');
+    for (final z in findings) {
+      final loc = '${z.file}:${z.line}:${z.column}';
+      final testSites = (z.orphanTests ?? [])
+          .map((t) {
+            final desc = t.description != null ? ' ("${t.description}")' : '';
+            return '`${t.file}:${t.line}`$desc';
+          })
+          .join('<br>');
       buffer.writeln(
-        '## Co-Invoked Test Hazards (Manual Refactoring Required)',
+        '| `${z.name}` | ${z.kind.jsonValue} | `$loc` | $testSites | '
+        'Delete declaration + orphan test block |',
       );
-      buffer.writeln();
+    }
+    buffer.writeln();
+  }
+
+  static void _writeCoInvokedHazards(
+    StringBuffer buffer,
+    List<UndeadFinding> findings,
+  ) {
+    if (findings.isEmpty) return;
+    buffer.writeln(
+      '## Co-Invoked Test Hazards (Manual Refactoring Required)\n',
+    );
+    buffer.writeln(
+      '| Symbol | Kind | Location | Co-Invoked Test Sites | '
+      'Suggested Action |',
+    );
+    buffer.writeln('| :--- | :--- | :--- | :--- | :--- |');
+    for (final z in findings) {
+      final loc = '${z.file}:${z.line}:${z.column}';
+      final testSites = (z.orphanTests ?? [])
+          .map((t) {
+            final desc = t.description != null ? ' ("${t.description}")' : '';
+            return '`${t.file}:${t.line}`$desc';
+          })
+          .join('<br>');
       buffer.writeln(
-        '| Symbol | Kind | Location | Co-Invoked Test Sites | '
-        'Suggested Action |',
+        '| `${z.name}` | ${z.kind.jsonValue} | `$loc` | $testSites | '
+        'Manual refactoring required |',
       );
-      buffer.writeln('| :--- | :--- | :--- | :--- | :--- |');
-      for (final z in coInvokedHazards) {
-        final loc = '${z.file}:${z.line}:${z.column}';
-        final testSites = (z.orphanTests ?? [])
-            .map((t) {
-              final desc = t.description != null ? ' ("${t.description}")' : '';
-              return '`${t.file}:${t.line}`$desc';
-            })
-            .join('<br>');
-        buffer.writeln(
-          '| `${z.name}` | ${z.kind.jsonValue} | `$loc` | $testSites | '
-          'Manual refactoring required |',
-        );
-      }
-      buffer.writeln();
     }
+    buffer.writeln();
+  }
 
-    if (privateCandidates.isNotEmpty) {
-      buffer.writeln('## Private Candidates (Suggest Library-Private)');
-      buffer.writeln();
-      buffer.writeln('| Symbol | Kind | Location | Suggested Action |');
-      buffer.writeln('| :--- | :--- | :--- | :--- |');
-      for (final z in privateCandidates) {
-        final loc = '${z.file}:${z.line}:${z.column}';
-        buffer.writeln(
-          '| `${z.name}` | ${z.kind.jsonValue} | `$loc` | '
-          'Make library-private (prefix with `_`) |',
-        );
-      }
-      buffer.writeln();
+  static void _writePrivateCandidates(
+    StringBuffer buffer,
+    List<UndeadFinding> findings,
+  ) {
+    if (findings.isEmpty) return;
+    buffer.writeln('## Private Candidates (Suggest Library-Private)\n');
+    buffer.writeln('| Symbol | Kind | Location | Suggested Action |');
+    buffer.writeln('| :--- | :--- | :--- | :--- |');
+    for (final z in findings) {
+      final loc = '${z.file}:${z.line}:${z.column}';
+      buffer.writeln(
+        '| `${z.name}` | ${z.kind.jsonValue} | `$loc` | '
+        'Make library-private (prefix with `_`) |',
+      );
     }
-
-    return buffer.toString();
+    buffer.writeln();
   }
 }

--- a/packages/undead/lib/src/formatters/markdown_formatter.dart
+++ b/packages/undead/lib/src/formatters/markdown_formatter.dart
@@ -23,6 +23,11 @@ class MarkdownFormatter {
     buffer.writeln(
       '| **Co-Invoked Hazards** | ${report.coInvokedHazardsFound} |',
     );
+    if (report.privateCandidatesFound > 0) {
+      buffer.writeln(
+        '| **Private Candidates** | ${report.privateCandidatesFound} |',
+      );
+    }
     buffer.writeln();
 
     if (report.undead.isEmpty) {
@@ -38,6 +43,9 @@ class MarkdownFormatter {
         .toList();
     final coInvokedHazards = report.undead
         .where((z) => z.classification == UndeadClassification.coInvokedHazard)
+        .toList();
+    final privateCandidates = report.undead
+        .where((z) => z.classification == UndeadClassification.privateCandidate)
         .toList();
 
     if (pureUndead.isNotEmpty) {
@@ -98,6 +106,21 @@ class MarkdownFormatter {
         buffer.writeln(
           '| `${z.name}` | ${z.kind.jsonValue} | `$loc` | $testSites | '
           'Manual refactoring required |',
+        );
+      }
+      buffer.writeln();
+    }
+
+    if (privateCandidates.isNotEmpty) {
+      buffer.writeln('## Private Candidates (Suggest Library-Private)');
+      buffer.writeln();
+      buffer.writeln('| Symbol | Kind | Location | Suggested Action |');
+      buffer.writeln('| :--- | :--- | :--- | :--- |');
+      for (final z in privateCandidates) {
+        final loc = '${z.file}:${z.line}:${z.column}';
+        buffer.writeln(
+          '| `${z.name}` | ${z.kind.jsonValue} | `$loc` | '
+          'Make library-private (prefix with `_`) |',
         );
       }
       buffer.writeln();

--- a/packages/undead/lib/src/models.dart
+++ b/packages/undead/lib/src/models.dart
@@ -17,7 +17,12 @@ enum UndeadClassification {
 
   /// A declaration referenced only in tests, but co-invoked within test blocks
   /// that also exercise live production code. Requires manual refactoring.
-  coInvokedHazard('coInvokedHazard', 'Co-Invoked Test Hazard');
+  coInvokedHazard('coInvokedHazard', 'Co-Invoked Test Hazard'),
+
+  /// A declaration referenced only within its declaring library (and its parts)
+  /// with zero cross-library references and zero test references. Candidate to
+  /// be made library-private.
+  privateCandidate('privateCandidate', 'Private Candidate');
 
   final String jsonValue;
   final String displayName;
@@ -28,6 +33,7 @@ enum UndeadClassification {
     'pureUndead' => pureUndead,
     'testedUndead' => testedUndead,
     'coInvokedHazard' => coInvokedHazard,
+    'privateCandidate' => privateCandidate,
     _ => throw ArgumentError.value(
       value,
       'value',
@@ -73,6 +79,7 @@ abstract final class SuggestedAction {
   static const String delete = 'delete';
   static const String deleteWithOrphanTests = 'deleteWithOrphanTests';
   static const String manualRefactorHazard = 'manualRefactorHazard';
+  static const String makePrivate = 'makePrivate';
 }
 
 /// How code in `example/` is treated during reachability analysis.
@@ -153,6 +160,7 @@ final class UndeadOptions {
   final List<String> extraRoots;
   final bool ignoreExternalBindings;
   final bool workspaceDiscovery;
+  final bool suggestPrivate;
 
   const UndeadOptions({
     required this.packagePath,
@@ -170,6 +178,7 @@ final class UndeadOptions {
     this.extraRoots = const [],
     this.ignoreExternalBindings = false,
     this.workspaceDiscovery = true,
+    this.suggestPrivate = false,
   });
 }
 
@@ -283,6 +292,7 @@ class UndeadReport {
   final int pureUndeadFound;
   final int testedUndeadFound;
   final int coInvokedHazardsFound;
+  final int privateCandidatesFound;
   final List<UndeadFinding> undead;
 
   const UndeadReport({
@@ -292,6 +302,7 @@ class UndeadReport {
     required this.pureUndeadFound,
     required this.testedUndeadFound,
     required this.coInvokedHazardsFound,
+    this.privateCandidatesFound = 0,
     required this.undead,
   });
 
@@ -311,6 +322,10 @@ class UndeadReport {
           (summary['testedUndeads'] as int?) ??
           0,
       coInvokedHazardsFound: summary['coInvokedHazards'] as int,
+      privateCandidatesFound:
+          (summary['privateCandidates'] as int?) ??
+          (summary['privateCandidate'] as int?) ??
+          0,
       undead: findingsList
           .map((e) => UndeadFinding.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -325,6 +340,7 @@ class UndeadReport {
       'pureUndead': pureUndeadFound,
       'testedUndead': testedUndeadFound,
       'coInvokedHazards': coInvokedHazardsFound,
+      'privateCandidates': privateCandidatesFound,
     },
     'undead': undead.map((z) => z.toJson()).toList(),
   };

--- a/packages/undead/lib/src/reachability_engine.dart
+++ b/packages/undead/lib/src/reachability_engine.dart
@@ -664,7 +664,7 @@ class UndeadEngine {
     });
 
     return UndeadReport(
-      version: '0.1.0',
+      version: '0.1.1-wip',
       package: topology.packageName,
       totalDeclarations: totalDeclarationsCount,
       pureUndeadFound: pureUndead,

--- a/packages/undead/lib/src/reachability_engine.dart
+++ b/packages/undead/lib/src/reachability_engine.dart
@@ -90,44 +90,12 @@ class UndeadEngine {
       final role = topology.roleOf(relPath);
 
       // Collect conditional imports in directives.
-      for (final directive in unitResult.unit.directives) {
-        if (directive is NamespaceDirective &&
-            directive.configurations.isNotEmpty) {
-          final targets = <String>{};
-          final defaultUri = directive.uri.stringValue;
-          if (defaultUri != null && defaultUri.isNotEmpty) {
-            final resolvedTarget = _resolveUri(
-              relPath,
-              defaultUri,
-              topology.packageName,
-            );
-            if (resolvedTarget != null) {
-              targets.add(resolvedTarget);
-            }
-          }
-          for (final config in directive.configurations) {
-            final uriStr = config.uri.stringValue;
-            if (uriStr != null && uriStr.isNotEmpty) {
-              final resolvedTarget = _resolveUri(
-                relPath,
-                uriStr,
-                topology.packageName,
-              );
-              if (resolvedTarget != null) {
-                targets.add(resolvedTarget);
-              }
-            }
-          }
-          if (targets.isNotEmpty) {
-            final allGroupFiles = {relPath, ...targets};
-            for (final file in allGroupFiles) {
-              conditionalTargets
-                  .putIfAbsent(file, () => {})
-                  .addAll(allGroupFiles.where((f) => f != file));
-            }
-          }
-        }
-      }
+      _collectConditionalImports(
+        directives: unitResult.unit.directives,
+        relPath: relPath,
+        packageName: topology.packageName,
+        conditionalTargets: conditionalTargets,
+      );
 
       // Collect file-level export directive references.
       final fileDirectivesExtractor = ElementReferenceExtractor(
@@ -340,19 +308,13 @@ class UndeadEngine {
           final targetNode = resolveNodeForElement(refElem);
           if (targetNode != null && targetNode.id != node.id) {
             node.outgoingTargetIds.add(targetNode.id);
-            if (isTestNode) {
-              testReferencedIds.add(targetNode.id);
-              crossLibraryReferenced.add(targetNode.id);
-            } else {
-              final isCrossLibrary =
-                  (node.element?.library != null &&
-                      targetNode.element?.library != null)
-                  ? node.element!.library != targetNode.element!.library
-                  : node.relativeFilePath != targetNode.relativeFilePath;
-              if (isCrossLibrary) {
-                crossLibraryReferenced.add(targetNode.id);
-              }
-            }
+            _trackEdge(
+              node,
+              targetNode,
+              isTestNode: isTestNode,
+              crossLibraryReferenced: crossLibraryReferenced,
+              testReferencedIds: testReferencedIds,
+            );
           }
         }
       }
@@ -365,19 +327,13 @@ class UndeadEngine {
             if (parentNode.isSealed) {
               sealedSubtypes.putIfAbsent(parentNode.id, () => {}).add(node.id);
             }
-            if (isTestNode) {
-              testReferencedIds.add(parentNode.id);
-              crossLibraryReferenced.add(parentNode.id);
-            } else {
-              final isCrossLibrary =
-                  (node.element?.library != null &&
-                      parentNode.element?.library != null)
-                  ? node.element!.library != parentNode.element!.library
-                  : node.relativeFilePath != parentNode.relativeFilePath;
-              if (isCrossLibrary) {
-                crossLibraryReferenced.add(parentNode.id);
-              }
-            }
+            _trackEdge(
+              node,
+              parentNode,
+              isTestNode: isTestNode,
+              crossLibraryReferenced: crossLibraryReferenced,
+              testReferencedIds: testReferencedIds,
+            );
           }
         }
       }
@@ -686,48 +642,17 @@ class UndeadEngine {
     }
 
     var privateCandidates = 0;
-
     if (options.suggestPrivate) {
-      for (final node in allNodes) {
-        final role = topology.roleOf(node.relativeFilePath);
-        final isCandidateScope = switch (role) {
-          FileRole.internalSrc => true,
-          FileRole.publicLib when options.mode == AnalysisMode.closedApp =>
-            true,
-          _ => false,
-        };
-
-        if (!isCandidateScope) continue;
-        if (node.name.startsWith('_')) continue;
-        if (node.isIgnored) continue;
-        if (node.isNativeRoot) continue;
-        if (node.isExternalBinding) continue;
-        if (node.isTestSupport) continue;
-        if (WildcardPattern.anyMatch(_ignoreNameWildcards, node.name)) continue;
-        if (WildcardPattern.anyMatch(_testSupportWildcards, node.name)) {
-          continue;
-        }
-        if (exportedNodeIds.contains(node.id)) continue;
-        if (!productionLive.contains(node.id)) continue;
-        if (crossLibraryReferenced.contains(node.id)) continue;
-        if (testReferencedIds.contains(node.id)) continue;
-
-        privateCandidates++;
-        findings.add(
-          UndeadFinding(
-            id: node.name,
-            name: node.name,
-            kind: node.kind,
-            file: node.relativeFilePath,
-            line: node.line,
-            column: node.column,
-            length: node.length,
-            classification: UndeadClassification.privateCandidate,
-            suggestedAction: SuggestedAction.makePrivate,
-            isExternalBinding: node.isExternalBinding,
-          ),
-        );
-      }
+      final candidates = _collectPrivateCandidates(
+        allNodes: allNodes,
+        topology: topology,
+        exportedNodeIds: exportedNodeIds,
+        productionLive: productionLive,
+        crossLibraryReferenced: crossLibraryReferenced,
+        testReferencedIds: testReferencedIds,
+      );
+      privateCandidates = candidates.length;
+      findings.addAll(candidates);
     }
 
     findings.sort((a, b) {
@@ -749,6 +674,144 @@ class UndeadEngine {
       undead: findings,
     );
   }
+
+  static Set<String> _extractDirectiveTargets(
+    NamespaceDirective directive,
+    String relPath,
+    String packageName,
+  ) {
+    final targets = <String>{};
+    final defaultUri = directive.uri.stringValue;
+    if (defaultUri != null && defaultUri.isNotEmpty) {
+      final resolved = _resolveUri(relPath, defaultUri, packageName);
+      if (resolved != null) {
+        targets.add(resolved);
+      }
+    }
+    for (final config in directive.configurations) {
+      final uriStr = config.uri.stringValue;
+      if (uriStr != null && uriStr.isNotEmpty) {
+        final resolved = _resolveUri(relPath, uriStr, packageName);
+        if (resolved != null) {
+          targets.add(resolved);
+        }
+      }
+    }
+    return targets;
+  }
+
+  static void _collectConditionalImports({
+    required List<Directive> directives,
+    required String relPath,
+    required String packageName,
+    required Map<String, Set<String>> conditionalTargets,
+  }) {
+    for (final directive in directives) {
+      if (directive is! NamespaceDirective ||
+          directive.configurations.isEmpty) {
+        continue;
+      }
+      final targets = _extractDirectiveTargets(directive, relPath, packageName);
+      if (targets.isEmpty) continue;
+
+      final allGroupFiles = {relPath, ...targets};
+      for (final file in allGroupFiles) {
+        conditionalTargets
+            .putIfAbsent(file, () => {})
+            .addAll(allGroupFiles.where((f) => f != file));
+      }
+    }
+  }
+
+  static bool _isCrossLibrary(DeclarationNode source, DeclarationNode target) {
+    final sourceLib = source.element?.library;
+    final targetLib = target.element?.library;
+    if (sourceLib != null && targetLib != null) {
+      return sourceLib != targetLib;
+    }
+    return source.relativeFilePath != target.relativeFilePath;
+  }
+
+  static void _trackEdge(
+    DeclarationNode source,
+    DeclarationNode target, {
+    required bool isTestNode,
+    required Set<String> crossLibraryReferenced,
+    required Set<String> testReferencedIds,
+  }) {
+    if (isTestNode) {
+      testReferencedIds.add(target.id);
+      crossLibraryReferenced.add(target.id);
+    } else if (_isCrossLibrary(source, target)) {
+      crossLibraryReferenced.add(target.id);
+    }
+  }
+
+  bool _isPrivateCandidate(
+    DeclarationNode node, {
+    required PackageTopology topology,
+    required Set<String> exportedNodeIds,
+    required Set<String> productionLive,
+    required Set<String> crossLibraryReferenced,
+    required Set<String> testReferencedIds,
+  }) {
+    final role = topology.roleOf(node.relativeFilePath);
+    final isCandidateScope = switch (role) {
+      FileRole.internalSrc => true,
+      FileRole.publicLib when options.mode == AnalysisMode.closedApp => true,
+      _ => false,
+    };
+
+    if (!isCandidateScope) return false;
+    if (node.name.startsWith('_')) return false;
+    if (node.isIgnored) return false;
+    if (node.isNativeRoot) return false;
+    if (node.isExternalBinding) return false;
+    if (node.isTestSupport) return false;
+    if (WildcardPattern.anyMatch(_ignoreNameWildcards, node.name)) return false;
+    if (WildcardPattern.anyMatch(_testSupportWildcards, node.name)) {
+      return false;
+    }
+    if (exportedNodeIds.contains(node.id)) return false;
+    if (!productionLive.contains(node.id)) return false;
+    if (crossLibraryReferenced.contains(node.id)) return false;
+    if (testReferencedIds.contains(node.id)) return false;
+    return true;
+  }
+
+  List<UndeadFinding> _collectPrivateCandidates({
+    required List<DeclarationNode> allNodes,
+    required PackageTopology topology,
+    required Set<String> exportedNodeIds,
+    required Set<String> productionLive,
+    required Set<String> crossLibraryReferenced,
+    required Set<String> testReferencedIds,
+  }) => allNodes
+      .where(
+        (node) => _isPrivateCandidate(
+          node,
+          topology: topology,
+          exportedNodeIds: exportedNodeIds,
+          productionLive: productionLive,
+          crossLibraryReferenced: crossLibraryReferenced,
+          testReferencedIds: testReferencedIds,
+        ),
+      )
+      .map(
+        (node) => UndeadFinding(
+          id: node.name,
+          name: node.name,
+          kind: node.kind,
+          file: node.relativeFilePath,
+          line: node.line,
+          column: node.column,
+          length: node.length,
+          classification: UndeadClassification.privateCandidate,
+          suggestedAction: SuggestedAction.makePrivate,
+          isExternalBinding: node.isExternalBinding,
+        ),
+      )
+      .toList();
 
   Set<String> _runBfs({
     required Set<String> startIds,
@@ -816,7 +879,7 @@ class UndeadEngine {
     return (DeclarationKind.function, false);
   }
 
-  String? _resolveUri(
+  static String? _resolveUri(
     String currentRelPath,
     String uriString,
     String packageName,

--- a/packages/undead/lib/src/reachability_engine.dart
+++ b/packages/undead/lib/src/reachability_engine.dart
@@ -327,13 +327,32 @@ class UndeadEngine {
     }
 
     // Step 2: Connect reference edges and sealed hierarchies.
+    final crossLibraryReferenced = <String>{};
+    final testReferencedIds = <String>{};
+
     for (final node in allNodes) {
+      final isTestNode =
+          topology.roleOf(node.relativeFilePath) == FileRole.test ||
+          topology.extraTestFiles.contains(node.relativeFilePath);
       final outbound = nodeOutboundElements[node];
       if (outbound != null) {
         for (final refElem in outbound) {
           final targetNode = resolveNodeForElement(refElem);
           if (targetNode != null && targetNode.id != node.id) {
             node.outgoingTargetIds.add(targetNode.id);
+            if (isTestNode) {
+              testReferencedIds.add(targetNode.id);
+              crossLibraryReferenced.add(targetNode.id);
+            } else {
+              final isCrossLibrary =
+                  (node.element?.library != null &&
+                      targetNode.element?.library != null)
+                  ? node.element!.library != targetNode.element!.library
+                  : node.relativeFilePath != targetNode.relativeFilePath;
+              if (isCrossLibrary) {
+                crossLibraryReferenced.add(targetNode.id);
+              }
+            }
           }
         }
       }
@@ -342,8 +361,23 @@ class UndeadEngine {
       if (superElems != null) {
         for (final superElem in superElems) {
           final parentNode = resolveNodeForElement(superElem);
-          if (parentNode != null && parentNode.isSealed) {
-            sealedSubtypes.putIfAbsent(parentNode.id, () => {}).add(node.id);
+          if (parentNode != null) {
+            if (parentNode.isSealed) {
+              sealedSubtypes.putIfAbsent(parentNode.id, () => {}).add(node.id);
+            }
+            if (isTestNode) {
+              testReferencedIds.add(parentNode.id);
+              crossLibraryReferenced.add(parentNode.id);
+            } else {
+              final isCrossLibrary =
+                  (node.element?.library != null &&
+                      parentNode.element?.library != null)
+                  ? node.element!.library != parentNode.element!.library
+                  : node.relativeFilePath != parentNode.relativeFilePath;
+              if (isCrossLibrary) {
+                crossLibraryReferenced.add(parentNode.id);
+              }
+            }
           }
         }
       }
@@ -362,6 +396,7 @@ class UndeadEngine {
       for (final sourceNode in sourceNodes) {
         for (final targetNode in targetNodes) {
           sourceNode.outgoingTargetIds.add(targetNode.id);
+          crossLibraryReferenced.add(targetNode.id);
         }
       }
     }
@@ -373,6 +408,8 @@ class UndeadEngine {
           final targetNode = resolveNodeForElement(elem);
           if (targetNode != null) {
             site.referencedDeclarationIds.add(targetNode.id);
+            testReferencedIds.add(targetNode.id);
+            crossLibraryReferenced.add(targetNode.id);
           }
         }
       }
@@ -381,6 +418,7 @@ class UndeadEngine {
     // Step 3: Identify roots for Production and Tests.
     final productionRoots = <String>{};
     final testRoots = <String>{};
+    final exportedNodeIds = <String>{};
 
     // 3.1 Public API roots (Open-World Invariant under library mode).
     if (options.mode == AnalysisMode.library) {
@@ -396,6 +434,8 @@ class UndeadEngine {
               final node = elementToNode[topLevel];
               if (node != null) {
                 productionRoots.add(node.id);
+                exportedNodeIds.add(node.id);
+                crossLibraryReferenced.add(node.id);
               }
             }
           }
@@ -405,6 +445,8 @@ class UndeadEngine {
         for (final node in allNodes) {
           if (node.relativeFilePath == relPath && !node.name.startsWith('_')) {
             productionRoots.add(node.id);
+            exportedNodeIds.add(node.id);
+            crossLibraryReferenced.add(node.id);
           }
         }
 
@@ -416,6 +458,8 @@ class UndeadEngine {
               if (node.relativeFilePath == targetRelPath &&
                   !node.name.startsWith('_')) {
                 productionRoots.add(node.id);
+                exportedNodeIds.add(node.id);
+                crossLibraryReferenced.add(node.id);
               }
             }
           }
@@ -641,6 +685,51 @@ class UndeadEngine {
       }
     }
 
+    var privateCandidates = 0;
+
+    if (options.suggestPrivate) {
+      for (final node in allNodes) {
+        final role = topology.roleOf(node.relativeFilePath);
+        final isCandidateScope = switch (role) {
+          FileRole.internalSrc => true,
+          FileRole.publicLib when options.mode == AnalysisMode.closedApp =>
+            true,
+          _ => false,
+        };
+
+        if (!isCandidateScope) continue;
+        if (node.name.startsWith('_')) continue;
+        if (node.isIgnored) continue;
+        if (node.isNativeRoot) continue;
+        if (node.isExternalBinding) continue;
+        if (node.isTestSupport) continue;
+        if (WildcardPattern.anyMatch(_ignoreNameWildcards, node.name)) continue;
+        if (WildcardPattern.anyMatch(_testSupportWildcards, node.name)) {
+          continue;
+        }
+        if (exportedNodeIds.contains(node.id)) continue;
+        if (!productionLive.contains(node.id)) continue;
+        if (crossLibraryReferenced.contains(node.id)) continue;
+        if (testReferencedIds.contains(node.id)) continue;
+
+        privateCandidates++;
+        findings.add(
+          UndeadFinding(
+            id: node.name,
+            name: node.name,
+            kind: node.kind,
+            file: node.relativeFilePath,
+            line: node.line,
+            column: node.column,
+            length: node.length,
+            classification: UndeadClassification.privateCandidate,
+            suggestedAction: SuggestedAction.makePrivate,
+            isExternalBinding: node.isExternalBinding,
+          ),
+        );
+      }
+    }
+
     findings.sort((a, b) {
       final fileComp = a.file.compareTo(b.file);
       if (fileComp != 0) return fileComp;
@@ -656,6 +745,7 @@ class UndeadEngine {
       pureUndeadFound: pureUndead,
       testedUndeadFound: testedUndead,
       coInvokedHazardsFound: coInvokedHazards,
+      privateCandidatesFound: privateCandidates,
       undead: findings,
     );
   }
@@ -816,7 +906,28 @@ Future<UndeadReport> analyzePackage(
   String packagePath, {
   UndeadOptions? options,
 }) async {
-  final opts = options ?? UndeadOptions(packagePath: packagePath);
+  final opts = options == null
+      ? UndeadOptions(packagePath: packagePath)
+      : (options.packagePath.isEmpty
+            ? UndeadOptions(
+                packagePath: packagePath,
+                format: options.format,
+                exampleMode: options.exampleMode,
+                mode: options.mode,
+                includeGenerated: options.includeGenerated,
+                failOnUndead: options.failOnUndead,
+                autoPubGet: options.autoPubGet,
+                sdkPath: options.sdkPath,
+                jsonOutputPath: options.jsonOutputPath,
+                frameworkAdapter: options.frameworkAdapter,
+                testSupportPatterns: options.testSupportPatterns,
+                ignoreNamePatterns: options.ignoreNamePatterns,
+                extraRoots: options.extraRoots,
+                ignoreExternalBindings: options.ignoreExternalBindings,
+                workspaceDiscovery: options.workspaceDiscovery,
+                suggestPrivate: options.suggestPrivate,
+              )
+            : options);
   final engine = UndeadEngine(opts);
   return engine.analyze();
 }

--- a/packages/undead/pubspec.yaml
+++ b/packages/undead/pubspec.yaml
@@ -1,6 +1,6 @@
 name: undead
 description: Reachability and dead/unused declaration analysis for Dart and Flutter packages.
-version: 0.1.0
+version: 0.1.1-wip
 repository: https://github.com/kevmoo/analytica.dart/tree/main/packages/undead
 
 resolution: workspace

--- a/packages/undead/test/cli_test.dart
+++ b/packages/undead/test/cli_test.dart
@@ -47,6 +47,7 @@ void main() {
       check(stdout).contains('--example-mode');
       check(stdout).contains('--mode');
       check(stdout).contains('--pub-get');
+      check(stdout).contains('suggest-private');
       check(stdout).contains('fail-on-undead');
       check(stdout).contains('workspace-discovery');
     });
@@ -443,5 +444,63 @@ void useHelper() {
         check(summary2['pureUndead']).equals(1);
       },
     );
+
+    test('supports --suggest-private to identify single-library internal '
+        'declarations', () async {
+      await d.dir('cli_suggest_private_pkg', [
+        packageConfig('cli_suggest_private_pkg'),
+        d.file('pubspec.yaml', '''
+name: cli_suggest_private_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+        d.dir('lib', [
+          d.file('cli_suggest_private_pkg.dart', '''
+export 'src/api.dart' show PublicApi;
+'''),
+          d.dir('src', [
+            d.file('api.dart', '''
+class PublicApi {
+  void call() {
+    onlyUsedHere();
+  }
+}
+
+void onlyUsedHere() {}
+'''),
+          ]),
+        ]),
+      ]).create();
+
+      // 1. Without --suggest-private, 0 undead
+      final proc1 = await runUndead([
+        '--format=json',
+        d.path('cli_suggest_private_pkg'),
+      ]);
+      final out1 = await proc1.stdoutStream().join('\n');
+      await proc1.shouldExit(0);
+      final json1 = jsonDecode(out1) as Map<String, dynamic>;
+      final summary1 = json1['summary'] as Map<String, dynamic>;
+      check(summary1['privateCandidates']).equals(0);
+      check(json1['undead'] as List).isEmpty();
+
+      // 2. With --suggest-private, onlyUsedHere is a private candidate
+      final proc2 = await runUndead([
+        '--format=json',
+        '--suggest-private',
+        d.path('cli_suggest_private_pkg'),
+      ]);
+      final out2 = await proc2.stdoutStream().join('\n');
+      await proc2.shouldExit(0);
+      final json2 = jsonDecode(out2) as Map<String, dynamic>;
+      final summary2 = json2['summary'] as Map<String, dynamic>;
+      check(summary2['privateCandidates']).equals(1);
+      final undeadList = json2['undead'] as List<dynamic>;
+      check(undeadList.length).equals(1);
+      final firstFinding = undeadList.first as Map<String, dynamic>;
+      check(firstFinding['name']).equals('onlyUsedHere');
+      check(firstFinding['classification']).equals('privateCandidate');
+      check(firstFinding['suggestedAction']).equals('makePrivate');
+    });
   });
 }

--- a/packages/undead/test/cli_test.dart
+++ b/packages/undead/test/cli_test.dart
@@ -57,7 +57,7 @@ void main() {
       final stdout = await proc.stdoutStream().join('\n');
       await proc.shouldExit(0);
 
-      check(stdout).contains('undead version: 0.1.0');
+      check(stdout).contains('undead version: 0.1.1-wip');
     });
 
     test('--mode accepts closed-app', () async {

--- a/packages/undead/test/formatters_test.dart
+++ b/packages/undead/test/formatters_test.dart
@@ -64,7 +64,19 @@ void main() {
             ),
           ],
         ),
+        UndeadFinding(
+          id: 'internalHelper',
+          name: 'internalHelper',
+          kind: DeclarationKind.function,
+          file: 'lib/src/internal.dart',
+          line: 10,
+          column: 1,
+          length: 14,
+          classification: UndeadClassification.privateCandidate,
+          suggestedAction: SuggestedAction.makePrivate,
+        ),
       ],
+      privateCandidatesFound: 1,
     );
 
     test('JsonFormatter generates valid and compliant JSON', () {
@@ -79,9 +91,10 @@ void main() {
       check(summary['pureUndead']).equals(1);
       check(summary['testedUndead']).equals(1);
       check(summary['coInvokedHazards']).equals(1);
+      check(summary['privateCandidates']).equals(1);
 
       final undead = decoded['undead'] as List<dynamic>;
-      check(undead.length).equals(3);
+      check(undead.length).equals(4);
     });
 
     test('MarkdownFormatter generates headers and categorized tables', () {
@@ -89,6 +102,7 @@ void main() {
       final output = formatter.format(sampleReport);
 
       check(output).contains('# Undead Code Analysis: `test_pkg`');
+      check(output).contains('| **Private Candidates** | 1 |');
       check(output).contains('## Pure Undead (Safe to Delete)');
       check(output).contains('`deadFunc`');
       check(output).contains('## Tested Undead (Orphan Tests)');
@@ -103,6 +117,9 @@ void main() {
       check(
         output,
       ).contains('`test/pipeline_test.dart:15` ("pipeline integration")');
+      check(output).contains('## Private Candidates (Suggest Library-Private)');
+      check(output).contains('`internalHelper`');
+      check(output).contains('Make library-private (prefix with `_`)');
     });
 
     test('MarkdownFormatter produces clean notice when 0 undead found', () {

--- a/packages/undead/test/models_test.dart
+++ b/packages/undead/test/models_test.dart
@@ -142,6 +142,9 @@ void main() {
       check(
         UndeadClassification.fromJson('coInvokedHazard'),
       ).equals(UndeadClassification.coInvokedHazard);
+      check(
+        UndeadClassification.fromJson('privateCandidate'),
+      ).equals(UndeadClassification.privateCandidate);
 
       check(
         DeclarationKind.fromJson('class'),
@@ -175,6 +178,7 @@ void main() {
       check(defaultOptions.failOnUndead).isFalse();
       check(defaultOptions.autoPubGet).isFalse();
       check(defaultOptions.workspaceDiscovery).isTrue();
+      check(defaultOptions.suggestPrivate).isFalse();
 
       const customOptions = UndeadOptions(
         packagePath: '/path/to/pkg',
@@ -182,6 +186,7 @@ void main() {
         ignoreNamePatterns: ['*_generated', 'Ignored*'],
         extraRoots: ['../companion_test', '/external/tests'],
         workspaceDiscovery: false,
+        suggestPrivate: true,
       );
       check(
         customOptions.testSupportPatterns,
@@ -193,6 +198,7 @@ void main() {
         customOptions.extraRoots,
       ).deepEquals(['../companion_test', '/external/tests']);
       check(customOptions.workspaceDiscovery).isFalse();
+      check(customOptions.suggestPrivate).isTrue();
     });
 
     test('UndeadReport deserializes camelCase JSON summary correctly', () {

--- a/packages/undead/test/reachability_engine_test.dart
+++ b/packages/undead/test/reachability_engine_test.dart
@@ -1989,5 +1989,198 @@ void runGen() {
         check(undeadNames).not((it) => it.contains('buildGenHelper'));
       },
     );
+
+    group('suggestPrivate candidate detection', () {
+      test(
+        'detects declaration only used within same library when suggestPrivate '
+        'is enabled',
+        () async {
+          await d.dir('suggest_private_pkg', [
+            packageConfig('suggest_private_pkg'),
+            d.file('pubspec.yaml', '''
+name: suggest_private_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+            d.dir('lib', [
+              d.file('suggest_private_pkg.dart', '''
+export 'src/service.dart' show PublicService;
+'''),
+              d.dir('src', [
+                d.file('service.dart', '''
+class PublicService {
+  void run() {
+    internalHelper();
+  }
+}
+
+void internalHelper() {}
+'''),
+              ]),
+            ]),
+          ]).create();
+
+          // Without suggestPrivate: internalHelper is live, 0 undead findings.
+          final defaultReport = await analyzePackage(
+            d.path('suggest_private_pkg'),
+            options: const UndeadOptions(
+              packagePath: '',
+              suggestPrivate: false,
+            ),
+          );
+          check(defaultReport.undead).isEmpty();
+          check(defaultReport.privateCandidatesFound).equals(0);
+
+          // With suggestPrivate: internalHelper is flagged as privateCandidate.
+          final privateReport = await analyzePackage(
+            d.path('suggest_private_pkg'),
+            options: const UndeadOptions(packagePath: '', suggestPrivate: true),
+          );
+          check(privateReport.privateCandidatesFound).equals(1);
+          check(privateReport.undead.length).equals(1);
+
+          final candidate = privateReport.undead.single;
+          check(candidate.name).equals('internalHelper');
+          check(candidate.kind).equals(DeclarationKind.function);
+          check(
+            candidate.classification,
+          ).equals(UndeadClassification.privateCandidate);
+          check(candidate.suggestedAction).equals(SuggestedAction.makePrivate);
+        },
+      );
+
+      test('honors part and part of directives within same library', () async {
+        await d.dir('part_private_pkg', [
+          packageConfig('part_private_pkg'),
+          d.file('pubspec.yaml', '''
+name: part_private_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+          d.dir('lib', [
+            d.file('part_private_pkg.dart', '''
+export 'src/main_lib.dart' show Service;
+'''),
+            d.dir('src', [
+              d.file('main_lib.dart', '''
+part 'part_lib.dart';
+
+class Service {
+  void doWork() {
+    partWorker();
+  }
+}
+
+void internalWorker() {}
+'''),
+              d.file('part_lib.dart', '''
+part of 'main_lib.dart';
+
+void partWorker() {
+  internalWorker();
+}
+'''),
+            ]),
+          ]),
+        ]).create();
+
+        final report = await analyzePackage(
+          d.path('part_private_pkg'),
+          options: const UndeadOptions(packagePath: '', suggestPrivate: true),
+        );
+
+        check(report.privateCandidatesFound).equals(2);
+        final names = report.undead.map((u) => u.name).toSet();
+        check(names).contains('internalWorker');
+        check(names).contains('partWorker');
+      });
+
+      test('does not flag declarations used across libraries', () async {
+        await d.dir('cross_lib_pkg', [
+          packageConfig('cross_lib_pkg'),
+          d.file('pubspec.yaml', '''
+name: cross_lib_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+          d.dir('lib', [
+            d.file('cross_lib_pkg.dart', '''
+export 'src/consumer.dart';
+'''),
+            d.dir('src', [
+              d.file('provider.dart', '''
+void sharedHelper() {}
+'''),
+              d.file('consumer.dart', '''
+import 'provider.dart';
+
+class Consumer {
+  void use() {
+    sharedHelper();
+  }
+}
+'''),
+            ]),
+          ]),
+        ]).create();
+
+        final report = await analyzePackage(
+          d.path('cross_lib_pkg'),
+          options: const UndeadOptions(packagePath: '', suggestPrivate: true),
+        );
+
+        check(report.privateCandidatesFound).equals(0);
+        check(report.undead).isEmpty();
+      });
+
+      test('does not flag declarations referenced in test files', () async {
+        await d.dir('tested_private_pkg', [
+          packageConfig('tested_private_pkg'),
+          d.file('pubspec.yaml', '''
+name: tested_private_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+          d.dir('lib', [
+            d.file('tested_private_pkg.dart', '''
+export 'src/live.dart';
+'''),
+            d.dir('src', [
+              d.file('live.dart', '''
+class LiveService {
+  void run() {
+    testHelper();
+  }
+}
+
+void testHelper() {}
+'''),
+            ]),
+          ]),
+          d.dir('test', [
+            d.file('live_test.dart', '''
+import 'package:tested_private_pkg/src/live.dart';
+
+void test(String desc, Function body) {}
+
+void main() {
+  test('tests helper', () {
+    testHelper();
+  });
+}
+'''),
+          ]),
+        ]).create();
+
+        final report = await analyzePackage(
+          d.path('tested_private_pkg'),
+          options: const UndeadOptions(packagePath: '', suggestPrivate: true),
+        );
+
+        // testHelper is referenced in test/live_test.dart, so it must not be suggested for privatization.
+        check(report.privateCandidatesFound).equals(0);
+        check(report.undead).isEmpty();
+      });
+    });
   });
 }

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -115,6 +115,7 @@ dart run undead@ --example-mode=demonstration
 | `--ignore-name-patterns` | Comma-separated wildcards for names to ignore. | `""` |
 | `--[no-]workspace-discovery` | Discover consumer roots from sibling packages in workspace. | `true` |
 | `--[no-]ignore-external-bindings` | Preserve unreferenced `@JS()` and FFI facades. | `false` |
+| `--[no-]suggest-private` | Identify top-level declarations that can be made library-private. | `false` |
 | `--pub-get` | Auto-run `dart pub get` / `flutter pub get` if needed. | `false` |
 | `--fail-on-undead` | Exit with non-zero code (1) on findings (useful for CI). | `false` |
 


### PR DESCRIPTION
Add opt-in --suggest-private flag to detect unexported top-level declarations in lib/src/ that are only referenced within their declaring library (and its parts), with zero cross-library references and zero test references.

- Add suggestPrivate to UndeadOptions and CLI arg parser
- Track cross-library references and test references during graph build
- Classify candidates as UndeadClassification.privateCandidate
- Render private candidates table in Markdown and JSON formatters
- Update dart-undead SKILL.md documentation
- Add comprehensive reachability, formatters, and CLI tests

Fixes #44
