### PR TITLE
fix(cognitive_complexity): anchor annotations to the declaration line

### DIFF
--- a/packages/cognitive_complexity/CHANGELOG.md
+++ b/packages/cognitive_complexity/CHANGELOG.md
@@ -6,6 +6,8 @@
   while the step summary keeps the full table.
 - Add `max-comment-rows` input to the GitHub Action (default `0` = unlimited)
   to keep sticky comments under GitHub's 65536-character body limit.
+- Anchor GitHub annotations to the declaration line only, so they render
+  under the function signature instead of after the closing brace.
 - Move package into pub workspace monorepo layout under `packages/cognitive_complexity`.
 - Restore root `action.yml` and `skills/` structure for monorepo workspace.
 

--- a/packages/cognitive_complexity/lib/src/complexity/github_reporter.dart
+++ b/packages/cognitive_complexity/lib/src/complexity/github_reporter.dart
@@ -94,9 +94,12 @@ class GitHubReporter {
       );
 
       if (isViolation) {
+        // Anchor only the declaration line: GitHub renders annotations below
+        // the last line of the range, so a whole-body range would place the
+        // message after the closing brace instead of under the signature.
         _stdoutSink.writeln(
           '::error file=${res.filePath},line=${res.startLine},'
-          'endLine=${res.endLine},title=High Cognitive Complexity '
+          'title=High Cognitive Complexity '
           '(${res.score} > $failThreshold)::${res.name} has score '
           '${res.score} which exceeds failure threshold of $failThreshold.',
         );
@@ -236,6 +239,9 @@ class GitHubReporter {
     return '⚪';
   }
 
+  /// Anchors annotations to the declaration line only: GitHub renders them
+  /// below the last line of the range, so a whole-body range would place the
+  /// message after the closing brace instead of under the signature.
   void _emitDiagnostic(ComplexityDelta d, int? failThreshold, bool failInc) {
     final isVio = d.isViolation(
       failThreshold: failThreshold,
@@ -248,13 +254,13 @@ class GitHubReporter {
           : 'increased in complexity (+${d.delta} points)';
       _stdoutSink.writeln(
         '::error file=${d.filePath},line=${d.startLine},'
-        'endLine=${d.endLine},title=Cognitive Complexity Violation::'
+        'title=Cognitive Complexity Violation::'
         '${d.name} was $reason to score ${d.newScore}.',
       );
     } else if (d.status == DeltaStatus.increased) {
       _stdoutSink.writeln(
         '::warning file=${d.filePath},line=${d.startLine},'
-        'endLine=${d.endLine},title=Cognitive Complexity Increased '
+        'title=Cognitive Complexity Increased '
         '(+${d.delta})::${d.name} increased from ${d.oldScore} to '
         '${d.newScore} (+${d.delta} points).',
       );

--- a/packages/cognitive_complexity/test/delta_analyzer_test.dart
+++ b/packages/cognitive_complexity/test/delta_analyzer_test.dart
@@ -138,7 +138,7 @@ void main() {
 
       reporter.printReport(deltaSummary: summary);
       check(outBuf.toString()).contains(
-        '::warning file=lib/service.dart,line=12,endLine=40,'
+        '::warning file=lib/service.dart,line=12,'
         'title=Cognitive Complexity Increased (+5)::Service.execute '
         'increased from 5 to 10 (+5 points).',
       );
@@ -167,7 +167,7 @@ void main() {
 
       reporter.printReport(deltaSummary: summary, failThreshold: 15);
       check(outBuf.toString()).contains(
-        '::error file=lib/parser.dart,line=1,endLine=80,'
+        '::error file=lib/parser.dart,line=1,'
         'title=Cognitive Complexity Violation::Parser.parse was '
         'increased in complexity (+15 points) to score 25.',
       );


### PR DESCRIPTION
GitHub renders workflow-command annotations below the last line of
the annotated range, so line+endLine spanning the whole body placed
the message after the closing brace. Anchoring only the declaration
line hangs it under the function signature instead.
