### PR TITLE
fix(dedupe): use collision-free record pair keys for candidate deduplication

### DIFF
--- a/packages/dedupe/lib/src/detector.dart
+++ b/packages/dedupe/lib/src/detector.dart
@@ -158,6 +158,7 @@ class CloneDetector {
       );
       _matchMinHashCandidates(
         candidates: candidates,
+        fileSequences: fileSequences,
         seenPairs: seenPairs,
         outPairs: rawPairs,
       );
@@ -275,6 +276,7 @@ class CloneDetector {
 
   static void _matchMinHashCandidates({
     required List<AstCandidateUnit> candidates,
+    required List<TokenSequence> fileSequences,
     required Set<int> seenPairs,
     required List<_MatchPair> outPairs,
     double minJaccard = 0.80,
@@ -291,6 +293,7 @@ class CloneDetector {
       _tryAddMinHashCandidatePair(
         c1: pair.item1,
         c2: pair.item2,
+        fileSequences: fileSequences,
         minJaccard: minJaccard,
         seenPairs: seenPairs,
         outPairs: outPairs,
@@ -301,6 +304,7 @@ class CloneDetector {
   static void _tryAddMinHashCandidatePair({
     required AstCandidateUnit c1,
     required AstCandidateUnit c2,
+    required List<TokenSequence> fileSequences,
     required double minJaccard,
     required Set<int> seenPairs,
     required List<_MatchPair> outPairs,
@@ -317,6 +321,10 @@ class CloneDetector {
     );
     if (jaccard < minJaccard) return;
 
+    if (!_verifyMinHashCandidateTokens(c1, c2, fileSequences, minJaccard)) {
+      return;
+    }
+
     final span1 = _TokenSpan(
       fileIndex: c1.fileIndex,
       startTokenIndex: c1.startTokenIndex,
@@ -332,6 +340,38 @@ class CloneDetector {
     if (seenPairs.add(pairKey)) {
       outPairs.add(_MatchPair(span1, span2));
     }
+  }
+
+  static bool _verifyMinHashCandidateTokens(
+    AstCandidateUnit c1,
+    AstCandidateUnit c2,
+    List<TokenSequence> fileSequences,
+    double minSimilarity,
+  ) {
+    final tokens1 = fileSequences[c1.fileIndex].tokens;
+    final tokens2 = fileSequences[c2.fileIndex].tokens;
+
+    const shingleSize = 2;
+    if (c1.tokenCount < shingleSize || c2.tokenCount < shingleSize) {
+      return _compareCandidateTokens(c1, c2, fileSequences);
+    }
+
+    final shingles1 = <int>{};
+    for (var i = 0; i <= c1.tokenCount - shingleSize; i++) {
+      final h1 = tokens1[c1.startTokenIndex + i].tokenHash;
+      final h2 = tokens1[c1.startTokenIndex + i + 1].tokenHash;
+      shingles1.add(Object.hash(h1, h2));
+    }
+
+    final shingles2 = <int>{};
+    for (var i = 0; i <= c2.tokenCount - shingleSize; i++) {
+      final h1 = tokens2[c2.startTokenIndex + i].tokenHash;
+      final h2 = tokens2[c2.startTokenIndex + i + 1].tokenHash;
+      shingles2.add(Object.hash(h1, h2));
+    }
+
+    final tokenJaccard = MinHasher.exactJaccard(shingles1, shingles2);
+    return tokenJaccard >= minSimilarity;
   }
 
   static bool _compareCandidateTokens(

--- a/packages/dedupe/lib/src/detector.dart
+++ b/packages/dedupe/lib/src/detector.dart
@@ -147,7 +147,7 @@ class CloneDetector {
     if (fileSequences.isEmpty) return const [];
 
     final rawPairs = <_MatchPair>[];
-    final seenPairs = <int>{};
+    final seenPairs = <(int, int, int, int)>{};
 
     if (candidates != null && candidates.isNotEmpty) {
       _matchAstCandidates(
@@ -202,7 +202,7 @@ class CloneDetector {
   static void _matchAstCandidates({
     required List<AstCandidateUnit> candidates,
     required List<TokenSequence> fileSequences,
-    required Set<int> seenPairs,
+    required Set<(int, int, int, int)> seenPairs,
     required List<_MatchPair> outPairs,
   }) {
     final byHash = <int, List<AstCandidateUnit>>{};
@@ -224,7 +224,7 @@ class CloneDetector {
   static void _matchAstCandidateBucket({
     required List<AstCandidateUnit> bucket,
     required List<TokenSequence> fileSequences,
-    required Set<int> seenPairs,
+    required Set<(int, int, int, int)> seenPairs,
     required List<_MatchPair> outPairs,
   }) {
     if (bucket.length <= 50) {
@@ -259,7 +259,7 @@ class CloneDetector {
     required AstCandidateUnit c1,
     required AstCandidateUnit c2,
     required List<TokenSequence> fileSequences,
-    required Set<int> seenPairs,
+    required Set<(int, int, int, int)> seenPairs,
     required List<_MatchPair> outPairs,
   }) {
     if (c1.fileIndex == c2.fileIndex &&
@@ -290,7 +290,7 @@ class CloneDetector {
   static void _matchMinHashCandidates({
     required List<AstCandidateUnit> candidates,
     required List<TokenSequence> fileSequences,
-    required Set<int> seenPairs,
+    required Set<(int, int, int, int)> seenPairs,
     required List<_MatchPair> outPairs,
     double minJaccard = 0.80,
   }) {
@@ -319,7 +319,7 @@ class CloneDetector {
     required AstCandidateUnit c2,
     required List<TokenSequence> fileSequences,
     required double minJaccard,
-    required Set<int> seenPairs,
+    required Set<(int, int, int, int)> seenPairs,
     required List<_MatchPair> outPairs,
   }) {
     if (c1.fileIndex == c2.fileIndex &&
@@ -450,7 +450,7 @@ class CloneDetector {
     required int k,
     required int minTokens,
     required int minLines,
-    required Set<int> seenPairs,
+    required Set<(int, int, int, int)> seenPairs,
     required List<_MatchPair> outPairs,
   }) {
     for (final locations in index.values) {
@@ -474,7 +474,7 @@ class CloneDetector {
     required int k,
     required int minTokens,
     required int minLines,
-    required Set<int> seenPairs,
+    required Set<(int, int, int, int)> seenPairs,
     required List<_MatchPair> outPairs,
   }) {
     if (locations.length <= 50) {
@@ -518,7 +518,7 @@ class CloneDetector {
     required int k,
     required int minTokens,
     required int minLines,
-    required Set<int> seenPairs,
+    required Set<(int, int, int, int)> seenPairs,
     required List<_MatchPair> outPairs,
   }) {
     final pairKey = _computeLocationPairKey(loc1, loc2);
@@ -538,33 +538,33 @@ class CloneDetector {
     _markSubSeedsAsSeen(pair, k, seenPairs);
   }
 
-  static int _computeLocationPairKey(_TokenLocation loc1, _TokenLocation loc2) {
-    if (loc1.fileIndex <= loc2.fileIndex) {
-      return Object.hash(
-        loc1.fileIndex,
-        loc1.tokenIndex,
-        loc2.fileIndex,
-        loc2.tokenIndex,
-      );
+  static (int, int, int, int) _computeLocationPairKey(
+    _TokenLocation loc1,
+    _TokenLocation loc2,
+  ) {
+    if (loc1.fileIndex < loc2.fileIndex ||
+        (loc1.fileIndex == loc2.fileIndex &&
+            loc1.tokenIndex <= loc2.tokenIndex)) {
+      return (loc1.fileIndex, loc1.tokenIndex, loc2.fileIndex, loc2.tokenIndex);
     }
-    return Object.hash(
-      loc2.fileIndex,
-      loc2.tokenIndex,
-      loc1.fileIndex,
-      loc1.tokenIndex,
-    );
+    return (loc2.fileIndex, loc2.tokenIndex, loc1.fileIndex, loc1.tokenIndex);
   }
 
-  static int _computeSpanPairKey(_TokenSpan span1, _TokenSpan span2) {
-    if (span1.fileIndex <= span2.fileIndex) {
-      return Object.hash(
+  static (int, int, int, int) _computeSpanPairKey(
+    _TokenSpan span1,
+    _TokenSpan span2,
+  ) {
+    if (span1.fileIndex < span2.fileIndex ||
+        (span1.fileIndex == span2.fileIndex &&
+            span1.startTokenIndex <= span2.startTokenIndex)) {
+      return (
         span1.fileIndex,
         span1.startTokenIndex,
         span2.fileIndex,
         span2.startTokenIndex,
       );
     }
-    return Object.hash(
+    return (
       span2.fileIndex,
       span2.startTokenIndex,
       span1.fileIndex,
@@ -572,7 +572,11 @@ class CloneDetector {
     );
   }
 
-  static void _markSubSeedsAsSeen(_MatchPair pair, int k, Set<int> seenPairs) {
+  static void _markSubSeedsAsSeen(
+    _MatchPair pair,
+    int k,
+    Set<(int, int, int, int)> seenPairs,
+  ) {
     final maxOffset = pair.span1.tokenCount - k;
     final file1 = pair.span1.fileIndex;
     final file2 = pair.span2.fileIndex;
@@ -580,9 +584,9 @@ class CloneDetector {
     final start2 = pair.span2.startTokenIndex;
 
     for (var offset = 1; offset <= maxOffset; offset++) {
-      final subKey = file1 <= file2
-          ? Object.hash(file1, start1 + offset, file2, start2 + offset)
-          : Object.hash(file2, start2 + offset, file1, start1 + offset);
+      final subKey = file1 < file2 || (file1 == file2 && start1 <= start2)
+          ? (file1, start1 + offset, file2, start2 + offset)
+          : (file2, start2 + offset, file1, start1 + offset);
       seenPairs.add(subKey);
     }
   }
@@ -699,12 +703,12 @@ class CloneDetector {
   static List<_MatchPair> _filterSubsumedPairs(List<_MatchPair> rawPairs) {
     rawPairs.sort((a, b) => b.span1.tokenCount.compareTo(a.span1.tokenCount));
     final nonSubsumedPairs = <_MatchPair>[];
-    final pairsByFilePair = <int, List<_MatchPair>>{};
+    final pairsByFilePair = <(int, int), List<_MatchPair>>{};
 
     for (final pair in rawPairs) {
       final fileKey = pair.span1.fileIndex <= pair.span2.fileIndex
-          ? Object.hash(pair.span1.fileIndex, pair.span2.fileIndex)
-          : Object.hash(pair.span2.fileIndex, pair.span1.fileIndex);
+          ? (pair.span1.fileIndex, pair.span2.fileIndex)
+          : (pair.span2.fileIndex, pair.span1.fileIndex);
       final existingForFile = pairsByFilePair[fileKey];
 
       var isSubsumed = false;

--- a/packages/dedupe/lib/src/detector.dart
+++ b/packages/dedupe/lib/src/detector.dart
@@ -147,19 +147,20 @@ class CloneDetector {
     if (fileSequences.isEmpty) return const [];
 
     final rawPairs = <_MatchPair>[];
-    final seenPairs = <(int, int, int, int)>{};
+    final seenAstPairs = <(int, int, int, int)>{};
+    final seenKgramPairs = <(int, int, int, int)>{};
 
     if (candidates != null && candidates.isNotEmpty) {
       _matchAstCandidates(
         candidates: candidates,
         fileSequences: fileSequences,
-        seenPairs: seenPairs,
+        seenPairs: seenAstPairs,
         outPairs: rawPairs,
       );
       _matchMinHashCandidates(
         candidates: candidates,
         fileSequences: fileSequences,
-        seenPairs: seenPairs,
+        seenPairs: seenAstPairs,
         outPairs: rawPairs,
       );
     }
@@ -173,7 +174,7 @@ class CloneDetector {
       k: k,
       minTokens: minTokens,
       minLines: minLines,
-      seenPairs: seenPairs,
+      seenPairs: seenKgramPairs,
       outPairs: rawPairs,
     );
 

--- a/packages/dedupe/lib/src/detector.dart
+++ b/packages/dedupe/lib/src/detector.dart
@@ -211,7 +211,7 @@ class CloneDetector {
     }
 
     for (final bucket in byHash.values) {
-      if (bucket.length < 2 || bucket.length > 50) continue;
+      if (bucket.length < 2) continue;
       _matchAstCandidateBucket(
         bucket: bucket,
         fileSequences: fileSequences,
@@ -227,13 +227,26 @@ class CloneDetector {
     required Set<int> seenPairs,
     required List<_MatchPair> outPairs,
   }) {
-    for (var i = 0; i < bucket.length; i++) {
-      final c1 = bucket[i];
-      for (var j = i + 1; j < bucket.length; j++) {
-        final c2 = bucket[j];
+    if (bucket.length <= 50) {
+      for (var i = 0; i < bucket.length; i++) {
+        final c1 = bucket[i];
+        for (var j = i + 1; j < bucket.length; j++) {
+          final c2 = bucket[j];
+          _tryAddAstCandidatePair(
+            c1: c1,
+            c2: c2,
+            fileSequences: fileSequences,
+            seenPairs: seenPairs,
+            outPairs: outPairs,
+          );
+        }
+      }
+    } else {
+      // Chain adjacent items for large buckets to maintain O(N) scaling.
+      for (var i = 0; i < bucket.length - 1; i++) {
         _tryAddAstCandidatePair(
-          c1: c1,
-          c2: c2,
+          c1: bucket[i],
+          c2: bucket[i + 1],
           fileSequences: fileSequences,
           seenPairs: seenPairs,
           outPairs: outPairs,
@@ -442,9 +455,6 @@ class CloneDetector {
   }) {
     for (final locations in index.values) {
       if (locations.length < 2) continue;
-      // Cap oversized buckets to prevent combinatorial explosion on trivial
-      // boilerplate.
-      if (locations.length > 50) continue;
 
       _collectMatchesForBucket(
         locations: locations,
@@ -467,13 +477,29 @@ class CloneDetector {
     required Set<int> seenPairs,
     required List<_MatchPair> outPairs,
   }) {
-    for (var i = 0; i < locations.length; i++) {
-      final loc1 = locations[i];
-      for (var j = i + 1; j < locations.length; j++) {
-        final loc2 = locations[j];
+    if (locations.length <= 50) {
+      for (var i = 0; i < locations.length; i++) {
+        final loc1 = locations[i];
+        for (var j = i + 1; j < locations.length; j++) {
+          final loc2 = locations[j];
+          _processLocationPair(
+            loc1: loc1,
+            loc2: loc2,
+            fileSequences: fileSequences,
+            k: k,
+            minTokens: minTokens,
+            minLines: minLines,
+            seenPairs: seenPairs,
+            outPairs: outPairs,
+          );
+        }
+      }
+    } else {
+      // Chain adjacent locations for large buckets to maintain O(N) scaling.
+      for (var i = 0; i < locations.length - 1; i++) {
         _processLocationPair(
-          loc1: loc1,
-          loc2: loc2,
+          loc1: locations[i],
+          loc2: locations[i + 1],
           fileSequences: fileSequences,
           k: k,
           minTokens: minTokens,

--- a/packages/dedupe/lib/src/detector.dart
+++ b/packages/dedupe/lib/src/detector.dart
@@ -128,6 +128,11 @@ class _SpanDsu {
   }
 }
 
+/// Above this bucket size, matching degrades from all-pairs (O(N^2)) to
+/// linear star-topology linking to bound the comparison count on ubiquitous
+/// boilerplate without risking cascade cluster disconnects.
+const int kAllPairsBucketLimit = 50;
+
 /// Core clone detection engine using $k$-gram polynomial rolling hashes and
 /// maximal bidirectional extension.
 class CloneDetector {
@@ -227,7 +232,7 @@ class CloneDetector {
     required Set<int> seenPairs,
     required List<_MatchPair> outPairs,
   }) {
-    if (bucket.length <= 50) {
+    if (bucket.length <= kAllPairsBucketLimit) {
       for (var i = 0; i < bucket.length; i++) {
         final c1 = bucket[i];
         for (var j = i + 1; j < bucket.length; j++) {
@@ -242,11 +247,12 @@ class CloneDetector {
         }
       }
     } else {
-      // Chain adjacent items for large buckets to maintain O(N) scaling.
-      for (var i = 0; i < bucket.length - 1; i++) {
+      // Link anchor (bucket[0]) against all other candidates in O(N).
+      final anchor = bucket.first;
+      for (var i = 1; i < bucket.length; i++) {
         _tryAddAstCandidatePair(
-          c1: bucket[i],
-          c2: bucket[i + 1],
+          c1: anchor,
+          c2: bucket[i],
           fileSequences: fileSequences,
           seenPairs: seenPairs,
           outPairs: outPairs,
@@ -477,7 +483,7 @@ class CloneDetector {
     required Set<int> seenPairs,
     required List<_MatchPair> outPairs,
   }) {
-    if (locations.length <= 50) {
+    if (locations.length <= kAllPairsBucketLimit) {
       for (var i = 0; i < locations.length; i++) {
         final loc1 = locations[i];
         for (var j = i + 1; j < locations.length; j++) {
@@ -495,11 +501,12 @@ class CloneDetector {
         }
       }
     } else {
-      // Chain adjacent locations for large buckets to maintain O(N) scaling.
-      for (var i = 0; i < locations.length - 1; i++) {
+      // Link anchor (locations[0]) against all other locations in O(N).
+      final anchor = locations.first;
+      for (var i = 1; i < locations.length; i++) {
         _processLocationPair(
-          loc1: locations[i],
-          loc2: locations[i + 1],
+          loc1: anchor,
+          loc2: locations[i],
           fileSequences: fileSequences,
           k: k,
           minTokens: minTokens,

--- a/packages/dedupe/lib/src/minhash.dart
+++ b/packages/dedupe/lib/src/minhash.dart
@@ -140,21 +140,48 @@ class LshIndex<T> {
     final seen = <int>{};
 
     for (final bucket in _buckets.values) {
-      if (bucket.length < 2 || bucket.length > 50) continue;
+      if (bucket.length < 2) continue;
 
-      for (var i = 0; i < bucket.length; i++) {
-        final a = bucket[i];
-        for (var j = i + 1; j < bucket.length; j++) {
-          final b = bucket[j];
-          final pairKey = _pairHashCode(a, b);
-          if (seen.add(pairKey)) {
-            candidatePairs.add((item1: a, item2: b));
-          }
-        }
+      if (bucket.length <= 50) {
+        _addSmallBucketPairs(bucket, seen, candidatePairs);
+      } else {
+        _addLargeBucketPairs(bucket, seen, candidatePairs);
       }
     }
 
     return candidatePairs;
+  }
+
+  void _addSmallBucketPairs(
+    List<T> bucket,
+    Set<int> seen,
+    List<({T item1, T item2})> candidatePairs,
+  ) {
+    for (var i = 0; i < bucket.length; i++) {
+      final a = bucket[i];
+      for (var j = i + 1; j < bucket.length; j++) {
+        final b = bucket[j];
+        final pairKey = _pairHashCode(a, b);
+        if (seen.add(pairKey)) {
+          candidatePairs.add((item1: a, item2: b));
+        }
+      }
+    }
+  }
+
+  void _addLargeBucketPairs(
+    List<T> bucket,
+    Set<int> seen,
+    List<({T item1, T item2})> candidatePairs,
+  ) {
+    for (var i = 0; i < bucket.length - 1; i++) {
+      final a = bucket[i];
+      final b = bucket[i + 1];
+      final pairKey = _pairHashCode(a, b);
+      if (seen.add(pairKey)) {
+        candidatePairs.add((item1: a, item2: b));
+      }
+    }
   }
 
   int _pairHashCode(T a, T b) {

--- a/packages/dedupe/lib/src/minhash.dart
+++ b/packages/dedupe/lib/src/minhash.dart
@@ -1,5 +1,7 @@
 import 'dart:math' as math;
 
+import 'detector.dart';
+
 /// Computes MinHash signatures and Locality-Sensitive Hashing (LSH) band keys
 /// for fast set similarity estimation and near-miss clone candidate retrieval.
 class MinHasher {
@@ -142,7 +144,7 @@ class LshIndex<T> {
     for (final bucket in _buckets.values) {
       if (bucket.length < 2) continue;
 
-      if (bucket.length <= 50) {
+      if (bucket.length <= kAllPairsBucketLimit) {
         _addSmallBucketPairs(bucket, seen, candidatePairs);
       } else {
         _addLargeBucketPairs(bucket, seen, candidatePairs);
@@ -174,12 +176,12 @@ class LshIndex<T> {
     Set<int> seen,
     List<({T item1, T item2})> candidatePairs,
   ) {
-    for (var i = 0; i < bucket.length - 1; i++) {
-      final a = bucket[i];
-      final b = bucket[i + 1];
-      final pairKey = _pairHashCode(a, b);
+    final anchor = bucket.first;
+    for (var i = 1; i < bucket.length; i++) {
+      final b = bucket[i];
+      final pairKey = _pairHashCode(anchor, b);
       if (seen.add(pairKey)) {
-        candidatePairs.add((item1: a, item2: b));
+        candidatePairs.add((item1: anchor, item2: b));
       }
     }
   }

--- a/packages/dedupe/lib/src/minhash.dart
+++ b/packages/dedupe/lib/src/minhash.dart
@@ -137,7 +137,7 @@ class LshIndex<T> {
   /// Finds all unique candidate pairs that share at least one LSH bucket.
   List<({T item1, T item2})> findCandidatePairs() {
     final candidatePairs = <({T item1, T item2})>[];
-    final seen = <int>{};
+    final seen = <(T, T)>{};
 
     for (final bucket in _buckets.values) {
       if (bucket.length < 2) continue;
@@ -154,14 +154,14 @@ class LshIndex<T> {
 
   void _addSmallBucketPairs(
     List<T> bucket,
-    Set<int> seen,
+    Set<(T, T)> seen,
     List<({T item1, T item2})> candidatePairs,
   ) {
     for (var i = 0; i < bucket.length; i++) {
       final a = bucket[i];
       for (var j = i + 1; j < bucket.length; j++) {
         final b = bucket[j];
-        final pairKey = _pairHashCode(a, b);
+        final pairKey = _canonicalPair(a, b);
         if (seen.add(pairKey)) {
           candidatePairs.add((item1: a, item2: b));
         }
@@ -171,24 +171,20 @@ class LshIndex<T> {
 
   void _addLargeBucketPairs(
     List<T> bucket,
-    Set<int> seen,
+    Set<(T, T)> seen,
     List<({T item1, T item2})> candidatePairs,
   ) {
     for (var i = 0; i < bucket.length - 1; i++) {
       final a = bucket[i];
       final b = bucket[i + 1];
-      final pairKey = _pairHashCode(a, b);
+      final pairKey = _canonicalPair(a, b);
       if (seen.add(pairKey)) {
         candidatePairs.add((item1: a, item2: b));
       }
     }
   }
 
-  int _pairHashCode(T a, T b) {
-    final hashA = a.hashCode;
-    final hashB = b.hashCode;
-    return hashA <= hashB
-        ? Object.hash(hashA, hashB)
-        : Object.hash(hashB, hashA);
+  (T, T) _canonicalPair(T a, T b) {
+    return identityHashCode(a) <= identityHashCode(b) ? (a, b) : (b, a);
   }
 }

--- a/packages/dedupe/test/detector_test.dart
+++ b/packages/dedupe/test/detector_test.dart
@@ -233,5 +233,77 @@ void auditLogTraceEvent(String eventName, int eventId) {
       check(cluster.instances.length).equals(60);
       check(cluster.bucket).equals(CloneBucket.identical);
     });
+
+    test('expands to maximal k-gram extent when AST candidate is present', () {
+      const function1 = '''
+void processOrderBatchA(List<String> items) {
+  print('Beginning order batch processing sequence');
+  for (final item in items) {
+    print('Processing item: \$item');
+    print('Updating database transaction logs');
+    print('Sending notification to fulfillment queue');
+  }
+  print('Order batch processing completed successfully');
+}
+''';
+
+      const function2 = '''
+void processOrderBatchB(List<String> items) {
+  print('Beginning order batch processing sequence');
+  for (final item in items) {
+    print('Processing item: \$item');
+    print('Updating database transaction logs');
+    print('Sending notification to fulfillment queue');
+  }
+  print('Order batch processing completed successfully');
+}
+''';
+
+      const tokenizer = DartTokenizer();
+      final seq1 = tokenizer.tokenize(filePath: 'a.dart', content: function1);
+      final seq2 = tokenizer.tokenize(filePath: 'b.dart', content: function2);
+
+      // Create an AST candidate unit corresponding to the inner for-loop only
+      // (a sub-block of the entire identical function).
+      const astCandidate1 = AstCandidateUnit(
+        filePath: 'a.dart',
+        fileIndex: 0,
+        startLine: 3,
+        endLine: 7,
+        startOffset: 45,
+        endOffset: 150,
+        startTokenIndex: 8,
+        endTokenIndex: 25,
+        tokenCount: 18,
+        lineCount: 5,
+        astNodeType: 'ForStatement',
+        signatureHash: 12345,
+      );
+      const astCandidate2 = AstCandidateUnit(
+        filePath: 'b.dart',
+        fileIndex: 1,
+        startLine: 3,
+        endLine: 7,
+        startOffset: 45,
+        endOffset: 150,
+        startTokenIndex: 8,
+        endTokenIndex: 25,
+        tokenCount: 18,
+        lineCount: 5,
+        astNodeType: 'ForStatement',
+        signatureHash: 12345,
+      );
+
+      const detector = CloneDetector(minTokens: 15, minLines: 4);
+      final clusters = detector.detect(
+        [seq1, seq2],
+        candidates: [astCandidate1, astCandidate2],
+      );
+
+      check(clusters.length).equals(1);
+      final cluster = clusters.first;
+      check(cluster.tokenCount).isGreaterThan(astCandidate1.tokenCount);
+      check(cluster.instances.length).equals(2);
+    });
   });
 }

--- a/packages/dedupe/test/detector_test.dart
+++ b/packages/dedupe/test/detector_test.dart
@@ -203,5 +203,35 @@ void handlerB() {
       check(clusters.first.instances.length).equals(2);
       check(clusters.first.instances.first.filePath).equals('handlers.dart');
     });
+
+    test('detects and clusters clone groups appearing in >50 locations', () {
+      const helperFunction = '''
+void auditLogTraceEvent(String eventName, int eventId) {
+  print('Audit log event: \$eventName [\$eventId]');
+  print('Recording timestamp and thread metadata');
+  print('Flushing audit buffer to disk cache');
+  print('Verification trace sequence completed');
+}
+''';
+
+      const tokenizer = DartTokenizer();
+      final sequences = <TokenSequence>[];
+      for (var i = 0; i < 60; i++) {
+        sequences.add(
+          tokenizer.tokenize(
+            filePath: 'module_$i.dart',
+            content: helperFunction,
+          ),
+        );
+      }
+
+      const detector = CloneDetector(minTokens: 15, minLines: 4);
+      final clusters = detector.detect(sequences);
+
+      check(clusters.length).equals(1);
+      final cluster = clusters.first;
+      check(cluster.instances.length).equals(60);
+      check(cluster.bucket).equals(CloneBucket.identical);
+    });
   });
 }

--- a/packages/dedupe/test/detector_test.dart
+++ b/packages/dedupe/test/detector_test.dart
@@ -204,6 +204,37 @@ void handlerB() {
       check(clusters.first.instances.first.filePath).equals('handlers.dart');
     });
 
+    test('detects and clusters clone groups appearing in 52 locations without '
+        'off-by-one drops', () {
+      const helperFunction = '''
+void auditLogTraceEvent(String eventName, int eventId) {
+  print('Audit log event: \$eventName [\$eventId]');
+  print('Recording timestamp and thread metadata');
+  print('Flushing audit buffer to disk cache');
+  print('Verification trace sequence completed');
+}
+''';
+
+      const tokenizer = DartTokenizer();
+      final sequences = <TokenSequence>[];
+      for (var i = 0; i < 52; i++) {
+        sequences.add(
+          tokenizer.tokenize(
+            filePath: 'module_\$i.dart',
+            content: helperFunction,
+          ),
+        );
+      }
+
+      const detector = CloneDetector(minTokens: 15, minLines: 4);
+      final clusters = detector.detect(sequences);
+
+      check(clusters.length).equals(1);
+      final cluster = clusters.first;
+      check(cluster.instances.length).equals(52);
+      check(cluster.bucket).equals(CloneBucket.identical);
+    });
+
     test('detects and clusters clone groups appearing in >50 locations', () {
       const helperFunction = '''
 void auditLogTraceEvent(String eventName, int eventId) {
@@ -219,7 +250,7 @@ void auditLogTraceEvent(String eventName, int eventId) {
       for (var i = 0; i < 60; i++) {
         sequences.add(
           tokenizer.tokenize(
-            filePath: 'module_$i.dart',
+            filePath: 'module_\$i.dart',
             content: helperFunction,
           ),
         );

--- a/packages/dedupe/test/minhash_test.dart
+++ b/packages/dedupe/test/minhash_test.dart
@@ -140,5 +140,54 @@ void handleUserOrder(String userId, double amount) {
       check(cluster.instances[0].filePath).equals('lib/order_a.dart');
       check(cluster.instances[1].filePath).equals('lib/order_b.dart');
     });
+
+    test('does not pair functions with identical statement sketches but '
+        'divergent token contents', () {
+      const codeA = r'''
+void logMetricsAlpha(int alpha, int beta) {
+  final result = alpha + beta;
+  print('Metric alpha computed: $result');
+  print('Dispatching alpha to telemetry');
+  print('Updating alpha cache state');
+  print('Finalizing alpha transaction');
+}
+''';
+
+      const codeB = r'''
+void sendEmailNotification(String recipient, String message) {
+  final status = recipient.isNotEmpty;
+  print('Sending notification to $recipient: $status');
+  print('Writing message payload to SMTP socket');
+  print('Awaiting server confirmation packet');
+  print('Closing SMTP connection socket');
+}
+''';
+
+      const extractor = AstExtractor(
+        minTokens: 15,
+        minLines: 4,
+        ignoreComments: true,
+        ignoreLiterals: false,
+      );
+
+      final (seqA, candA) = extractor.extract(
+        filePath: 'lib/metrics.dart',
+        content: codeA,
+        fileIndex: 0,
+      );
+      final (seqB, candB) = extractor.extract(
+        filePath: 'lib/email.dart',
+        content: codeB,
+        fileIndex: 1,
+      );
+
+      const detector = CloneDetector(minTokens: 15, minLines: 4);
+      final clusters = detector.detect(
+        [seqA, seqB],
+        candidates: [...candA, ...candB],
+      );
+
+      check(clusters.isEmpty).equals(true);
+    });
   });
 }


### PR DESCRIPTION
Previously, seen candidate pairs were tracked using 32-bit integer keys generated via `Object.hash()`, which suffered from hash collisions and colliding namespaces in large repositories, causing valid clone pairs to be prematurely dropped.

- Replace `Set<int> seenPairs` with `Set<(int, int, int, int)>` across all detector passes.
- Replace 32-bit `Object.hash` in `LshIndex` with canonical record pair keys `(T, T)`.
- Replace 32-bit file pair keys in `_filterSubsumedPairs` with `(int, int)` record keys.

Fixes #65