### PR TITLE
fix(action): evaluate monorepo targets in caller workspace (#76)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build/
 pubspec.lock
 .deslop/
+.dedupe_cache/
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Repository Agent Guidelines
+
+## Workspace Structure
+
+- This repository is a Dart pub workspace monorepo containing multiple packages under `packages/`:
+  - `packages/analytica`
+  - `packages/cognitive_complexity`
+  - `packages/dedupe`
+  - `packages/undead`
+
+## Testing Instructions
+
+- Leverage multi-core execution by running package test suites concurrently in parallel across all packages:
+  ```bash
+  pids=(); for pkg in packages/*; do [ -d "$pkg/test" ] && (echo "Starting $pkg..." && cd "$pkg" && dart test) & pids+=($!); done; status=0; for pid in "${pids[@]}"; do wait "$pid" || status=1; done; exit $status
+  ```
+- To run tests for an individual package: `(cd packages/<package_name> && dart test)`.
+
+## Code Quality & Verification
+
+- Run `dart format --output=none --set-exit-if-changed .` before committing.
+- Run `dart analyze --fatal-infos` across the workspace.
+- Update `CHANGELOG.md` in the affected package under `packages/<package_name>/CHANGELOG.md` before landing.

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
 
         # When a row cap is requested, the scanner renders a second, trimmed
         # report for the PR comment while the step summary keeps every row.
-        # Absolute path: the scanner runs with the action directory as cwd.
+        # Absolute path so it is independent of the scanner's cwd.
         # An array keeps the path intact even if RUNNER_TEMP contains spaces.
         comment_args=()
         comment_file=""
@@ -109,13 +109,19 @@ runs:
           targets="packages"
         fi
 
-        # Navigate to action repo directory, run pub get to resolve dependencies deterministically
-        cd "$ACTION_PATH"
-        dart pub get >/dev/null
-        
+        # Resolve the scanner's dependencies inside the action checkout, but
+        # run it from the caller's workspace: relative targets and the
+        # --git-diff working tree must both resolve against the repository
+        # under audit, not the action download directory (which is not even
+        # a git clone). `dart run <absolute script>` picks up the action's
+        # package config from the script location, so no activation is
+        # needed.
+        (cd "$ACTION_PATH" && dart pub get >/dev/null)
+        cd "$workspace"
+
         # Execute the scanner CLI tool and capture exit code
         set +e
-        dart run cognitive_complexity \
+        dart run "$ACTION_PATH/packages/cognitive_complexity/bin/cognitive_complexity.dart" \
           --threshold="$INPUT_THRESHOLD" \
           --fail-threshold="$INPUT_FAIL_THRESHOLD" \
           --format="$INPUT_FORMAT" \

--- a/action.yml
+++ b/action.yml
@@ -102,15 +102,16 @@ runs:
           comment_args=(--comment-output="$comment_file" --max-comment-rows="$INPUT_MAX_COMMENT_ROWS")
         fi
 
+        # Auto-detect monorepos when default 'lib' target does not exist in caller workspace
+        workspace="${GITHUB_WORKSPACE:-$PWD}"
+        targets="$INPUT_TARGETS"
+        if [ "$targets" = "lib" ] && [ ! -d "$workspace/lib" ] && [ -d "$workspace/packages" ]; then
+          targets="packages"
+        fi
+
         # Navigate to action repo directory, run pub get to resolve dependencies deterministically
         cd "$ACTION_PATH"
         dart pub get >/dev/null
-        
-        # Auto-detect monorepos when default 'lib' target does not exist
-        targets="$INPUT_TARGETS"
-        if [ "$targets" = "lib" ] && [ ! -d "lib" ] && [ -d "packages" ]; then
-          targets="packages"
-        fi
         
         # Execute the scanner CLI tool and capture exit code
         set +e

--- a/packages/cognitive_complexity/CHANGELOG.md
+++ b/packages/cognitive_complexity/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Fix `action.yml` monorepo auto-detection to evaluate default `lib` vs
   `packages` existence against the caller's `$GITHUB_WORKSPACE` instead of
   `$ACTION_PATH` (#76).
+- Fix `action.yml` to run the scanner from the caller's `$GITHUB_WORKSPACE`
+  rather than `$ACTION_PATH`, so relative `targets` and `--git-diff` resolve
+  against the repository under audit when the action is used from another
+  repository (#76).
 
 - Add `--comment-output` and `--max-comment-rows` CLI options: with
   `--format=github`, write a second report capped to the most significant rows

--- a/packages/cognitive_complexity/CHANGELOG.md
+++ b/packages/cognitive_complexity/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.2.4-wip
 
+- Fix `action.yml` monorepo auto-detection to evaluate default `lib` vs
+  `packages` existence against the caller's `$GITHUB_WORKSPACE` instead of
+  `$ACTION_PATH` (#76).
+
 - Add `--comment-output` and `--max-comment-rows` CLI options: with
   `--format=github`, write a second report capped to the most significant rows
   (violations, then increases, then additions) for posting as a PR comment,


### PR DESCRIPTION
- Resolve workspace directory as ${GITHUB_WORKSPACE:-$PWD} before navigating
  into $ACTION_PATH.
- Check existence of lib and packages against caller workspace rather than
  action repo directory to avoid unconditionally forcing targets to packages.
- Add AGENTS.md with monorepo layout and parallel test instructions.
- Add .dedupe_cache/ to .gitignore.

Fixes #76
