### PR TITLE
feat(action): add max-comment-rows to cap the sticky PR comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,14 @@ inputs:
     description: 'Output format: github (summary table + annotations), text, or json.'
     required: false
     default: 'github'
+  max-comment-rows:
+    description: >-
+      Maximum table rows in the sticky PR comment, most significant first
+      (0 = unlimited). The step summary always keeps the full table, and inline
+      annotations are unaffected. GitHub rejects issue-comment bodies over
+      65536 characters, so an uncapped table on a large diff fails to post.
+    required: false
+    default: '0'
 
 runs:
   using: 'composite'
@@ -65,6 +73,7 @@ runs:
         INPUT_FAIL_ON_INCREASE: ${{ inputs.fail-on-increase }}
         INPUT_FORMAT: ${{ inputs.format }}
         INPUT_TARGETS: ${{ inputs.targets }}
+        INPUT_MAX_COMMENT_ROWS: ${{ inputs.max-comment-rows }}
         DIFF_ARG: ${{ steps.prepare.outputs.diff_arg }}
         ACTION_PATH: ${{ github.action_path }}
         GH_TOKEN: ${{ github.token }}
@@ -74,7 +83,24 @@ runs:
         if [ "$INPUT_FAIL_ON_INCREASE" = "true" ]; then
           fail_inc_arg="--fail-on-increase"
         fi
-        
+
+        case "${INPUT_MAX_COMMENT_ROWS:-0}" in
+          ''|*[!0-9]*)
+            echo "::error::max-comment-rows must be a non-negative integer, got '${INPUT_MAX_COMMENT_ROWS}'."
+            exit 1
+            ;;
+        esac
+
+        # With a row cap the scanner renders a second, trimmed report for the
+        # comment while the step summary keeps every row. Absolute path: the
+        # scanner runs with the action directory as its working directory.
+        comment_args=""
+        comment_file=""
+        if [ "$INPUT_FORMAT" = "github" ] && [ "${INPUT_MAX_COMMENT_ROWS:-0}" -gt 0 ]; then
+          comment_file="${RUNNER_TEMP}/complexity-comment.md"
+          comment_args="--comment-output=$comment_file --max-comment-rows=$INPUT_MAX_COMMENT_ROWS"
+        fi
+
         # Navigate to action repo directory, run pub get to resolve dependencies deterministically
         cd "$ACTION_PATH"
         dart pub get >/dev/null
@@ -93,13 +119,21 @@ runs:
           --format="$INPUT_FORMAT" \
           $DIFF_ARG \
           $fail_inc_arg \
+          $comment_args \
           $targets
         exit_code=$?
         set -e
 
         # If running inside a PR context and GH_TOKEN is present, post or update sticky comment
         if [ -n "$PR_NUMBER" ] && [ -n "$GH_TOKEN" ]; then
-          if [ -f "$GITHUB_STEP_SUMMARY" ] && [ -s "$GITHUB_STEP_SUMMARY" ]; then
+          # Prefer the trimmed report when a row cap produced one; the step
+          # summary keeps the full table either way.
+          body_file="$GITHUB_STEP_SUMMARY"
+          if [ -n "$comment_file" ] && [ -s "$comment_file" ]; then
+            body_file="$comment_file"
+          fi
+
+          if [ -f "$body_file" ] && [ -s "$body_file" ]; then
             echo "Searching for existing complexity audit comment on PR #$PR_NUMBER..."
             
             # Find the ID of any existing comment containing our tracking marker
@@ -108,10 +142,10 @@ runs:
 
             if [ -n "$comment_id" ]; then
               echo "Updating existing comment (ID: $comment_id)..."
-              gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" -F body=@"$GITHUB_STEP_SUMMARY" > /dev/null || true
+              gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" -F body=@"$body_file" > /dev/null || true
             else
               echo "Creating new PR comment..."
-              gh pr comment "$PR_NUMBER" --body-file "$GITHUB_STEP_SUMMARY" --repo "$GITHUB_REPOSITORY" > /dev/null || true
+              gh pr comment "$PR_NUMBER" --body-file "$body_file" --repo "$GITHUB_REPOSITORY" > /dev/null || true
             fi
           fi
         fi

--- a/packages/cognitive_complexity/lib/src/complexity/cli.dart
+++ b/packages/cognitive_complexity/lib/src/complexity/cli.dart
@@ -63,6 +63,23 @@ Future<int> runCli(
       defaultsTo: 'text',
       allowed: ['text', 'json', 'github'],
       help: 'Output format.',
+    )
+    ..addOption(
+      'comment-output',
+      valueHelp: 'path',
+      help:
+          'With --format=github, also write a standalone report to this path, '
+          'ordered by significance and capped by --max-comment-rows. Intended '
+          'for posting as a PR comment while the step summary keeps the full '
+          'table.',
+    )
+    ..addOption(
+      'max-comment-rows',
+      defaultsTo: '0',
+      valueHelp: 'count',
+      help:
+          'Maximum table rows in --comment-output (0 = unlimited). GitHub '
+          'rejects comment bodies over 65536 characters.',
     );
 
   try {
@@ -89,11 +106,22 @@ Future<int> runCli(
     final format = argResults['format'] as String;
     final gitDiffBase = argResults['git-diff'] as String?;
     final failOnIncrease = argResults['fail-on-increase'] as bool;
+    final commentOutput = argResults['comment-output'] as String?;
+    final maxCommentRows = parseNonNegativeInt(
+      argResults['max-comment-rows'] as String,
+      'max-comment-rows',
+    );
 
     if (failOnIncrease && gitDiffBase == null) {
       stderrSink.writeln(
         'Warning: --fail-on-increase has no effect unless --git-diff is '
         'specified.',
+      );
+    }
+
+    if (commentOutput != null && format != 'github') {
+      stderrSink.writeln(
+        'Warning: --comment-output has no effect unless --format=github.',
       );
     }
 
@@ -107,6 +135,8 @@ Future<int> runCli(
         format: format,
         failThreshold: failThreshold,
         failOnIncrease: failOnIncrease,
+        commentOutput: commentOutput,
+        maxCommentRows: maxCommentRows,
         out: stdoutSink,
         err: stderrSink,
       );
@@ -141,6 +171,8 @@ Future<int> _handleDiffMode({
   required bool failOnIncrease,
   required StringSink out,
   required StringSink err,
+  String? commentOutput,
+  int maxCommentRows = 0,
 }) async {
   final deltaAnalyzer = DeltaAnalyzer();
   final summary = await deltaAnalyzer.computeDeltas(
@@ -161,6 +193,8 @@ Future<int> _handleDiffMode({
     final reporter = GitHubReporter(
       stdoutSink: out,
       summaryFile: resolveGitHubSummaryFile(),
+      commentFile: commentOutput == null ? null : File(commentOutput),
+      maxCommentRows: maxCommentRows,
     );
     reporter.printReport(
       deltaSummary: summary,

--- a/packages/cognitive_complexity/lib/src/complexity/github_reporter.dart
+++ b/packages/cognitive_complexity/lib/src/complexity/github_reporter.dart
@@ -6,37 +6,69 @@ import 'delta_analyzer.dart';
 class GitHubReporter {
   final StringSink _stdoutSink;
   final File? _summaryFile;
+  final File? _commentFile;
+  final int _maxCommentRows;
 
-  GitHubReporter({StringSink? stdoutSink, this._summaryFile})
-    : _stdoutSink = stdoutSink ?? stdout;
+  GitHubReporter({
+    StringSink? stdoutSink,
+    this._summaryFile,
+    this._commentFile,
+    this._maxCommentRows = 0,
+  }) : _stdoutSink = stdoutSink ?? stdout;
 
   /// Generates diagnostic workflow annotations and updates step summary table.
+  ///
+  /// The step summary always receives the complete table. When [_commentFile]
+  /// is configured, a second rendering is written there with the most
+  /// significant rows first, capped at [_maxCommentRows]. GitHub rejects
+  /// issue-comment bodies over 65536 characters, so posting an uncapped table
+  /// on a large diff silently fails.
   void printReport({
     List<FunctionComplexity>? regularResults,
     DeltaSummary? deltaSummary,
     int? failThreshold,
     bool failOnIncrease = false,
   }) {
-    final summaryBuf = StringBuffer();
-    summaryBuf.writeln('<!-- complexity-comment-marker -->');
-    summaryBuf.writeln('# 📊 Cognitive Complexity Analysis');
-    summaryBuf.writeln();
+    final summaryBuf = _newBuffer();
+    final commentBuf = _commentFile == null ? null : _newBuffer();
 
     if (deltaSummary != null) {
-      _reportDelta(deltaSummary, failThreshold, failOnIncrease, summaryBuf);
+      _reportDelta(
+        deltaSummary,
+        failThreshold,
+        failOnIncrease,
+        summaryBuf,
+        commentBuf,
+      );
     } else if (regularResults != null) {
       _reportRegular(regularResults, failThreshold, summaryBuf);
     }
 
-    if (_summaryFile != null) {
-      try {
-        _summaryFile.writeAsStringSync(
-          summaryBuf.toString(),
-          mode: FileMode.append,
-        );
-      } catch (e) {
-        stderr.writeln('Warning: Failed to write to step summary file: $e');
-      }
+    _write(_summaryFile, summaryBuf, 'step summary', append: true);
+    if (commentBuf != null) {
+      _write(_commentFile, commentBuf, 'comment output', append: false);
+    }
+  }
+
+  StringBuffer _newBuffer() => StringBuffer()
+    ..writeln('<!-- complexity-comment-marker -->')
+    ..writeln('# 📊 Cognitive Complexity Analysis')
+    ..writeln();
+
+  void _write(
+    File? file,
+    StringBuffer buf,
+    String label, {
+    required bool append,
+  }) {
+    if (file == null) return;
+    try {
+      file.writeAsStringSync(
+        buf.toString(),
+        mode: append ? FileMode.append : FileMode.write,
+      );
+    } catch (e) {
+      stderr.writeln('Warning: Failed to write to $label file: $e');
     }
   }
 
@@ -77,6 +109,7 @@ class GitHubReporter {
     int? failThreshold,
     bool failOnIncrease,
     StringBuffer summaryBuf,
+    StringBuffer? commentBuf,
   ) {
     final net = summary.netDelta;
     final sign = net > 0 ? '+' : '';
@@ -84,35 +117,91 @@ class GitHubReporter {
       failThreshold: failThreshold,
       failOnIncrease: failOnIncrease,
     );
-    summaryBuf.writeln(
-      '**Net Delta**: $sign$net | **Added**: ${summary.countAdded} | '
-      '**Increased**: ${summary.countIncreased} | '
-      '**Improved**: ${summary.countImproved} | **Violations**: $violations',
-    );
-    summaryBuf.writeln();
+    final header =
+        '**Net Delta**: $sign$net | **Added**: ${summary.countAdded} | '
+        '**Increased**: ${summary.countIncreased} | '
+        '**Improved**: ${summary.countImproved} | **Violations**: $violations';
+    for (final buf in [summaryBuf, ?commentBuf]) {
+      buf
+        ..writeln(header)
+        ..writeln();
+    }
+
+    final changed = summary.deltas
+        .where((d) => d.status != DeltaStatus.unchanged)
+        .toList();
+
+    // Annotations are emitted once for every changed declaration, independent
+    // of how many rows each table renders. Capping the comment must not hide
+    // an inline warning from the Files-changed view.
+    for (final d in changed) {
+      _emitDiagnostic(d, failThreshold, failOnIncrease);
+    }
 
     if (summary.deltas.isEmpty) {
-      summaryBuf.writeln('No modified Dart declarations detected.');
+      for (final buf in [summaryBuf, ?commentBuf]) {
+        buf.writeln('No modified Dart declarations detected.');
+      }
       return;
     }
 
-    _renderDeltaTable(summary, failThreshold, failOnIncrease, summaryBuf);
+    _renderDeltaTable(changed, failThreshold, failOnIncrease, summaryBuf);
+
+    if (commentBuf != null) {
+      final ranked = [...changed]
+        ..sort((a, b) {
+          final byRank = _rank(
+            b,
+            failThreshold,
+            failOnIncrease,
+          ).compareTo(_rank(a, failThreshold, failOnIncrease));
+          if (byRank != 0) return byRank;
+          return (b.newScore ?? 0).compareTo(a.newScore ?? 0);
+        });
+
+      final capped = _maxCommentRows > 0 && ranked.length > _maxCommentRows
+          ? ranked.sublist(0, _maxCommentRows)
+          : ranked;
+
+      _renderDeltaTable(capped, failThreshold, failOnIncrease, commentBuf);
+
+      final omitted = ranked.length - capped.length;
+      if (omitted > 0) {
+        commentBuf
+          ..writeln()
+          ..writeln(
+            '_Showing the $_maxCommentRows most significant of '
+            '${ranked.length} changed declarations. '
+            'See the workflow Step Summary for the full table._',
+          );
+      }
+    }
+  }
+
+  /// Display priority for the capped comment: violations, then regressions,
+  /// then additions, then everything else.
+  int _rank(ComplexityDelta d, int? failThreshold, bool failOnIncrease) {
+    if (d.isViolation(
+      failThreshold: failThreshold,
+      failOnIncrease: failOnIncrease,
+    )) {
+      return 3;
+    }
+    if (d.status == DeltaStatus.increased) return 2;
+    if (d.status == DeltaStatus.added) return 1;
+    return 0;
   }
 
   void _renderDeltaTable(
-    DeltaSummary summary,
+    List<ComplexityDelta> deltas,
     int? failThreshold,
     bool failOnIncrease,
-    StringBuffer summaryBuf,
+    StringBuffer buf,
   ) {
-    summaryBuf.writeln('| Status | Declaration | Location | Delta | Score |');
-    summaryBuf.writeln('| :---: | :--- | :--- | :---: | :---: |');
+    buf.writeln('| Status | Declaration | Location | Delta | Score |');
+    buf.writeln('| :---: | :--- | :--- | :---: | :---: |');
 
-    for (final d in summary.deltas) {
-      if (d.status == DeltaStatus.unchanged) {
-        continue;
-      }
-
+    for (final d in deltas) {
       final isVio = d.isViolation(
         failThreshold: failThreshold,
         failOnIncrease: failOnIncrease,
@@ -124,11 +213,7 @@ class GitHubReporter {
           ? '${d.oldScore} -> **${d.newScore}**'
           : '**${d.newScore ?? "Deleted"}**';
 
-      summaryBuf.writeln(
-        '| $icon | `${d.name}` | `$loc` | `$deltaStr` | $scoreStr |',
-      );
-
-      _emitDiagnostic(d, failThreshold, failOnIncrease);
+      buf.writeln('| $icon | `${d.name}` | `$loc` | `$deltaStr` | $scoreStr |');
     }
   }
 

--- a/packages/cognitive_complexity/test/comment_output_test.dart
+++ b/packages/cognitive_complexity/test/comment_output_test.dart
@@ -1,0 +1,169 @@
+import 'dart:io';
+import 'package:checks/checks.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+/// Builds a declaration whose cognitive complexity grows with [depth].
+/// depth 1 scores 7 (below a threshold of 15), depth 3 scores 30 (above it).
+String _decl(String name, int depth) {
+  final buf = StringBuffer('int $name(int x) {\n');
+  for (var i = 0; i < depth; i++) {
+    final pad = '  ' * (i + 1);
+    buf
+      ..writeln('${pad}if (x > $i) {')
+      ..writeln('$pad  for (var i = 0; i < x; i++) {')
+      ..writeln('$pad    if (i % 2 == 0) x++; else x--;')
+      ..writeln('$pad  }');
+  }
+  for (var i = depth - 1; i >= 0; i--) {
+    buf.writeln('${'  ' * (i + 1)}}');
+  }
+  return (buf
+        ..writeln('  return x;')
+        ..writeln('}'))
+      .toString();
+}
+
+void main() {
+  final binPath = File('bin/cognitive_complexity.dart').existsSync()
+      ? p.normalize(p.absolute('bin/cognitive_complexity.dart'))
+      : p.normalize(
+          p.absolute(
+            'packages/cognitive_complexity/bin/cognitive_complexity.dart',
+          ),
+        );
+
+  group('--comment-output', () {
+    late String repoPath;
+    late String summaryPath;
+    late String commentPath;
+
+    Future<void> runGit(List<String> args) async {
+      final res = await Process.run('git', args, workingDirectory: repoPath);
+      if (res.exitCode != 0) {
+        fail('git ${args.join(" ")} failed:\n${res.stderr}');
+      }
+    }
+
+    /// Runs the scanner against the fixture repo, returning stdout.
+    Future<ProcessResult> runScanner(List<String> extraArgs) => Process.run(
+      Platform.resolvedExecutable,
+      [
+        binPath,
+        '--git-diff=HEAD~1',
+        '--fail-threshold=15',
+        '--fail-on-increase',
+        '--format=github',
+        ...extraArgs,
+        'lib',
+      ],
+      workingDirectory: repoPath,
+      environment: {'GITHUB_STEP_SUMMARY': summaryPath},
+    );
+
+    setUp(() async {
+      repoPath = p.join(d.sandbox, 'repo');
+      summaryPath = p.join(d.sandbox, 'summary.md');
+      commentPath = p.join(d.sandbox, 'comment.md');
+      await Directory(p.join(repoPath, 'lib')).create(recursive: true);
+      await File(summaryPath).writeAsString('');
+
+      await runGit(['init', '-b', 'main']);
+      await runGit(['config', 'user.name', 'Tester']);
+      await runGit(['config', 'user.email', 'test@example.com']);
+      await runGit(['config', 'commit.gpgsign', 'false']);
+
+      final src = p.join(repoPath, 'lib', 'a.dart');
+
+      // Base: six trivial declarations.
+      await File(src).writeAsString(
+        [
+          for (var i = 0; i < 6; i++) 'int f$i(int x) { return x + $i; }\n',
+        ].join('\n'),
+      );
+      await runGit(['add', '.']);
+      await runGit(['commit', '-m', 'base']);
+
+      // Head: f0..f2 become violations (score 30), f3..f5 stay under the
+      // threshold but still regress (score 7).
+      await File(src).writeAsString(
+        [
+          for (var i = 0; i < 3; i++) _decl('f$i', 3),
+          for (var i = 3; i < 6; i++) _decl('f$i', 1),
+        ].join('\n'),
+      );
+      await runGit(['add', '.']);
+      await runGit(['commit', '-m', 'head']);
+    });
+
+    test('caps comment rows and keeps the full table in the step '
+        'summary', () async {
+      await runScanner([
+        '--comment-output=$commentPath',
+        '--max-comment-rows=2',
+      ]);
+
+      int rows(String s) =>
+          s.split('\n').where((l) => l.startsWith('| ')).length;
+
+      final comment = await File(commentPath).readAsString();
+      final summary = await File(summaryPath).readAsString();
+
+      // 2 header rows + 2 capped data rows.
+      check(rows(comment)).equals(4);
+      // 2 header rows + all 6 changed declarations.
+      check(rows(summary)).equals(8);
+      check(comment).contains('most significant of 6 changed declarations');
+    });
+
+    test('orders violations ahead of sub-threshold regressions', () async {
+      await runScanner([
+        '--comment-output=$commentPath',
+        '--max-comment-rows=3',
+      ]);
+
+      final comment = await File(commentPath).readAsString();
+      final shown = comment
+          .split('\n')
+          .where((l) => l.startsWith('| ') && l.contains('`f'))
+          .toList();
+
+      check(shown).length.equals(3);
+      // Only the three violations may occupy a three-row budget.
+      for (final line in shown) {
+        check(line).contains('🔴');
+      }
+    });
+
+    test('omits the truncation footer when everything fits', () async {
+      await runScanner([
+        '--comment-output=$commentPath',
+        '--max-comment-rows=50',
+      ]);
+
+      final comment = await File(commentPath).readAsString();
+      check(comment).not((c) => c.contains('most significant of'));
+    });
+
+    test('annotates every changed declaration regardless of the '
+        'cap', () async {
+      final res = await runScanner([
+        '--comment-output=$commentPath',
+        '--max-comment-rows=1',
+      ]);
+
+      final out = res.stdout as String;
+      // Capping the comment must not hide inline Files-changed annotations.
+      check('::error'.allMatches(out).length).equals(3);
+      check('::warning'.allMatches(out).length).equals(3);
+    });
+
+    test('writes no comment file when --comment-output is omitted', () async {
+      await runScanner([]);
+
+      check(File(commentPath).existsSync()).isFalse();
+      check(await File(summaryPath).readAsString()).contains('| 🔴 |');
+    });
+  });
+}


### PR DESCRIPTION
GitHub rejects issue-comment bodies over 65536 characters. On a large diff
the rendered delta table exceeds that, and because both write paths in
`action.yml` end in `|| true`, the failure is silent — either no comment
appears, or a stale one from an earlier push is left in place with nothing
indicating it is out of date.

The table is also per *declaration*, not per file, so the row count grows
faster than people expect: a 100-file PR can produce well over a thousand rows.

### What this adds

`max-comment-rows`, default `0` (unlimited), so **existing behaviour is
unchanged unless you opt in**. When set, the reporter writes a second, trimmed
rendering via a new `--comment-output` and the action posts that instead. The
step summary still receives the complete table.

Rows in the trimmed rendering are ordered by significance — violations, then
regressions, then additions. Ordering matters: a cap without it can hide every
violation behind `improved` declarations that happen to score higher. A footer
reports how many were omitted and points at the step summary.

Inline annotations are emitted for **every** changed declaration regardless of
the cap, so trimming the comment never hides a Files-changed warning.

### Testing

Five tests in `test/comment_output_test.dart` covering the cap, the ordering,
the footer only appearing when truncated, annotation coverage under a cap of 1,
and that omitting `--comment-output` writes no file. Full suite green (128).

### Known gap

`--comment-output` is currently wired only in diff mode; with no `--git-diff`
it is silently ignored. Happy to wire `_handleRegularMode` too, but that needs
`_reportRegular` routed into the comment buffer as well — otherwise it emits a
header-only file that the action would still post. Left out to keep this
reviewable; say the word and I will add it here or as a follow-up.