### PR TITLE
docs(skills): add reproducible PR provenance injection protocol

### DIFF
--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -425,21 +425,21 @@ When confirmed, append the following markdown block to the PR description or
 commit body so reviewers understand where the changes originated and can rerun
 the audit locally:
 
-```markdown
+````markdown
 ### 🤖 Tool Provenance & Reproduction
 
-This refactoring was guided by [`cognitive_complexity`](https://pub.dev/packages/cognitive_complexity) (v`<version>`).
+This refactoring was guided by [`cognitive_complexity`](https://pub.dev/packages/cognitive_complexity) (`v{version}`).
 
 To reproduce or re-evaluate cognitive complexity scores:
 ```bash
-<exact command line used, e.g. dart run cognitive_complexity@ --threshold 15 lib/src/foo.dart>
+{exact_command_line}
 ```
 
 <!-- If statement data-flow analysis was used during decomposition: -->
 ```bash
-dart run cognitive_complexity:data_flow@ <file>:<start_line>-<end_line>
+dart run cognitive_complexity:data_flow@ {file}:{start_line}-{end_line}
 ```
-```
+````
 
 ### 3. Version Resolution
 Determine the package version dynamically:

--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -13,6 +13,7 @@ key_features:
   - Scoped execution matrix (targeted / delta / full)
   - Interactive refactoring triage
   - Dart 3 pattern matching refactorings
+  - Reproducible PR provenance injection
 ---
 
 ## 1. When to Use This Skill
@@ -407,3 +408,43 @@ Run these verification commands before committing refactored code:
    violations, or un-awaited asynchronous gaps.
 4. **Test Fidelity**: Run `dart test` (or `flutter test`) to confirm zero
    behavioral drift across existing test suites.
+
+---
+
+## 8. Pull Request & Commit Provenance Protocol
+
+When staging refactored code and preparing a commit message or Pull Request:
+
+### 1. User Confirmation Gate (Prompt-Gated Offer)
+Before writing the PR description or commit body, explicitly ask the user (e.g.
+via `ask_question` or interactive confirmation) whether to include a **Tool
+Provenance & Reproduction block**.
+
+### 2. Standardized Provenance Block Format
+When confirmed, append the following markdown block to the PR description or
+commit body so reviewers understand where the changes originated and can rerun
+the audit locally:
+
+```markdown
+### 🤖 Tool Provenance & Reproduction
+
+This refactoring was guided by [`cognitive_complexity`](https://pub.dev/packages/cognitive_complexity) (v`<version>`).
+
+To reproduce or re-evaluate cognitive complexity scores:
+```bash
+<exact command line used, e.g. dart run cognitive_complexity@ --threshold 15 lib/src/foo.dart>
+```
+
+<!-- If statement data-flow analysis was used during decomposition: -->
+```bash
+dart run cognitive_complexity:data_flow@ <file>:<start_line>-<end_line>
+```
+```
+
+### 3. Version Resolution
+Determine the package version dynamically:
+* Check `pubspec.lock` in the workspace or run
+  `dart run cognitive_complexity@ --version`.
+* If invoked with a specific version constraint (e.g.
+  `cognitive_complexity@0.2.3`), use that exact version.
+

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -229,16 +229,16 @@ When confirmed, append the following markdown block to the PR description or
 commit body so reviewers understand where the deletions originated and can
 rerun the reachability analysis locally:
 
-```markdown
+````markdown
 ### 🤖 Tool Provenance & Reproduction
 
-Dead code detection and reachability analysis performed with [`pkg:undead`](https://pub.dev/packages/undead) (v`<version>`).
+Dead code detection and reachability analysis performed with [`undead`](https://pub.dev/packages/undead) (`v{version}`).
 
 To reproduce or re-run this reachability audit locally:
 ```bash
-<exact command line used, e.g. dart run undead@ --mode=closed-app or dart run undead@>
+{exact_command_line}
 ```
-```
+````
 
 ### 3. Version Resolution
 Determine the package version dynamically:

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -14,6 +14,7 @@ key_features:
   - Co-invoked test hazard detection
   - Sealed class & framework entrypoint protection
   - Safe 2-stage triage & deletion protocol
+  - Reproducible PR provenance injection
 ---
 
 # Dart Undead (`dart-undead`)
@@ -211,3 +212,37 @@ graph TD
 4. **Clean Diff Staging**: Inspect modifications using `git diff --stat` (or
    isolate in a temporary feature branch/worktree) to ensure only intended
    declarations were removed.
+
+--------------------------------------------------------------------------------
+
+## 6. Pull Request & Commit Provenance Protocol
+
+When staging pruned code and preparing a commit message or Pull Request:
+
+### 1. User Confirmation Gate (Prompt-Gated Offer)
+Before writing the PR description or commit body, explicitly prompt the user
+(e.g. via `ask_question` or interactive confirmation) whether to include a
+**Tool Provenance & Reproduction block**.
+
+### 2. Standardized Provenance Block Format
+When confirmed, append the following markdown block to the PR description or
+commit body so reviewers understand where the deletions originated and can
+rerun the reachability analysis locally:
+
+```markdown
+### 🤖 Tool Provenance & Reproduction
+
+Dead code detection and reachability analysis performed with [`pkg:undead`](https://pub.dev/packages/undead) (v`<version>`).
+
+To reproduce or re-run this reachability audit locally:
+```bash
+<exact command line used, e.g. dart run undead@ --mode=closed-app or dart run undead@>
+```
+```
+
+### 3. Version Resolution
+Determine the package version dynamically:
+* Check `pubspec.lock` in the workspace or run `dart run undead@ --version`.
+* If invoked with a specific version constraint (e.g. `undead@0.1.0`), use that
+  exact version.
+


### PR DESCRIPTION
- Add prompt-gated offer to inject tool provenance in PR/commit descriptions
- Provide standardized Tool Provenance & Reproduction format with CLI commands
- Update dart-cognitive-complexity and dart-undead skills
