### PR TITLE
fix(dedupe): resolve git-diff paths against repo root independently of cwd

### DIFF
--- a/packages/dedupe/lib/src/cache.dart
+++ b/packages/dedupe/lib/src/cache.dart
@@ -153,6 +153,16 @@ class DedupeCacheManager {
     } catch (_) {}
   }
 
+  static final _cacheEntryFileNamePattern = RegExp(r'^[0-9a-fA-F]{16}\.json$');
+  static final _cacheEntryDirPattern = RegExp(r'^[0-9a-fA-F]{2}$');
+
+  bool _isCacheEntryFile(String filePath) {
+    final fileName = p.basename(filePath);
+    if (!_cacheEntryFileNamePattern.hasMatch(fileName)) return false;
+    final parentDir = p.basename(p.dirname(filePath));
+    return _cacheEntryDirPattern.hasMatch(parentDir);
+  }
+
   /// Prunes stale cache entries that no longer correspond to [activeRelPaths].
   void pruneStale(Set<String> activeRelPaths) {
     if (!enabled) return;
@@ -164,15 +174,30 @@ class DedupeCacheManager {
       final files = cacheDir.listSync(recursive: true).whereType<File>();
       for (final file in files) {
         if (!file.path.endsWith('.json')) continue;
+        if (!_isCacheEntryFile(file.path)) continue;
         try {
-          final data =
-              jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
-          final relPath = data['relPath'] as String?;
-          if (relPath != null && !activeRelPaths.contains(relPath)) {
+          final decoded = jsonDecode(file.readAsStringSync());
+          if (decoded is! Map<String, dynamic>) continue;
+          final relPath = decoded['relPath'] as String?;
+          final version = decoded['version'];
+          final optionsHash = decoded['optionsHash'];
+          final contentHash = decoded['contentHash'];
+          final entry = decoded['entry'];
+
+          // Only prune entries that strictly match the dedupe cache schema.
+          if (relPath == null ||
+              version == null ||
+              optionsHash == null ||
+              contentHash == null ||
+              entry == null) {
+            continue;
+          }
+
+          if (!activeRelPaths.contains(relPath)) {
             file.deleteSync();
           }
         } catch (_) {
-          file.deleteSync();
+          // Never delete unrecognized, malformed, or non-dedupe files.
         }
       }
     } catch (_) {}

--- a/packages/dedupe/lib/src/cache.dart
+++ b/packages/dedupe/lib/src/cache.dart
@@ -163,6 +163,26 @@ class DedupeCacheManager {
     return _cacheEntryDirPattern.hasMatch(parentDir);
   }
 
+  /// Returns the `relPath` of a dedupe cache entry file, or `null` if [file]
+  /// is not one: unreadable, not JSON, or missing any schema field.
+  String? _cacheEntryRelPath(File file) {
+    try {
+      final decoded = jsonDecode(file.readAsStringSync());
+      if (decoded is! Map<String, dynamic>) return null;
+      for (final key in const [
+        'version',
+        'optionsHash',
+        'contentHash',
+        'entry',
+      ]) {
+        if (decoded[key] == null) return null;
+      }
+      return decoded['relPath'] as String?;
+    } catch (_) {
+      return null;
+    }
+  }
+
   /// Prunes stale cache entries that no longer correspond to [activeRelPaths].
   void pruneStale(Set<String> activeRelPaths) {
     if (!enabled) return;
@@ -173,42 +193,47 @@ class DedupeCacheManager {
     try {
       final files = cacheDir.listSync(recursive: true).whereType<File>();
       for (final file in files) {
-        if (!file.path.endsWith('.json')) continue;
         if (!_isCacheEntryFile(file.path)) continue;
+        final relPath = _cacheEntryRelPath(file);
+        if (relPath == null || activeRelPaths.contains(relPath)) continue;
         try {
-          final decoded = jsonDecode(file.readAsStringSync());
-          if (decoded is! Map<String, dynamic>) continue;
-          final relPath = decoded['relPath'] as String?;
-          final version = decoded['version'];
-          final optionsHash = decoded['optionsHash'];
-          final contentHash = decoded['contentHash'];
-          final entry = decoded['entry'];
-
-          // Only prune entries that strictly match the dedupe cache schema.
-          if (relPath == null ||
-              version == null ||
-              optionsHash == null ||
-              contentHash == null ||
-              entry == null) {
-            continue;
-          }
-
-          if (!activeRelPaths.contains(relPath)) {
-            file.deleteSync();
-          }
-        } catch (_) {
-          // Never delete unrecognized, malformed, or non-dedupe files.
-        }
+          file.deleteSync();
+        } catch (_) {}
       }
     } catch (_) {}
   }
 
-  /// Clears the entire cache directory.
+  /// Clears dedupe cache entries from the cache directory without removing
+  /// unrelated user files.
   void clear() {
     final cacheDir = Directory(cacheDirPath);
-    if (cacheDir.existsSync()) {
+    if (!cacheDir.existsSync()) return;
+
+    try {
+      final files = cacheDir.listSync(recursive: true).whereType<File>();
+      for (final file in files) {
+        _deleteCacheEntryFile(file);
+      }
+      _deleteEmptyShardDirs(cacheDir);
+    } catch (_) {}
+  }
+
+  void _deleteCacheEntryFile(File file) {
+    if (!_isCacheEntryFile(file.path)) return;
+    if (_cacheEntryRelPath(file) == null) return;
+    try {
+      file.deleteSync();
+    } catch (_) {}
+  }
+
+  void _deleteEmptyShardDirs(Directory cacheDir) {
+    for (final entity in cacheDir.listSync()) {
+      if (entity is! Directory) continue;
+      if (!_cacheEntryDirPattern.hasMatch(p.basename(entity.path))) continue;
       try {
-        cacheDir.deleteSync(recursive: true);
+        if (entity.listSync().isEmpty) {
+          entity.deleteSync();
+        }
       } catch (_) {}
     }
   }

--- a/packages/dedupe/lib/src/delta_service.dart
+++ b/packages/dedupe/lib/src/delta_service.dart
@@ -19,17 +19,45 @@ class DedupeDeltaService {
     return _gitDiffService.getParsedDiff(baseRef, targetPaths: targetPaths);
   }
 
+  /// Returns the absolute path to the root of the Git repository.
+  Future<String> getRepoRoot() => _gitDiffService.getRepoRoot();
+
   /// Maps a list of [GitFileDiff]s to a map of normalized relative file paths
   /// to their added or modified [LineRange]s.
   Map<String, List<LineRange>> extractDiffRanges(
     List<GitFileDiff> fileDiffs, {
     String? baseDir,
+    String? repoRoot,
   }) {
     final map = <String, List<LineRange>>{};
+    final absBaseDir = baseDir != null
+        ? p.normalize(p.absolute(baseDir))
+        : null;
+
     for (final diff in fileDiffs) {
-      var path = diff.path;
-      if (baseDir != null && p.isWithin(baseDir, path)) {
-        path = p.relative(path, from: baseDir);
+      final diffPath = diff.path;
+      String path;
+      if (absBaseDir != null) {
+        String absDiffPath;
+        if (repoRoot != null) {
+          absDiffPath = p.normalize(p.join(repoRoot, diffPath));
+        } else if (p.isAbsolute(diffPath)) {
+          absDiffPath = p.normalize(diffPath);
+        } else if (baseDir != null &&
+            (p.isWithin(baseDir, diffPath) || p.equals(baseDir, diffPath))) {
+          absDiffPath = p.normalize(p.absolute(diffPath));
+        } else {
+          absDiffPath = p.normalize(p.join(absBaseDir, diffPath));
+        }
+
+        if (p.isWithin(absBaseDir, absDiffPath) ||
+            p.equals(absBaseDir, absDiffPath)) {
+          path = p.relative(absDiffPath, from: absBaseDir);
+        } else {
+          continue;
+        }
+      } else {
+        path = diffPath;
       }
       path = p.normalize(path);
       map[path] = diff.addedOrModifiedLineRanges;

--- a/packages/dedupe/lib/src/delta_service.dart
+++ b/packages/dedupe/lib/src/delta_service.dart
@@ -38,17 +38,9 @@ class DedupeDeltaService {
       final diffPath = diff.path;
       String path;
       if (absBaseDir != null) {
-        String absDiffPath;
-        if (repoRoot != null) {
-          absDiffPath = p.normalize(p.join(repoRoot, diffPath));
-        } else if (p.isAbsolute(diffPath)) {
-          absDiffPath = p.normalize(diffPath);
-        } else if (baseDir != null &&
-            (p.isWithin(baseDir, diffPath) || p.equals(baseDir, diffPath))) {
-          absDiffPath = p.normalize(p.absolute(diffPath));
-        } else {
-          absDiffPath = p.normalize(p.join(absBaseDir, diffPath));
-        }
+        final absDiffPath = repoRoot != null
+            ? p.normalize(p.join(repoRoot, diffPath))
+            : p.normalize(p.absolute(diffPath));
 
         if (p.isWithin(absBaseDir, absDiffPath) ||
             p.equals(absBaseDir, absDiffPath)) {

--- a/packages/dedupe/lib/src/engine.dart
+++ b/packages/dedupe/lib/src/engine.dart
@@ -167,10 +167,7 @@ class DedupeEngine {
     }
 
     final deltaService = DedupeDeltaService(workingDirectory: targetDirPath);
-    String? repoRoot;
-    try {
-      repoRoot = await deltaService.getRepoRoot();
-    } catch (_) {}
+    final repoRoot = await deltaService.getRepoRoot();
     final diffs = await deltaService.getParsedDiff(options.gitDiffBase!);
     final diffRanges = deltaService.extractDiffRanges(
       diffs,

--- a/packages/dedupe/lib/src/engine.dart
+++ b/packages/dedupe/lib/src/engine.dart
@@ -167,10 +167,15 @@ class DedupeEngine {
     }
 
     final deltaService = DedupeDeltaService(workingDirectory: targetDirPath);
+    String? repoRoot;
+    try {
+      repoRoot = await deltaService.getRepoRoot();
+    } catch (_) {}
     final diffs = await deltaService.getParsedDiff(options.gitDiffBase!);
     final diffRanges = deltaService.extractDiffRanges(
       diffs,
       baseDir: targetDirPath,
+      repoRoot: repoRoot,
     );
 
     final result = deltaService.applyDiffToClusters(

--- a/packages/dedupe/test/cache_test.dart
+++ b/packages/dedupe/test/cache_test.dart
@@ -209,6 +209,58 @@ void main() {
       check(arrayJson.existsSync()).isTrue();
       check(nonCacheJson.existsSync()).isTrue();
     });
+
+    test(
+      'clear removes only valid cache files and empty shard directories',
+      () {
+        const options = DedupeOptions(targetPath: '.');
+        final cache = DedupeCacheManager(
+          cacheDirPath: cacheDir,
+          enabled: true,
+          options: options,
+        );
+
+        // Add a valid cache entry
+        const code = 'void testMethod() { print(1); }';
+        final hash = DedupeCacheManager.computeContentHash(code);
+        const extractor = AstExtractor(minTokens: 5, minLines: 1);
+        final (seq, candidates) = extractor.extract(
+          filePath: 'lib/sample.dart',
+          content: code,
+          fileIndex: 0,
+        );
+        cache.putEntry(
+          relPath: 'lib/sample.dart',
+          contentHash: hash,
+          sequence: seq,
+          candidates: candidates,
+        );
+
+        // Add unrelated files in the cache directory
+        final configJson = File(p.join(cacheDir, 'config.json'));
+        configJson.writeAsStringSync('{"settings": true}');
+
+        final notesTxt = File(p.join(cacheDir, 'notes.txt'));
+        notesTxt.writeAsStringSync('important notes');
+
+        // Verify entry exists before clear
+        check(
+          cache.getEntry(relPath: 'lib/sample.dart', contentHash: hash),
+        ).isNotNull();
+
+        // Clear cache
+        cache.clear();
+
+        // Cache entry is gone
+        check(
+          cache.getEntry(relPath: 'lib/sample.dart', contentHash: hash),
+        ).isNull();
+
+        // Unrelated files remain untouched
+        check(configJson.existsSync()).isTrue();
+        check(notesTxt.existsSync()).isTrue();
+      },
+    );
   });
 
   group('DedupeEngine Incremental Cache Integration', () {

--- a/packages/dedupe/test/cache_test.dart
+++ b/packages/dedupe/test/cache_test.dart
@@ -170,6 +170,45 @@ void main() {
         cache.getEntry(relPath: 'lib/old.dart', contentHash: hash),
       ).isNull();
     });
+
+    test('pruneStale does not delete unrelated or malformed JSON files', () {
+      const options = DedupeOptions(targetPath: '.');
+      final cache = DedupeCacheManager(
+        cacheDirPath: cacheDir,
+        enabled: true,
+        options: options,
+      );
+
+      // Create a mix of unrelated files in cache directory
+      final configJson = File(p.join(cacheDir, 'config.json'));
+      configJson.parent.createSync(recursive: true);
+      configJson.writeAsStringSync(
+        '{"settings": true, "relPath": "other.dart"}',
+      );
+
+      final malformedJson = File(p.join(cacheDir, 'ab', 'malformed.json'));
+      malformedJson.parent.createSync(recursive: true);
+      malformedJson.writeAsStringSync('invalid json content {{{');
+
+      final arrayJson = File(p.join(cacheDir, 'cd', '0123456789abcdef.json'));
+      arrayJson.parent.createSync(recursive: true);
+      arrayJson.writeAsStringSync('[1, 2, 3]');
+
+      final nonCacheJson = File(
+        p.join(cacheDir, 'cd', 'fedcba9876543210.json'),
+      );
+      nonCacheJson.parent.createSync(recursive: true);
+      nonCacheJson.writeAsStringSync('{"someKey": "value"}');
+
+      // Run pruneStale with empty active set
+      cache.pruneStale(<String>{});
+
+      // All unrelated files must survive
+      check(configJson.existsSync()).isTrue();
+      check(malformedJson.existsSync()).isTrue();
+      check(arrayJson.existsSync()).isTrue();
+      check(nonCacheJson.existsSync()).isTrue();
+    });
   });
 
   group('DedupeEngine Incremental Cache Integration', () {

--- a/packages/dedupe/test/delta_service_test.dart
+++ b/packages/dedupe/test/delta_service_test.dart
@@ -32,6 +32,53 @@ void main() {
     });
 
     test(
+      'extractDiffRanges resolves repo-relative diffs against absolute baseDir and repoRoot',
+      () {
+        final service = DedupeDeltaService();
+        final diffs = [
+          const GitFileDiff(
+            newPath: 'packages/core/lib/src/util.dart',
+            hunks: [
+              DiffHunk(
+                oldStart: 10,
+                oldCount: 5,
+                newStart: 10,
+                newCount: 8,
+                lines: [],
+                addedOrModifiedRanges: [LineRange(12, 16)],
+              ),
+            ],
+          ),
+          const GitFileDiff(
+            newPath: 'packages/other/lib/other.dart',
+            hunks: [
+              DiffHunk(
+                oldStart: 1,
+                oldCount: 1,
+                newStart: 1,
+                newCount: 5,
+                lines: [],
+                addedOrModifiedRanges: [LineRange(1, 5)],
+              ),
+            ],
+          ),
+        ];
+
+        final ranges = service.extractDiffRanges(
+          diffs,
+          baseDir: '/repo/root/packages/core',
+          repoRoot: '/repo/root',
+        );
+
+        check(ranges['lib/src/util.dart']).isNotNull();
+        check(
+          ranges['lib/src/util.dart']!.single,
+        ).equals(const LineRange(12, 16));
+        check(ranges.containsKey('packages/other/lib/other.dart')).isFalse();
+      },
+    );
+
+    test(
       'applyDiffToClusters annotates instances and computes diff duplication',
       () {
         final service = DedupeDeltaService();

--- a/packages/dedupe/test/delta_service_test.dart
+++ b/packages/dedupe/test/delta_service_test.dart
@@ -31,52 +31,50 @@ void main() {
       ).equals(const LineRange(12, 16));
     });
 
-    test(
-      'extractDiffRanges resolves repo-relative diffs against absolute baseDir and repoRoot',
-      () {
-        final service = DedupeDeltaService();
-        final diffs = [
-          const GitFileDiff(
-            newPath: 'packages/core/lib/src/util.dart',
-            hunks: [
-              DiffHunk(
-                oldStart: 10,
-                oldCount: 5,
-                newStart: 10,
-                newCount: 8,
-                lines: [],
-                addedOrModifiedRanges: [LineRange(12, 16)],
-              ),
-            ],
-          ),
-          const GitFileDiff(
-            newPath: 'packages/other/lib/other.dart',
-            hunks: [
-              DiffHunk(
-                oldStart: 1,
-                oldCount: 1,
-                newStart: 1,
-                newCount: 5,
-                lines: [],
-                addedOrModifiedRanges: [LineRange(1, 5)],
-              ),
-            ],
-          ),
-        ];
+    test('extractDiffRanges resolves repo-relative diffs against absolute '
+        'baseDir and repoRoot', () {
+      final service = DedupeDeltaService();
+      final diffs = [
+        const GitFileDiff(
+          newPath: 'packages/core/lib/src/util.dart',
+          hunks: [
+            DiffHunk(
+              oldStart: 10,
+              oldCount: 5,
+              newStart: 10,
+              newCount: 8,
+              lines: [],
+              addedOrModifiedRanges: [LineRange(12, 16)],
+            ),
+          ],
+        ),
+        const GitFileDiff(
+          newPath: 'packages/other/lib/other.dart',
+          hunks: [
+            DiffHunk(
+              oldStart: 1,
+              oldCount: 1,
+              newStart: 1,
+              newCount: 5,
+              lines: [],
+              addedOrModifiedRanges: [LineRange(1, 5)],
+            ),
+          ],
+        ),
+      ];
 
-        final ranges = service.extractDiffRanges(
-          diffs,
-          baseDir: '/repo/root/packages/core',
-          repoRoot: '/repo/root',
-        );
+      final ranges = service.extractDiffRanges(
+        diffs,
+        baseDir: '/repo/root/packages/core',
+        repoRoot: '/repo/root',
+      );
 
-        check(ranges['lib/src/util.dart']).isNotNull();
-        check(
-          ranges['lib/src/util.dart']!.single,
-        ).equals(const LineRange(12, 16));
-        check(ranges.containsKey('packages/other/lib/other.dart')).isFalse();
-      },
-    );
+      check(ranges['lib/src/util.dart']).isNotNull();
+      check(
+        ranges['lib/src/util.dart']!.single,
+      ).equals(const LineRange(12, 16));
+      check(ranges.containsKey('packages/other/lib/other.dart')).isFalse();
+    });
 
     test(
       'applyDiffToClusters annotates instances and computes diff duplication',


### PR DESCRIPTION
DedupeDeltaService.extractDiffRanges previously resolved repo-relative
Git file diff paths against Directory.current instead of the Git repo
root, causing --git-diff and --only-changed to silently report 0.0% diff
duplication when run from package subdirectories.

- Pass repoRoot to DedupeDeltaService.extractDiffRanges.
- Resolve Git diff paths to absolute paths before checking containment within baseDir.
- Expose getRepoRoot() on DedupeDeltaService.
- Add test verifying that repo-relative diffs match absolute baseDir targets.

Fixes #58
