### PR TITLE
fix(dedupe): forward options and filters to GitHub MarkdownFormatter

### DIFF
--- a/packages/dedupe/lib/src/cli.dart
+++ b/packages/dedupe/lib/src/cli.dart
@@ -348,7 +348,10 @@ class DedupeCliRunner {
         );
         outSink.writeln(mdFormatter.format(report));
       case OutputFormat.github:
-        final reporter = DedupeGitHubReporter(stdoutSink: outSink);
+        final reporter = DedupeGitHubReporter(
+          stdoutSink: outSink,
+          options: options,
+        );
         reporter.report(report);
       case OutputFormat.text:
         final txtFormatter = TextFormatter(

--- a/packages/dedupe/lib/src/formatters/github_reporter.dart
+++ b/packages/dedupe/lib/src/formatters/github_reporter.dart
@@ -10,29 +10,58 @@ import 'markdown_formatter.dart';
 class DedupeGitHubReporter {
   final StringSink stdoutSink;
   final File? summaryFile;
+  final DedupeOptions? options;
+  final int topCount;
+  final String categoryFilter;
+  final String bucketFilter;
+  final bool includeFileTable;
+  final bool includeClusters;
 
-  DedupeGitHubReporter({StringSink? stdoutSink, File? summaryFile})
-    : stdoutSink = stdoutSink ?? stdout,
-      summaryFile = summaryFile ?? resolveGitHubSummaryFile();
+  DedupeGitHubReporter({
+    StringSink? stdoutSink,
+    File? summaryFile,
+    this.options,
+    int? topCount,
+    String? categoryFilter,
+    String? bucketFilter,
+    bool? includeFileTable,
+    bool? includeClusters,
+  }) : stdoutSink = stdoutSink ?? stdout,
+       summaryFile = summaryFile ?? resolveGitHubSummaryFile(),
+       topCount = topCount ?? options?.top ?? 0,
+       categoryFilter = categoryFilter ?? options?.categoryFilter ?? 'all',
+       bucketFilter = bucketFilter ?? options?.bucketFilter ?? 'all',
+       includeFileTable = includeFileTable ?? options?.includeFileTable ?? true,
+       includeClusters = includeClusters ?? options?.includeClusters ?? true;
 
   void report(DedupeReport report) {
     // 1. Emit GitHub Actions workflow warning annotations for duplicate
     // instances
-    for (final cluster in report.clusters) {
-      for (final instance in cluster.instances) {
-        final categoryName = cluster.category.displayName;
-        stdoutSink.writeln(
-          '::warning file=${instance.filePath},line=${instance.startLine},'
-          'endLine=${instance.endLine},title=Code Duplication (${cluster.id})::'
-          'Duplicate block found (${instance.lineCount} lines, '
-          '${instance.tokenCount} tokens). Shared across '
-          '${cluster.instances.length} occurrences in $categoryName.',
-        );
+    if (includeClusters) {
+      final clusters = _filterClusters(report.clusters);
+      for (final cluster in clusters) {
+        for (final instance in cluster.instances) {
+          final categoryName = cluster.category.displayName;
+          stdoutSink.writeln(
+            '::warning file=${instance.filePath},line=${instance.startLine},'
+            'endLine=${instance.endLine},'
+            'title=Code Duplication (${cluster.id})::'
+            'Duplicate block found (${instance.lineCount} lines, '
+            '${instance.tokenCount} tokens). Shared across '
+            '${cluster.instances.length} occurrences in $categoryName.',
+          );
+        }
       }
     }
 
     // 2. Render Markdown report
-    const formatter = MarkdownFormatter();
+    final formatter = MarkdownFormatter(
+      topCount: topCount,
+      categoryFilter: categoryFilter,
+      bucketFilter: bucketFilter,
+      includeFileTable: includeFileTable,
+      includeClusters: includeClusters,
+    );
     final markdown = formatter.format(report);
     stdoutSink.writeln(markdown);
 
@@ -44,5 +73,21 @@ class DedupeGitHubReporter {
         // Non-fatal if step summary cannot be written
       }
     }
+  }
+
+  List<DuplicateCluster> _filterClusters(List<DuplicateCluster> clusters) {
+    var result = clusters;
+    if (categoryFilter != 'all') {
+      result = result
+          .where((c) => c.category.jsonValue == categoryFilter)
+          .toList();
+    }
+    if (bucketFilter != 'all') {
+      result = result.where((c) => c.bucket.jsonValue == bucketFilter).toList();
+    }
+    if (topCount > 0 && result.length > topCount) {
+      result = result.sublist(0, topCount);
+    }
+    return result;
   }
 }

--- a/packages/dedupe/test/cli_test.dart
+++ b/packages/dedupe/test/cli_test.dart
@@ -142,6 +142,128 @@ int computeScore(int base, int multiplier) {
       check(stdout).contains('## 🔍 Duplicate Clusters');
     });
 
+    test(
+      'runs analysis and outputs GitHub format with --format=github',
+      () async {
+        await d.dir('cli_gh_pkg', [
+          d.dir('lib', [
+            d.file('calc_a.dart', '''
+int computeScore(int base, int multiplier) {
+  if (base < 0) return 0;
+  final bonus = multiplier * 10;
+  final result = base + bonus;
+  return result;
+}
+'''),
+            d.file('calc_b.dart', '''
+int computeScore(int base, int multiplier) {
+  if (base < 0) return 0;
+  final bonus = multiplier * 10;
+  final result = base + bonus;
+  return result;
+}
+'''),
+          ]),
+        ]).create();
+
+        final proc = await runDedupe([
+          '--format=github',
+          '--min-tokens=15',
+          '--min-lines=3',
+          d.path('cli_gh_pkg'),
+        ]);
+
+        final stdout = await proc.stdoutStream().join('\n');
+        await proc.shouldExit(0);
+
+        check(stdout).contains('::warning file=lib/calc_a.dart');
+        check(stdout).contains('# 🔍 Dedupe Duplication Analysis:');
+        check(stdout).contains('## 📊 Summary');
+        check(stdout).contains('## 📁 File Breakdown');
+        check(stdout).contains('## 🔍 Duplicate Clusters');
+      },
+    );
+
+    test('--format=github respects --no-files, --no-clusters, --category, and '
+        '--bucket', () async {
+      await d.dir('cli_gh_filters_pkg', [
+        d.dir('lib', [
+          d.file('a.dart', '''
+int calc(int x) {
+  if (x < 0) return 0;
+  final a = x * 10;
+  final b = a + 5;
+  return b;
+}
+'''),
+          d.file('b.dart', '''
+int calc(int x) {
+  if (x < 0) return 0;
+  final a = x * 10;
+  final b = a + 5;
+  return b;
+}
+'''),
+        ]),
+      ]).create();
+
+      // Test --no-files
+      final procNoFiles = await runDedupe([
+        '--format=github',
+        '--no-files',
+        '--min-tokens=10',
+        '--min-lines=3',
+        d.path('cli_gh_filters_pkg'),
+      ]);
+      final outNoFiles = await procNoFiles.stdoutStream().join('\n');
+      await procNoFiles.shouldExit(0);
+      check(outNoFiles).not((it) => it.contains('## 📁 File Breakdown'));
+      check(outNoFiles).contains('## 📊 Summary');
+      check(outNoFiles).contains('::warning');
+
+      // Test --no-clusters
+      final procNoClusters = await runDedupe([
+        '--format=github',
+        '--no-clusters',
+        '--min-tokens=10',
+        '--min-lines=3',
+        d.path('cli_gh_filters_pkg'),
+      ]);
+      final outNoClusters = await procNoClusters.stdoutStream().join('\n');
+      await procNoClusters.shouldExit(0);
+      check(outNoClusters).not((it) => it.contains('::warning'));
+      check(outNoClusters).not((it) => it.contains('## 🔍 Duplicate Clusters'));
+      check(outNoClusters).contains('## 📊 Summary');
+
+      // Test --category=data (when existing cluster is logic)
+      final procCategory = await runDedupe([
+        '--format=github',
+        '--category=data',
+        '--min-tokens=10',
+        '--min-lines=3',
+        d.path('cli_gh_filters_pkg'),
+      ]);
+      final outCategory = await procCategory.stdoutStream().join('\n');
+      await procCategory.shouldExit(0);
+      check(outCategory).not((it) => it.contains('::warning'));
+      check(
+        outCategory,
+      ).contains('No duplicate clusters matched the current filter criteria.');
+
+      // Test --bucket=identical
+      final procBucket = await runDedupe([
+        '--format=github',
+        '--bucket=identical',
+        '--min-tokens=10',
+        '--min-lines=3',
+        d.path('cli_gh_filters_pkg'),
+      ]);
+      final outBucket = await procBucket.stdoutStream().join('\n');
+      await procBucket.shouldExit(0);
+      check(outBucket).contains('::warning');
+      check(outBucket).contains('Identical');
+    });
+
     test('writes JSON report to file with --json-output', () async {
       await d.dir('cli_out_file_pkg', [
         d.dir('lib', [

--- a/packages/dedupe/test/github_reporter_test.dart
+++ b/packages/dedupe/test/github_reporter_test.dart
@@ -1,0 +1,313 @@
+import 'dart:io';
+
+import 'package:checks/checks.dart';
+import 'package:dedupe/dedupe.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+void main() {
+  group('DedupeGitHubReporter', () {
+    const inst1A = CloneInstance(
+      filePath: 'lib/src/logic_a.dart',
+      startLine: 10,
+      endLine: 20,
+      startColumn: 1,
+      endColumn: 1,
+      tokenCount: 40,
+      lineCount: 11,
+      snippet: 'void doLogic() { print("a"); }',
+    );
+    const inst1B = CloneInstance(
+      filePath: 'lib/src/logic_b.dart',
+      startLine: 10,
+      endLine: 20,
+      startColumn: 1,
+      endColumn: 1,
+      tokenCount: 40,
+      lineCount: 11,
+      snippet: 'void doLogic() { print("a"); }',
+    );
+    const clusterLogic = DuplicateCluster(
+      id: 'cluster-logic',
+      instances: [inst1A, inst1B],
+      tokenCount: 40,
+      lineCount: 11,
+      category: CloneCategory.logic,
+      bucket: CloneBucket.identical,
+      estimatedLinesSaved: 11,
+    );
+
+    const inst2A = CloneInstance(
+      filePath: 'lib/src/data_a.dart',
+      startLine: 30,
+      endLine: 45,
+      startColumn: 1,
+      endColumn: 1,
+      tokenCount: 50,
+      lineCount: 16,
+      snippet: 'final data = [1, 2, 3];',
+    );
+    const inst2B = CloneInstance(
+      filePath: 'lib/src/data_b.dart',
+      startLine: 30,
+      endLine: 45,
+      startColumn: 1,
+      endColumn: 1,
+      tokenCount: 50,
+      lineCount: 16,
+      snippet: 'final data = [10, 20, 30];',
+    );
+    const clusterData = DuplicateCluster(
+      id: 'cluster-data',
+      instances: [inst2A, inst2B],
+      tokenCount: 50,
+      lineCount: 16,
+      category: CloneCategory.data,
+      bucket: CloneBucket.structural,
+      estimatedLinesSaved: 16,
+    );
+
+    const inst3A = CloneInstance(
+      filePath: 'lib/src/boiler_a.dart',
+      startLine: 1,
+      endLine: 8,
+      startColumn: 1,
+      endColumn: 1,
+      tokenCount: 30,
+      lineCount: 8,
+      snippet: 'class BoilerA {}',
+    );
+    const inst3B = CloneInstance(
+      filePath: 'lib/src/boiler_b.dart',
+      startLine: 1,
+      endLine: 8,
+      startColumn: 1,
+      endColumn: 1,
+      tokenCount: 30,
+      lineCount: 8,
+      snippet: 'class BoilerB {}',
+    );
+    const clusterBoiler = DuplicateCluster(
+      id: 'cluster-boiler',
+      instances: [inst3A, inst3B],
+      tokenCount: 30,
+      lineCount: 8,
+      category: CloneCategory.boilerplate,
+      bucket: CloneBucket.parameterized,
+      estimatedLinesSaved: 8,
+    );
+
+    const summary = DedupeSummary(
+      filesAnalyzed: 6,
+      totalLines: 300,
+      totalTokens: 1000,
+      duplicateLines: 70,
+      duplicateTokens: 240,
+      duplicationPercentage: 23.3,
+      clusterCount: 3,
+      cloneInstanceCount: 6,
+      estimatedLinesSaved: 35,
+    );
+
+    const fileMetrics = [
+      FileDuplicationMetric(
+        filePath: 'lib/src/logic_a.dart',
+        totalLines: 50,
+        duplicateLines: 11,
+        totalTokens: 150,
+        duplicateTokens: 40,
+        duplicationPercentage: 22.0,
+        clusterCount: 1,
+      ),
+      FileDuplicationMetric(
+        filePath: 'lib/src/data_a.dart',
+        totalLines: 50,
+        duplicateLines: 16,
+        totalTokens: 150,
+        duplicateTokens: 50,
+        duplicationPercentage: 32.0,
+        clusterCount: 1,
+      ),
+    ];
+
+    const report = DedupeReport(
+      version: '0.1.0-wip',
+      targetPath: 'pkg/sample',
+      summary: summary,
+      clusters: [clusterLogic, clusterData, clusterBoiler],
+      fileMetrics: fileMetrics,
+    );
+
+    test(
+      'emits annotations and markdown for all clusters by default',
+      () async {
+        await d.dir('gh_default', [d.file('step_summary.md', '')]).create();
+        final summaryFile = File(d.path('gh_default/step_summary.md'));
+        final buffer = StringBuffer();
+
+        final reporter = DedupeGitHubReporter(
+          stdoutSink: buffer,
+          summaryFile: summaryFile,
+        );
+        reporter.report(report);
+
+        final out = buffer.toString();
+        // Annotations
+        check(out).contains(
+          '::warning file=lib/src/logic_a.dart,line=10,endLine=20,'
+          'title=Code Duplication (cluster-logic)::',
+        );
+        check(out).contains(
+          '::warning file=lib/src/data_a.dart,line=30,endLine=45,'
+          'title=Code Duplication (cluster-data)::',
+        );
+        check(out).contains(
+          '::warning file=lib/src/boiler_a.dart,line=1,endLine=8,'
+          'title=Code Duplication (cluster-boiler)::',
+        );
+
+        // Markdown
+        check(out).contains('## 📊 Summary');
+        check(out).contains('## 📁 File Breakdown');
+        check(
+          out,
+        ).contains('### cluster-logic: Logic & Control Flow (Identical)');
+        check(out).contains(
+          '### cluster-data: Data & Declarative Boilerplate (Structural)',
+        );
+        check(out).contains(
+          '### cluster-boiler: Scaffolding & Structural Boilerplate '
+          '(Parameterized)',
+        );
+
+        // Summary File
+        final summaryContent = summaryFile.readAsStringSync();
+        check(
+          summaryContent,
+        ).contains('# 🔍 Dedupe Duplication Analysis: `pkg/sample`');
+        check(summaryContent).contains('### cluster-logic');
+      },
+    );
+
+    test('respects topCount filter in annotations and markdown', () {
+      final buffer = StringBuffer();
+      final reporter = DedupeGitHubReporter(stdoutSink: buffer, topCount: 1);
+      reporter.report(report);
+
+      final out = buffer.toString();
+      check(out).contains('title=Code Duplication (cluster-logic)::');
+      check(
+        out,
+      ).not((it) => it.contains('title=Code Duplication (cluster-data)::'));
+      check(
+        out,
+      ).not((it) => it.contains('title=Code Duplication (cluster-boiler)::'));
+
+      check(out).contains('### cluster-logic');
+      check(out).not((it) => it.contains('### cluster-data'));
+      check(out).not((it) => it.contains('### cluster-boiler'));
+    });
+
+    test('respects categoryFilter in annotations and markdown', () {
+      final buffer = StringBuffer();
+      final reporter = DedupeGitHubReporter(
+        stdoutSink: buffer,
+        categoryFilter: 'data',
+      );
+      reporter.report(report);
+
+      final out = buffer.toString();
+      check(
+        out,
+      ).not((it) => it.contains('title=Code Duplication (cluster-logic)::'));
+      check(out).contains('title=Code Duplication (cluster-data)::');
+      check(
+        out,
+      ).not((it) => it.contains('title=Code Duplication (cluster-boiler)::'));
+
+      check(out).not((it) => it.contains('### cluster-logic'));
+      check(out).contains('### cluster-data');
+      check(out).not((it) => it.contains('### cluster-boiler'));
+    });
+
+    test('respects bucketFilter in annotations and markdown', () {
+      final buffer = StringBuffer();
+      final reporter = DedupeGitHubReporter(
+        stdoutSink: buffer,
+        bucketFilter: 'parameterized',
+      );
+      reporter.report(report);
+
+      final out = buffer.toString();
+      check(
+        out,
+      ).not((it) => it.contains('title=Code Duplication (cluster-logic)::'));
+      check(
+        out,
+      ).not((it) => it.contains('title=Code Duplication (cluster-data)::'));
+      check(out).contains('title=Code Duplication (cluster-boiler)::');
+
+      check(out).not((it) => it.contains('### cluster-logic'));
+      check(out).not((it) => it.contains('### cluster-data'));
+      check(out).contains('### cluster-boiler');
+    });
+
+    test('respects includeFileTable=false', () {
+      final buffer = StringBuffer();
+      final reporter = DedupeGitHubReporter(
+        stdoutSink: buffer,
+        includeFileTable: false,
+      );
+      reporter.report(report);
+
+      final out = buffer.toString();
+      check(out).not((it) => it.contains('## 📁 File Breakdown'));
+      check(out).contains('## 📊 Summary');
+      check(out).contains('### cluster-logic');
+    });
+
+    test(
+      'respects includeClusters=false (suppresses clusters and annotations)',
+      () {
+        final buffer = StringBuffer();
+        final reporter = DedupeGitHubReporter(
+          stdoutSink: buffer,
+          includeClusters: false,
+        );
+        reporter.report(report);
+
+        final out = buffer.toString();
+        check(out).not((it) => it.contains('::warning'));
+        check(out).not((it) => it.contains('## 🔍 Duplicate Clusters'));
+        check(out).contains('## 📊 Summary');
+        check(out).contains('## 📁 File Breakdown');
+      },
+    );
+
+    test('propagates DedupeOptions configuration', () {
+      final buffer = StringBuffer();
+      const options = DedupeOptions(
+        targetPath: 'pkg/sample',
+        top: 1,
+        categoryFilter: 'logic',
+        bucketFilter: 'identical',
+        includeFileTable: false,
+        includeClusters: true,
+      );
+
+      final reporter = DedupeGitHubReporter(
+        stdoutSink: buffer,
+        options: options,
+      );
+      reporter.report(report);
+
+      final out = buffer.toString();
+      check(out).contains('title=Code Duplication (cluster-logic)::');
+      check(
+        out,
+      ).not((it) => it.contains('title=Code Duplication (cluster-data)::'));
+      check(out).not((it) => it.contains('## 📁 File Breakdown'));
+      check(out).contains('### cluster-logic');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stacked on #81.

Addresses #67:
- **Forward Options in DedupeGitHubReporter**: Pass `topCount`, `categoryFilter`, `bucketFilter`, `includeFileTable`, and `includeClusters` from `DedupeOptions` into `MarkdownFormatter`.
- **Workflow Annotation Filtering**: Align workflow `::warning` annotations with category, bucket, and top limits, and suppress them when `includeClusters` is false.
- **CLI Runner Integration**: Pass `options: options` to `DedupeGitHubReporter` in `DedupeCliRunner`.
- **Testing**: Add unit tests for `DedupeGitHubReporter` and CLI end-to-end filter tests for `--format=github`.

Fixes #67