### PR TITLE
fix(analytica): resolve declaration names correctly with doc comments

### DIFF
--- a/packages/analytica/lib/src/analyzer/ast_helpers.dart
+++ b/packages/analytica/lib/src/analyzer/ast_helpers.dart
@@ -26,18 +26,18 @@ const _declarationHeaderKeywords = {
 /// and [ConstructorDeclaration], falling back to recursive identifier token
 /// scanning.
 String? extractNodeName(AstNode node) => switch (node) {
-  ClassDeclaration(:final declaredFragment) =>
-    declaredFragment?.element.name ?? _findFirstIdentifier(node),
+  ClassDeclaration(:final declaredFragment, :final namePart) =>
+    declaredFragment?.element.name ?? namePart.typeName.lexeme,
   ClassTypeAlias(:final declaredFragment, :final name) =>
     declaredFragment?.element.name ?? name.lexeme,
-  EnumDeclaration(:final declaredFragment) =>
-    declaredFragment?.element.name ?? _findFirstIdentifier(node),
+  EnumDeclaration(:final declaredFragment, :final namePart) =>
+    declaredFragment?.element.name ?? namePart.typeName.lexeme,
   MixinDeclaration(:final declaredFragment, :final name) =>
     declaredFragment?.element.name ?? name.lexeme,
   ExtensionDeclaration(:final declaredFragment, :final name) =>
     declaredFragment?.element.name ?? name?.lexeme,
-  ExtensionTypeDeclaration(:final declaredFragment) =>
-    declaredFragment?.element.name ?? _findFirstIdentifier(node),
+  ExtensionTypeDeclaration(:final declaredFragment, :final namePart) =>
+    declaredFragment?.element.name ?? namePart.typeName.lexeme,
   TypeAlias(:final declaredFragment, :final name) =>
     declaredFragment?.element.name ?? name.lexeme,
   FunctionDeclaration(:final declaredFragment, :final name) =>
@@ -48,6 +48,7 @@ String? extractNodeName(AstNode node) => switch (node) {
     declaredFragment?.element.name ?? name.lexeme,
   ConstructorDeclaration(:final declaredFragment, :final name) =>
     declaredFragment?.element.name ?? name?.lexeme,
+  EnumConstantDeclaration(:final name) => name.lexeme,
   TopLevelVariableDeclaration(:final variables)
       when variables.variables.isNotEmpty =>
     extractNodeName(variables.variables.first),
@@ -58,7 +59,10 @@ String? extractNodeName(AstNode node) => switch (node) {
 
 String? _findFirstIdentifier(AstNode node) {
   for (final entity in node.childEntities) {
-    if (entity is NodeList<Annotation> || entity is Annotation) {
+    if (entity is NodeList<Annotation> ||
+        entity is Annotation ||
+        entity is Comment ||
+        entity is CommentReference) {
       continue;
     }
     if (entity is Token &&

--- a/packages/analytica/lib/src/analyzer/ast_helpers.dart
+++ b/packages/analytica/lib/src/analyzer/ast_helpers.dart
@@ -26,18 +26,18 @@ const _declarationHeaderKeywords = {
 /// and [ConstructorDeclaration], falling back to recursive identifier token
 /// scanning.
 String? extractNodeName(AstNode node) => switch (node) {
-  ClassDeclaration(:final declaredFragment, :final namePart) =>
-    declaredFragment?.element.name ?? namePart.typeName.lexeme,
+  ClassDeclaration(:final declaredFragment) =>
+    declaredFragment?.element.name ?? _findFirstIdentifier(node),
   ClassTypeAlias(:final declaredFragment, :final name) =>
     declaredFragment?.element.name ?? name.lexeme,
-  EnumDeclaration(:final declaredFragment, :final namePart) =>
-    declaredFragment?.element.name ?? namePart.typeName.lexeme,
+  EnumDeclaration(:final declaredFragment) =>
+    declaredFragment?.element.name ?? _findFirstIdentifier(node),
   MixinDeclaration(:final declaredFragment, :final name) =>
     declaredFragment?.element.name ?? name.lexeme,
   ExtensionDeclaration(:final declaredFragment, :final name) =>
     declaredFragment?.element.name ?? name?.lexeme,
-  ExtensionTypeDeclaration(:final declaredFragment, :final namePart) =>
-    declaredFragment?.element.name ?? namePart.typeName.lexeme,
+  ExtensionTypeDeclaration(:final declaredFragment) =>
+    declaredFragment?.element.name ?? _findFirstIdentifier(node),
   TypeAlias(:final declaredFragment, :final name) =>
     declaredFragment?.element.name ?? name.lexeme,
   FunctionDeclaration(:final declaredFragment, :final name) =>
@@ -59,6 +59,10 @@ String? extractNodeName(AstNode node) => switch (node) {
 
 String? _findFirstIdentifier(AstNode node) {
   for (final entity in node.childEntities) {
+    // Annotations and doc comments are lexically inside the declaration but
+    // are not part of its name, and both can contain identifiers that would
+    // otherwise win this depth-first scan: `@Foo()` or `/// See [bar].` on
+    // `class Baz` would resolve the name as `Foo` or `bar`.
     if (entity is NodeList<Annotation> ||
         entity is Annotation ||
         entity is Comment ||

--- a/packages/analytica/test/analyzer/ast_helpers_test.dart
+++ b/packages/analytica/test/analyzer/ast_helpers_test.dart
@@ -102,6 +102,57 @@ void annotatedFunc() {}
       check(extractNodeName(decls[3])).equals('AnnotatedExtType');
       check(extractNodeName(decls[4])).equals('annotatedFunc');
     });
+
+    test('extracts names correctly when declarations have doc comments '
+        'referencing other symbols', () {
+      const source = '''
+/// A thing. See [bar] and [otherMethod] for details.
+class Foo {
+  int bar(int x) => x;
+}
+
+/// Enum docs. See [constantRef] for details.
+enum Status {
+  /// Constant doc. See [otherRef] here.
+  ready,
+  paused,
+}
+
+/// Mixin docs referencing [somethingElse].
+mixin Loggable {}
+
+/// Extension docs referencing [anotherThing].
+extension StringExt on String {}
+
+/// Extension type docs referencing [typeRef].
+extension type Id(int value) {}
+
+/// Function docs referencing [paramRef].
+void topLevelFn() {}
+
+/// Top-level variable doc referencing [someOtherVar].
+int topLevelVar = 1;
+''';
+      final parsed = parseString(
+        content: source,
+        featureSet: FeatureSet.latestLanguageVersion(),
+      );
+
+      final decls = parsed.unit.declarations;
+      check(extractNodeName(decls[0])).equals('Foo');
+      check(extractNodeName(decls[1])).equals('Status');
+      check(extractNodeName(decls[2])).equals('Loggable');
+      check(extractNodeName(decls[3])).equals('StringExt');
+      check(extractNodeName(decls[4])).equals('Id');
+      check(extractNodeName(decls[5])).equals('topLevelFn');
+
+      final topVar = decls[6] as TopLevelVariableDeclaration;
+      check(extractNodeName(topVar)).equals('topLevelVar');
+
+      final enumDecl = decls[1] as EnumDeclaration;
+      check(extractNodeName(enumDecl.body.constants[0])).equals('ready');
+      check(extractNodeName(enumDecl.body.constants[1])).equals('paused');
+    });
   });
 
   group('getTopLevelElement', () {

--- a/packages/cognitive_complexity/test/cognitive_complexity_test.dart
+++ b/packages/cognitive_complexity/test/cognitive_complexity_test.dart
@@ -604,5 +604,21 @@ void main() {
         results.map((r) => r.name),
       ).unorderedEquals(['C.mC', 'E.mE', 'M.mM', 'Ext.mExt', 'Et.mEt']);
     });
+
+    test('Enclosing names ignore doc comment references', () {
+      final results = analyzer.analyzeCode('''
+        /// A thing. See [bar] and [other] for details.
+        class Foo {
+          int bar(int x) => x > 1 ? 1 : 0;
+        }
+
+        /// Enum docs with [foo] reference.
+        enum Bar {
+          a;
+          void baz() {}
+        }
+      ''');
+      check(results.map((r) => r.name)).unorderedEquals(['Foo.bar', 'Bar.baz']);
+    });
   });
 }


### PR DESCRIPTION
When declarations such as ClassDeclaration, EnumDeclaration, or
ExtensionTypeDeclaration are parsed without element resolution,
extractNodeName previously fell back to _findFirstIdentifier(node)
because declaredFragment was null. _findFirstIdentifier traversed child
entities depth-first, causing it to pick the first identifier inside doc
comment references (e.g. `/// See [bar] for details.` on `class Foo`
resolved the class name as `bar` instead of `Foo`).

- In extractNodeName, match namePart on ClassDeclaration,
  EnumDeclaration, and ExtensionTypeDeclaration to read
  namePart.typeName.lexeme directly.
- Add explicit extractNodeName pattern for EnumConstantDeclaration.
- In _findFirstIdentifier, skip Comment and CommentReference nodes so
  comment contents are never mistaken for declaration names in fallback
  scans.
- Add unit tests in pkg:analytica and pkg:cognitive_complexity.

Fixes #79
