### PR TITLE
fix(dedupe): validate numeric CLI args cleanly and reject NaN thresholds

### DIFF
--- a/packages/dedupe/lib/src/cli.dart
+++ b/packages/dedupe/lib/src/cli.dart
@@ -166,17 +166,33 @@ class DedupeCliRunner {
     if (results.flag('help')) return _handleHelp();
     if (results.flag('version')) return _handleVersion();
 
+    if (results.rest.isEmpty) {
+      final normalizedPath = p.normalize(p.absolute('.'));
+      if (!Directory(normalizedPath).existsSync() &&
+          !File(normalizedPath).existsSync()) {
+        errSink.writeln('Error: Target path does not exist: .');
+        return ExitCode.noInput.code;
+      }
+    } else {
+      for (final target in results.rest) {
+        final normalizedPath = p.normalize(p.absolute(target));
+        if (!Directory(normalizedPath).existsSync() &&
+            !File(normalizedPath).existsSync()) {
+          errSink.writeln('Error: Target path does not exist: $target');
+          return ExitCode.noInput.code;
+        }
+      }
+    }
+
     final targetPath = results.rest.isNotEmpty ? results.rest.first : '.';
     final normalizedPath = p.normalize(p.absolute(targetPath));
 
-    if (!Directory(normalizedPath).existsSync() &&
-        !File(normalizedPath).existsSync()) {
-      errSink.writeln('Error: Target path does not exist: $targetPath');
-      return ExitCode.noInput.code;
+    final DedupeOptions options;
+    try {
+      options = _buildOptions(results, normalizedPath);
+    } on FormatException catch (e) {
+      return _handleFormatException(e);
     }
-
-    final options = _buildOptions(results, normalizedPath);
-    if (options == null) return ExitCode.usage.code;
 
     return _executeAnalysis(options);
   }
@@ -206,7 +222,7 @@ class DedupeCliRunner {
     return ExitCode.success.code;
   }
 
-  DedupeOptions? _buildOptions(ArgResults results, String normalizedPath) {
+  DedupeOptions _buildOptions(ArgResults results, String normalizedPath) {
     final format = OutputFormat.fromString(results.option('format')!);
     final minTokens = parseNonNegativeInt(
       results.option('min-tokens') ?? '40',
@@ -225,13 +241,12 @@ class DedupeCliRunner {
 
     double? failThreshold;
     if (results.option('fail-threshold') != null) {
-      final parsed = double.tryParse(results.option('fail-threshold')!);
-      if (parsed == null || parsed < 0) {
-        errSink.writeln(
-          'Error: Invalid fail-threshold: ${results.option('fail-threshold')}. '
-          'Must be a non-negative number.',
+      final raw = results.option('fail-threshold')!;
+      final parsed = double.tryParse(raw);
+      if (parsed == null || parsed < 0 || parsed.isNaN || parsed.isInfinite) {
+        throw FormatException(
+          'Invalid fail-threshold: "$raw". Must be a non-negative finite number.',
         );
-        return null;
       }
       failThreshold = parsed;
     }

--- a/packages/dedupe/lib/src/cli.dart
+++ b/packages/dedupe/lib/src/cli.dart
@@ -166,24 +166,6 @@ class DedupeCliRunner {
     if (results.flag('help')) return _handleHelp();
     if (results.flag('version')) return _handleVersion();
 
-    if (results.rest.isEmpty) {
-      final normalizedPath = p.normalize(p.absolute('.'));
-      if (!Directory(normalizedPath).existsSync() &&
-          !File(normalizedPath).existsSync()) {
-        errSink.writeln('Error: Target path does not exist: .');
-        return ExitCode.noInput.code;
-      }
-    } else {
-      for (final target in results.rest) {
-        final normalizedPath = p.normalize(p.absolute(target));
-        if (!Directory(normalizedPath).existsSync() &&
-            !File(normalizedPath).existsSync()) {
-          errSink.writeln('Error: Target path does not exist: $target');
-          return ExitCode.noInput.code;
-        }
-      }
-    }
-
     final targetPath = results.rest.isNotEmpty ? results.rest.first : '.';
     final normalizedPath = p.normalize(p.absolute(targetPath));
 
@@ -192,6 +174,15 @@ class DedupeCliRunner {
       options = _buildOptions(results, normalizedPath);
     } on FormatException catch (e) {
       return _handleFormatException(e);
+    }
+
+    for (final target in results.rest) {
+      final normalizedPath = p.normalize(p.absolute(target));
+      if (!Directory(normalizedPath).existsSync() &&
+          !File(normalizedPath).existsSync()) {
+        errSink.writeln('Error: Target path does not exist: $target');
+        return ExitCode.noInput.code;
+      }
     }
 
     return _executeAnalysis(options);
@@ -245,7 +236,8 @@ class DedupeCliRunner {
       final parsed = double.tryParse(raw);
       if (parsed == null || parsed < 0 || parsed.isNaN || parsed.isInfinite) {
         throw FormatException(
-          'Invalid fail-threshold: "$raw". Must be a non-negative finite number.',
+          'Invalid fail-threshold: "$raw". '
+          'Must be a non-negative finite number.',
         );
       }
       failThreshold = parsed;

--- a/packages/dedupe/test/cli_test.dart
+++ b/packages/dedupe/test/cli_test.dart
@@ -267,6 +267,30 @@ void uniqueB() {
       check(code).equals(66);
     });
 
+    test('run fails when any positional path does not exist', () async {
+      await d.dir('in_proc_pkg_valid', [
+        d.dir('lib', [d.file('a.dart', 'void main() {}')]),
+      ]).create();
+
+      final runner = DedupeCliRunner();
+      final code = await runner.run([
+        d.path('in_proc_pkg_valid'),
+        'does/not/exist/second_dir',
+      ]);
+      check(code).equals(66);
+    });
+
+    test('run reports usage on invalid numeric options', () async {
+      final runner = DedupeCliRunner();
+      check(await runner.run(['--min-tokens=abc', '.'])).equals(64);
+      check(await runner.run(['--min-tokens=-5', '.'])).equals(64);
+      check(await runner.run(['--min-lines=foo', '.'])).equals(64);
+      check(await runner.run(['--top=xyz', '.'])).equals(64);
+      check(await runner.run(['--fail-threshold=-1', '.'])).equals(64);
+      check(await runner.run(['--fail-threshold=NaN', '.'])).equals(64);
+      check(await runner.run(['--fail-threshold=Infinity', '.'])).equals(64);
+    });
+
     test('run executes analysis on temporary directory', () async {
       await d.dir('in_proc_pkg', [
         d.dir('lib', [d.file('a.dart', 'void main() { print("hi"); }')]),

--- a/packages/dedupe/test/cli_test.dart
+++ b/packages/dedupe/test/cli_test.dart
@@ -288,8 +288,25 @@ void uniqueB() {
       check(await runner.run(['--top=xyz', '.'])).equals(64);
       check(await runner.run(['--fail-threshold=-1', '.'])).equals(64);
       check(await runner.run(['--fail-threshold=NaN', '.'])).equals(64);
+      check(await runner.run(['--fail-threshold=nan', '.'])).equals(64);
       check(await runner.run(['--fail-threshold=Infinity', '.'])).equals(64);
+      check(await runner.run(['--fail-threshold=inf', '.'])).equals(64);
+      check(await runner.run(['--fail-threshold=1e400', '.'])).equals(64);
+      check(await runner.run(['--fail-threshold=1e309', '.'])).equals(64);
+      check(await runner.run(['--fail-threshold=-Infinity', '.'])).equals(64);
     });
+
+    test(
+      'run prioritizes flag validation errors over nonexistent paths',
+      () async {
+        final runner = DedupeCliRunner();
+        final code = await runner.run([
+          '--min-tokens=abc',
+          'does/not/exist/path',
+        ]);
+        check(code).equals(64);
+      },
+    );
 
     test('run executes analysis on temporary directory', () async {
       await d.dir('in_proc_pkg', [


### PR DESCRIPTION
DedupeCliRunner.run previously called _buildOptions outside the
try/on FormatException block, causing invalid numeric arguments
(--min-tokens=abc, --min-lines=-5, --top=xyz) to crash with exit code 255
and a raw stack trace instead of reporting usage errors with exit code 64.
In addition, fail-threshold accepted NaN and Infinity, silently
disabling the CI failure gate.

- Wrap option parsing and conversion in run() to return clean exit 64 usage errors.
- Reject NaN, Infinity, and non-finite numbers in fail-threshold.
- Validate all positional paths before execution and return exit 66 on missing paths.
- Add comprehensive in-process CLI error handling tests.

Fixes #66
