### PR TITLE
fix(dedupe): verify token similarity on MinHash near-miss candidate pairs

### DIFF
--- a/packages/dedupe/lib/src/detector.dart
+++ b/packages/dedupe/lib/src/detector.dart
@@ -158,6 +158,7 @@ class CloneDetector {
       );
       _matchMinHashCandidates(
         candidates: candidates,
+        fileSequences: fileSequences,
         seenPairs: seenPairs,
         outPairs: rawPairs,
       );
@@ -275,6 +276,7 @@ class CloneDetector {
 
   static void _matchMinHashCandidates({
     required List<AstCandidateUnit> candidates,
+    required List<TokenSequence> fileSequences,
     required Set<int> seenPairs,
     required List<_MatchPair> outPairs,
     double minJaccard = 0.80,
@@ -291,6 +293,7 @@ class CloneDetector {
       _tryAddMinHashCandidatePair(
         c1: pair.item1,
         c2: pair.item2,
+        fileSequences: fileSequences,
         minJaccard: minJaccard,
         seenPairs: seenPairs,
         outPairs: outPairs,
@@ -301,6 +304,7 @@ class CloneDetector {
   static void _tryAddMinHashCandidatePair({
     required AstCandidateUnit c1,
     required AstCandidateUnit c2,
+    required List<TokenSequence> fileSequences,
     required double minJaccard,
     required Set<int> seenPairs,
     required List<_MatchPair> outPairs,
@@ -317,6 +321,10 @@ class CloneDetector {
     );
     if (jaccard < minJaccard) return;
 
+    if (!_verifyMinHashCandidateTokens(c1, c2, fileSequences, minJaccard)) {
+      return;
+    }
+
     final span1 = _TokenSpan(
       fileIndex: c1.fileIndex,
       startTokenIndex: c1.startTokenIndex,
@@ -332,6 +340,38 @@ class CloneDetector {
     if (seenPairs.add(pairKey)) {
       outPairs.add(_MatchPair(span1, span2));
     }
+  }
+
+  static bool _verifyMinHashCandidateTokens(
+    AstCandidateUnit c1,
+    AstCandidateUnit c2,
+    List<TokenSequence> fileSequences,
+    double minSimilarity,
+  ) {
+    final tokens1 = fileSequences[c1.fileIndex].tokens;
+    final tokens2 = fileSequences[c2.fileIndex].tokens;
+
+    const shingleSize = 2;
+    if (c1.tokenCount < shingleSize || c2.tokenCount < shingleSize) {
+      return _compareCandidateTokens(c1, c2, fileSequences);
+    }
+
+    final shingles1 = <int>{};
+    for (var i = 0; i <= c1.tokenCount - shingleSize; i++) {
+      final h1 = tokens1[c1.startTokenIndex + i].tokenHash;
+      final h2 = tokens1[c1.startTokenIndex + i + 1].tokenHash;
+      shingles1.add(Object.hash(h1, h2));
+    }
+
+    final shingles2 = <int>{};
+    for (var i = 0; i <= c2.tokenCount - shingleSize; i++) {
+      final h1 = tokens2[c2.startTokenIndex + i].tokenHash;
+      final h2 = tokens2[c2.startTokenIndex + i + 1].tokenHash;
+      shingles2.add(Object.hash(h1, h2));
+    }
+
+    final tokenJaccard = MinHasher.exactJaccard(shingles1, shingles2);
+    return tokenJaccard >= minSimilarity;
   }
 
   static bool _compareCandidateTokens(

--- a/packages/dedupe/lib/src/detector.dart
+++ b/packages/dedupe/lib/src/detector.dart
@@ -360,14 +360,14 @@ class CloneDetector {
     for (var i = 0; i <= c1.tokenCount - shingleSize; i++) {
       final h1 = tokens1[c1.startTokenIndex + i].tokenHash;
       final h2 = tokens1[c1.startTokenIndex + i + 1].tokenHash;
-      shingles1.add(Object.hash(h1, h2));
+      shingles1.add((h1 << 32) ^ (h2 & 0xFFFFFFFF));
     }
 
     final shingles2 = <int>{};
     for (var i = 0; i <= c2.tokenCount - shingleSize; i++) {
       final h1 = tokens2[c2.startTokenIndex + i].tokenHash;
       final h2 = tokens2[c2.startTokenIndex + i + 1].tokenHash;
-      shingles2.add(Object.hash(h1, h2));
+      shingles2.add((h1 << 32) ^ (h2 & 0xFFFFFFFF));
     }
 
     final tokenJaccard = MinHasher.exactJaccard(shingles1, shingles2);

--- a/packages/dedupe/test/minhash_test.dart
+++ b/packages/dedupe/test/minhash_test.dart
@@ -140,5 +140,54 @@ void handleUserOrder(String userId, double amount) {
       check(cluster.instances[0].filePath).equals('lib/order_a.dart');
       check(cluster.instances[1].filePath).equals('lib/order_b.dart');
     });
+
+    test('does not pair functions with identical statement sketches but '
+        'divergent token contents', () {
+      const codeA = r'''
+void logMetricsAlpha(int alpha, int beta) {
+  final result = alpha + beta;
+  print('Metric alpha computed: $result');
+  print('Dispatching alpha to telemetry');
+  print('Updating alpha cache state');
+  print('Finalizing alpha transaction');
+}
+''';
+
+      const codeB = r'''
+void sendEmailNotification(String recipient, String message) {
+  final status = recipient.isNotEmpty;
+  print('Sending notification to $recipient: $status');
+  print('Writing message payload to SMTP socket');
+  print('Awaiting server confirmation packet');
+  print('Closing SMTP connection socket');
+}
+''';
+
+      const extractor = AstExtractor(
+        minTokens: 15,
+        minLines: 4,
+        ignoreComments: true,
+        ignoreLiterals: false,
+      );
+
+      final (seqA, candA) = extractor.extract(
+        filePath: 'lib/metrics.dart',
+        content: codeA,
+        fileIndex: 0,
+      );
+      final (seqB, candB) = extractor.extract(
+        filePath: 'lib/email.dart',
+        content: codeB,
+        fileIndex: 1,
+      );
+
+      const detector = CloneDetector(minTokens: 15, minLines: 4);
+      final clusters = detector.detect(
+        [seqA, seqB],
+        candidates: [...candA, ...candB],
+      );
+
+      check(clusters.isEmpty).equals(true);
+    });
   });
 }


### PR DESCRIPTION
The MinHash LSH path previously emitted near-miss candidate pairs directly based on statement-level Jaccard similarity without checking whether the underlying token sequences actually shared token similarity, leading to false positive clone pairs when functions shared a similar statement sketch but had divergent token contents.

- Pass `fileSequences` to `_matchMinHashCandidates` and `_tryAddMinHashCandidatePair`.
- Add `_verifyMinHashCandidateTokens` to verify token sequence similarity via 2-gram token shingles before reporting candidate pairs.
- Add tests in `test/minhash_test.dart` asserting that functions with divergent token contents are not paired.

Fixes #64