### PR TITLE
fix(action): paginate sticky comment lookup and avoid SIGPIPE

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,9 +102,14 @@ runs:
           if [ -f "$GITHUB_STEP_SUMMARY" ] && [ -s "$GITHUB_STEP_SUMMARY" ]; then
             echo "Searching for existing complexity audit comment on PR #$PR_NUMBER..."
             
-            # Find the ID of any existing comment containing our tracking marker
-            comment_id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-              --jq '.[] | select(.body | contains("<!-- complexity-comment-marker -->")) | .id' | head -n 1)
+            # Find the ID of any existing comment containing our tracking marker.
+            # --paginate: the endpoint returns 30 comments per page, so on a busy
+            # PR the marker falls off page one and a duplicate comment is posted.
+            # Collect before selecting: piping gh straight into `head` closes the
+            # pipe early, and SIGPIPE under `set -o pipefail` fails the step.
+            comment_ids=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              --jq '.[] | select(.body | contains("<!-- complexity-comment-marker -->")) | .id')
+            comment_id=$(printf '%s\n' "$comment_ids" | head -n 1)
 
             if [ -n "$comment_id" ]; then
               echo "Updating existing comment (ID: $comment_id)..."


### PR DESCRIPTION
The sticky-comment lookup in `action.yml` has two issues that show up on
busy PRs.

**Pagination.** `gh api repos/.../issues/<n>/comments` returns 30 comments
per page. On a PR with more than 30 comments the tracking marker is never
found, so every run posts a *new* duplicate comment instead of updating the
existing one.

**SIGPIPE.** Piping `gh` straight into `head -n 1` closes the pipe as soon as
the first id is read. Adding `--paginate` makes this worse, since gh keeps
fetching pages, takes SIGPIPE, and exits 141. The composite action runs under
bash `-eo pipefail`, so that fails the whole step. Reproduced standalone:

```
$ bash -c 'set -eo pipefail; x=$(yes hello | head -n 1); echo "$x"'
$ echo $?
141
```

Collecting the ids into a variable before selecting the first one avoids it.

No behaviour change when a PR has fewer than 30 comments.