### PR TITLE
fix(action): paginate sticky comment lookup without SIGPIPE

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,10 +101,15 @@ runs:
         if [ -n "$PR_NUMBER" ] && [ -n "$GH_TOKEN" ]; then
           if [ -f "$GITHUB_STEP_SUMMARY" ] && [ -s "$GITHUB_STEP_SUMMARY" ]; then
             echo "Searching for existing complexity audit comment on PR #$PR_NUMBER..."
-            
-            # Find the ID of any existing comment containing our tracking marker
-            comment_id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-              --jq '.[] | select(.body | contains("<!-- complexity-comment-marker -->")) | .id' | head -n 1)
+
+            # Find the ID of any existing comment containing our tracking marker.
+            # --paginate is required: without it only the first page of comments is
+            # searched, so on busy PRs the marker is missed and a duplicate posted.
+            # Collect fully before selecting: piping gh directly into `head` closes
+            # the pipe early, and SIGPIPE + pipefail would fail the step.
+            comment_ids=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              --jq '.[] | select(.body | contains("<!-- complexity-comment-marker -->")) | .id')
+            comment_id=$(printf '%s\n' "$comment_ids" | head -n 1)
 
             if [ -n "$comment_id" ]; then
               echo "Updating existing comment (ID: $comment_id)..."


### PR DESCRIPTION
## Problem

Sticky-comment lookup used a single `gh api` page piped into `head -n 1`.

- Without `--paginate`, only the first page of PR comments is searched, so the `<!-- complexity-comment-marker -->` can be missed and a **duplicate** comment posted.
- Piping `gh` into `head` closes the pipe early. Under `set -o pipefail` that SIGPIPE can fail the step (`exit 141`).

## Change

Collect matching comment IDs fully, then take the first:

```bash
comment_ids=$(gh api --paginate ... --jq '...')
comment_id=$(printf '%s\n' "$comment_ids" | head -n 1)
```

No CLI or reporter changes.