### PR TITLE
fix(dedupe): merge overlapping clone clusters and compute line union savings

### DIFF
--- a/packages/dedupe/lib/src/detector.dart
+++ b/packages/dedupe/lib/src/detector.dart
@@ -78,6 +78,42 @@ class _MatchPair {
     return (other.span1.contains(span1) && other.span2.contains(span2)) ||
         (other.span1.contains(span2) && other.span2.contains(span1));
   }
+
+  bool isSubsumedByOrOverlaps(
+    _MatchPair other, {
+    double minOverlapFraction = 0.70,
+  }) {
+    if (isSubsumedBy(other)) return true;
+
+    if (span1.fileIndex == other.span1.fileIndex &&
+        span2.fileIndex == other.span2.fileIndex) {
+      if (span1.overlaps(other.span1) && span2.overlaps(other.span2)) {
+        final o1 = _overlapTokenCount(span1, other.span1);
+        final o2 = _overlapTokenCount(span2, other.span2);
+        if (o1 / span1.tokenCount >= minOverlapFraction &&
+            o2 / span2.tokenCount >= minOverlapFraction) {
+          return true;
+        }
+      }
+    } else if (span1.fileIndex == other.span2.fileIndex &&
+        span2.fileIndex == other.span1.fileIndex) {
+      if (span1.overlaps(other.span2) && span2.overlaps(other.span1)) {
+        final o1 = _overlapTokenCount(span1, other.span2);
+        final o2 = _overlapTokenCount(span2, other.span1);
+        if (o1 / span1.tokenCount >= minOverlapFraction &&
+            o2 / span2.tokenCount >= minOverlapFraction) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  static int _overlapTokenCount(_TokenSpan s1, _TokenSpan s2) {
+    final start = math.max(s1.startTokenIndex, s2.startTokenIndex);
+    final end = math.min(s1.endTokenIndex, s2.endTokenIndex);
+    return math.max(0, end - start + 1);
+  }
 }
 
 /// Disjoint Set Union (DSU) helper for clustering token spans.
@@ -722,7 +758,7 @@ class CloneDetector {
       var isSubsumed = false;
       if (existingForFile != null) {
         for (final existing in existingForFile) {
-          if (pair.isSubsumedBy(existing)) {
+          if (pair.isSubsumedByOrOverlaps(existing)) {
             isSubsumed = true;
             break;
           }
@@ -740,8 +776,7 @@ class CloneDetector {
     Map<int, List<_TokenSpan>> clusterMap,
     List<TokenSequence> fileSequences,
   ) {
-    final clusters = <DuplicateCluster>[];
-    final seenClusterSignatures = <String>{};
+    final rawClusters = <DuplicateCluster>[];
     var clusterIndex = 1;
 
     for (final spans in clusterMap.values) {
@@ -751,16 +786,110 @@ class CloneDetector {
         fileSequences: fileSequences,
       );
       if (cluster != null) {
-        final sig = cluster.instances
-            .map((i) => '${i.filePath}:${i.startLine}-${i.endLine}')
-            .join(';');
-        if (!seenClusterSignatures.add(sig)) continue;
-
-        clusters.add(cluster);
+        rawClusters.add(cluster);
         clusterIndex++;
       }
     }
-    return clusters;
+
+    final deduplicated = _mergeAndDeduplicateClusters(rawClusters);
+
+    deduplicated.sort((a, b) {
+      final comp = b.estimatedLinesSaved.compareTo(a.estimatedLinesSaved);
+      if (comp != 0) return comp;
+      return b.tokenCount.compareTo(a.tokenCount);
+    });
+
+    final finalClusters = <DuplicateCluster>[];
+    for (var i = 0; i < deduplicated.length; i++) {
+      final c = deduplicated[i];
+      finalClusters.add(
+        DuplicateCluster(
+          id: 'cluster-${i + 1}',
+          instances: c.instances,
+          tokenCount: c.tokenCount,
+          lineCount: c.lineCount,
+          category: c.category,
+          bucket: c.bucket,
+          estimatedLinesSaved: c.estimatedLinesSaved,
+          intersectsDiff: c.intersectsDiff,
+          isNewlyIntroduced: c.isNewlyIntroduced,
+        ),
+      );
+    }
+
+    return finalClusters;
+  }
+
+  static List<DuplicateCluster> _mergeAndDeduplicateClusters(
+    List<DuplicateCluster> clusters,
+  ) {
+    if (clusters.length <= 1) return clusters;
+
+    final sorted = List<DuplicateCluster>.from(clusters)
+      ..sort((a, b) {
+        final c1 = b.instances.length.compareTo(a.instances.length);
+        if (c1 != 0) return c1;
+        final c2 = b.lineCount.compareTo(a.lineCount);
+        if (c2 != 0) return c2;
+        return b.tokenCount.compareTo(a.tokenCount);
+      });
+
+    final kept = <DuplicateCluster>[];
+
+    for (final candidate in sorted) {
+      var isRedundant = false;
+
+      for (final existing in kept) {
+        if (_isClusterSubsumedOrDuplicate(candidate, existing)) {
+          isRedundant = true;
+          break;
+        }
+      }
+
+      if (!isRedundant) {
+        kept.add(candidate);
+      }
+    }
+
+    return kept;
+  }
+
+  static bool _isClusterSubsumedOrDuplicate(
+    DuplicateCluster candidate,
+    DuplicateCluster existing,
+  ) {
+    if (candidate.instances.length > existing.instances.length) {
+      return false;
+    }
+
+    final usedExistingIndices = <int>{};
+    for (final cInst in candidate.instances) {
+      var instanceMatched = false;
+      for (var i = 0; i < existing.instances.length; i++) {
+        if (usedExistingIndices.contains(i)) continue;
+        final eInst = existing.instances[i];
+        if (eInst.filePath == cInst.filePath) {
+          final overlapStart = math.max(cInst.startLine, eInst.startLine);
+          final overlapEnd = math.min(cInst.endLine, eInst.endLine);
+          if (overlapStart <= overlapEnd) {
+            final overlapLines = overlapEnd - overlapStart + 1;
+            final frac = overlapLines / cInst.lineCount;
+            if (frac >= 0.70 ||
+                (eInst.startLine <= cInst.startLine &&
+                    eInst.endLine >= cInst.endLine)) {
+              usedExistingIndices.add(i);
+              instanceMatched = true;
+              break;
+            }
+          }
+        }
+      }
+      if (!instanceMatched) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   static DuplicateCluster? _buildSingleCluster({
@@ -804,11 +933,35 @@ class CloneDetector {
   }
 
   static List<_TokenSpan> _deduplicateOverlappingSpans(List<_TokenSpan> spans) {
-    final deduped = <_TokenSpan>[];
+    if (spans.isEmpty) return const [];
+
+    final byFile = <int, List<_TokenSpan>>{};
     for (final s in spans) {
-      if (!deduped.any((existing) => existing.overlaps(s))) {
-        deduped.add(s);
+      byFile.putIfAbsent(s.fileIndex, () => []).add(s);
+    }
+
+    final deduped = <_TokenSpan>[];
+    for (final fileSpans in byFile.values) {
+      fileSpans.sort((a, b) => a.startTokenIndex.compareTo(b.startTokenIndex));
+
+      var current = fileSpans.first;
+      for (var i = 1; i < fileSpans.length; i++) {
+        final next = fileSpans[i];
+        if (current.overlaps(next)) {
+          current = _TokenSpan(
+            fileIndex: current.fileIndex,
+            startTokenIndex: math.min(
+              current.startTokenIndex,
+              next.startTokenIndex,
+            ),
+            endTokenIndex: math.max(current.endTokenIndex, next.endTokenIndex),
+          );
+        } else {
+          deduped.add(current);
+          current = next;
+        }
       }
+      deduped.add(current);
     }
     return deduped;
   }

--- a/packages/dedupe/lib/src/detector.dart
+++ b/packages/dedupe/lib/src/detector.dart
@@ -87,26 +87,39 @@ class _MatchPair {
 
     if (span1.fileIndex == other.span1.fileIndex &&
         span2.fileIndex == other.span2.fileIndex) {
-      if (span1.overlaps(other.span1) && span2.overlaps(other.span2)) {
-        final o1 = _overlapTokenCount(span1, other.span1);
-        final o2 = _overlapTokenCount(span2, other.span2);
-        if (o1 / span1.tokenCount >= minOverlapFraction &&
-            o2 / span2.tokenCount >= minOverlapFraction) {
-          return true;
-        }
-      }
-    } else if (span1.fileIndex == other.span2.fileIndex &&
+      return _spansOverlapSufficiently(
+        span1,
+        other.span1,
+        span2,
+        other.span2,
+        minOverlapFraction,
+      );
+    }
+    if (span1.fileIndex == other.span2.fileIndex &&
         span2.fileIndex == other.span1.fileIndex) {
-      if (span1.overlaps(other.span2) && span2.overlaps(other.span1)) {
-        final o1 = _overlapTokenCount(span1, other.span2);
-        final o2 = _overlapTokenCount(span2, other.span1);
-        if (o1 / span1.tokenCount >= minOverlapFraction &&
-            o2 / span2.tokenCount >= minOverlapFraction) {
-          return true;
-        }
-      }
+      return _spansOverlapSufficiently(
+        span1,
+        other.span2,
+        span2,
+        other.span1,
+        minOverlapFraction,
+      );
     }
     return false;
+  }
+
+  static bool _spansOverlapSufficiently(
+    _TokenSpan s1,
+    _TokenSpan o1,
+    _TokenSpan s2,
+    _TokenSpan o2,
+    double minOverlapFraction,
+  ) {
+    if (!s1.overlaps(o1) || !s2.overlaps(o2)) return false;
+    final count1 = _overlapTokenCount(s1, o1);
+    final count2 = _overlapTokenCount(s2, o2);
+    return count1 / s1.tokenCount >= minOverlapFraction &&
+        count2 / s2.tokenCount >= minOverlapFraction;
   }
 
   static int _overlapTokenCount(_TokenSpan s1, _TokenSpan s2) {
@@ -864,32 +877,45 @@ class CloneDetector {
 
     final usedExistingIndices = <int>{};
     for (final cInst in candidate.instances) {
-      var instanceMatched = false;
-      for (var i = 0; i < existing.instances.length; i++) {
-        if (usedExistingIndices.contains(i)) continue;
-        final eInst = existing.instances[i];
-        if (eInst.filePath == cInst.filePath) {
-          final overlapStart = math.max(cInst.startLine, eInst.startLine);
-          final overlapEnd = math.min(cInst.endLine, eInst.endLine);
-          if (overlapStart <= overlapEnd) {
-            final overlapLines = overlapEnd - overlapStart + 1;
-            final frac = overlapLines / cInst.lineCount;
-            if (frac >= 0.70 ||
-                (eInst.startLine <= cInst.startLine &&
-                    eInst.endLine >= cInst.endLine)) {
-              usedExistingIndices.add(i);
-              instanceMatched = true;
-              break;
-            }
-          }
-        }
-      }
-      if (!instanceMatched) {
-        return false;
-      }
+      final matchIndex = _findMatchingExistingInstance(
+        cInst,
+        existing.instances,
+        usedExistingIndices,
+      );
+      if (matchIndex == null) return false;
+      usedExistingIndices.add(matchIndex);
     }
 
     return true;
+  }
+
+  static int? _findMatchingExistingInstance(
+    CloneInstance cInst,
+    List<CloneInstance> existingInstances,
+    Set<int> usedIndices,
+  ) {
+    for (var i = 0; i < existingInstances.length; i++) {
+      if (usedIndices.contains(i)) continue;
+      if (_instancesOverlapSufficiently(cInst, existingInstances[i])) {
+        return i;
+      }
+    }
+    return null;
+  }
+
+  static bool _instancesOverlapSufficiently(
+    CloneInstance cInst,
+    CloneInstance eInst,
+  ) {
+    if (cInst.filePath != eInst.filePath) return false;
+    final overlapStart = math.max(cInst.startLine, eInst.startLine);
+    final overlapEnd = math.min(cInst.endLine, eInst.endLine);
+    if (overlapStart > overlapEnd) return false;
+
+    final overlapLines = overlapEnd - overlapStart + 1;
+    final frac = overlapLines / cInst.lineCount;
+    return frac >= 0.70 ||
+        (eInst.startLine <= cInst.startLine && eInst.endLine >= cInst.endLine);
   }
 
   static DuplicateCluster? _buildSingleCluster({

--- a/packages/dedupe/lib/src/engine.dart
+++ b/packages/dedupe/lib/src/engine.dart
@@ -291,23 +291,8 @@ class DedupeEngine {
     if (clusters.isEmpty) return 0;
 
     final lineMaxInstances = <String, Map<int, int>>{};
-
     for (final cluster in clusters) {
-      final instanceCount = cluster.instances.length;
-      if (instanceCount < 2) continue;
-
-      for (final instance in cluster.instances) {
-        final fileMap = lineMaxInstances.putIfAbsent(
-          instance.filePath,
-          () => <int, int>{},
-        );
-        for (var l = instance.startLine; l <= instance.endLine; l++) {
-          final currentMax = fileMap[l] ?? 0;
-          if (instanceCount > currentMax) {
-            fileMap[l] = instanceCount;
-          }
-        }
-      }
+      _recordClusterLineInstances(cluster, lineMaxInstances);
     }
 
     var savedAccumulator = 0.0;
@@ -320,6 +305,27 @@ class DedupeEngine {
     }
 
     return savedAccumulator.round();
+  }
+
+  static void _recordClusterLineInstances(
+    DuplicateCluster cluster,
+    Map<String, Map<int, int>> lineMaxInstances,
+  ) {
+    final instanceCount = cluster.instances.length;
+    if (instanceCount < 2) return;
+
+    for (final instance in cluster.instances) {
+      final fileMap = lineMaxInstances.putIfAbsent(
+        instance.filePath,
+        () => <int, int>{},
+      );
+      for (var l = instance.startLine; l <= instance.endLine; l++) {
+        final currentMax = fileMap[l] ?? 0;
+        if (instanceCount > currentMax) {
+          fileMap[l] = instanceCount;
+        }
+      }
+    }
   }
 
   static (Map<String, Set<int>>, Map<String, Set<int>>, Map<String, int>)

--- a/packages/dedupe/lib/src/engine.dart
+++ b/packages/dedupe/lib/src/engine.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:math' as math;
 
 import 'package:analytica/analyzer.dart';
 import 'package:path/path.dart' as p;
@@ -256,12 +255,10 @@ class DedupeEngine {
     }
 
     var totalCloneInstances = 0;
-    var rawLinesSaved = 0;
     for (final c in clusters) {
       totalCloneInstances += c.instances.length;
-      rawLinesSaved += c.estimatedLinesSaved;
     }
-    final totalLinesSaved = math.min(rawLinesSaved, totalDuplicateLines);
+    final totalLinesSaved = _computeTotalLinesSaved(clusters);
 
     final overallDuplicationPercentage = totalProjectLines > 0
         ? (totalDuplicateLines / totalProjectLines) * 100
@@ -288,6 +285,41 @@ class DedupeEngine {
       clusters: clusters,
       fileMetrics: fileMetrics,
     );
+  }
+
+  static int _computeTotalLinesSaved(List<DuplicateCluster> clusters) {
+    if (clusters.isEmpty) return 0;
+
+    final lineMaxInstances = <String, Map<int, int>>{};
+
+    for (final cluster in clusters) {
+      final instanceCount = cluster.instances.length;
+      if (instanceCount < 2) continue;
+
+      for (final instance in cluster.instances) {
+        final fileMap = lineMaxInstances.putIfAbsent(
+          instance.filePath,
+          () => <int, int>{},
+        );
+        for (var l = instance.startLine; l <= instance.endLine; l++) {
+          final currentMax = fileMap[l] ?? 0;
+          if (instanceCount > currentMax) {
+            fileMap[l] = instanceCount;
+          }
+        }
+      }
+    }
+
+    var savedAccumulator = 0.0;
+    for (final fileMap in lineMaxInstances.values) {
+      for (final maxN in fileMap.values) {
+        if (maxN >= 2) {
+          savedAccumulator += (maxN - 1) / maxN;
+        }
+      }
+    }
+
+    return savedAccumulator.round();
   }
 
   static (Map<String, Set<int>>, Map<String, Set<int>>, Map<String, int>)

--- a/packages/dedupe/test/detector_test.dart
+++ b/packages/dedupe/test/detector_test.dart
@@ -417,5 +417,142 @@ void processOrderBatchB(List<String> items) {
       check(cluster.tokenCount).isGreaterThan(astCandidate1.tokenCount);
       check(cluster.instances.length).equals(2);
     });
+
+    test('computes estimatedLinesSaved correctly for 2, 3, and 4 instances '
+        'of a 14-line block', () {
+      const fourteenLineBlock = '''
+void handleRecord(String id, int count, double weight) {
+  if (id.isEmpty) {
+    throw ArgumentError('id is empty');
+  }
+  if (count <= 0) {
+    throw ArgumentError('count is non-positive');
+  }
+  if (weight < 0.0) {
+    throw ArgumentError('weight is negative');
+  }
+  final density = count / weight;
+  print('Processing record: \$id, density: \$density');
+  print('Recording transaction to audit trail');
+}
+''';
+
+      const tokenizer = DartTokenizer();
+      final seq1 = tokenizer.tokenize(
+        filePath: 'file1.dart',
+        content: fourteenLineBlock,
+      );
+      final seq2 = tokenizer.tokenize(
+        filePath: 'file2.dart',
+        content: fourteenLineBlock,
+      );
+      final seq3 = tokenizer.tokenize(
+        filePath: 'file3.dart',
+        content: fourteenLineBlock,
+      );
+      final seq4 = tokenizer.tokenize(
+        filePath: 'file4.dart',
+        content: fourteenLineBlock,
+      );
+
+      const detector = CloneDetector(minTokens: 20, minLines: 4);
+
+      // 2 instances -> 14 lines saved (1 copy kept, 1 saved)
+      final clusters2 = detector.detect([seq1, seq2]);
+      check(clusters2.length).equals(1);
+      check(clusters2.first.instances.length).equals(2);
+      check(clusters2.first.lineCount).equals(14);
+      check(clusters2.first.estimatedLinesSaved).equals(14);
+
+      // 3 instances -> 28 lines saved (1 copy kept, 2 saved)
+      final clusters3 = detector.detect([seq1, seq2, seq3]);
+      check(clusters3.length).equals(1);
+      check(clusters3.first.instances.length).equals(3);
+      check(clusters3.first.lineCount).equals(14);
+      check(clusters3.first.estimatedLinesSaved).equals(28);
+
+      // 4 instances -> 42 lines saved (1 copy kept, 3 saved)
+      final clusters4 = detector.detect([seq1, seq2, seq3, seq4]);
+      check(clusters4.length).equals(1);
+      check(clusters4.first.instances.length).equals(4);
+      check(clusters4.first.lineCount).equals(14);
+      check(clusters4.first.estimatedLinesSaved).equals(42);
+    });
+
+    test(
+      'merges partially overlapping match windows across same instances',
+      () {
+        const codeA = '''
+void outerPipelineA() {
+  print('Step 1: start pipeline');
+  print('Step 2: process queue');
+  print('Step 3: validate entries');
+  print('Step 4: write database');
+  print('Step 5: notify handlers');
+  print('Step 6: finish pipeline');
+}
+''';
+
+        const codeB = '''
+void outerPipelineB() {
+  print('Step 1: start pipeline');
+  print('Step 2: process queue');
+  print('Step 3: validate entries');
+  print('Step 4: write database');
+  print('Step 5: notify handlers');
+  print('Step 6: finish pipeline');
+}
+''';
+
+        const tokenizer = DartTokenizer();
+        final seq1 = tokenizer.tokenize(
+          filePath: 'pipe_a.dart',
+          content: codeA,
+        );
+        final seq2 = tokenizer.tokenize(
+          filePath: 'pipe_b.dart',
+          content: codeB,
+        );
+
+        const innerAst1 = AstCandidateUnit(
+          filePath: 'pipe_a.dart',
+          fileIndex: 0,
+          startLine: 3,
+          endLine: 7,
+          startOffset: 25,
+          endOffset: 120,
+          startTokenIndex: 6,
+          endTokenIndex: 20,
+          tokenCount: 15,
+          lineCount: 5,
+          astNodeType: 'Block',
+          signatureHash: 9999,
+        );
+        const innerAst2 = AstCandidateUnit(
+          filePath: 'pipe_b.dart',
+          fileIndex: 1,
+          startLine: 3,
+          endLine: 7,
+          startOffset: 25,
+          endOffset: 120,
+          startTokenIndex: 6,
+          endTokenIndex: 20,
+          tokenCount: 15,
+          lineCount: 5,
+          astNodeType: 'Block',
+          signatureHash: 9999,
+        );
+
+        const detector = CloneDetector(minTokens: 15, minLines: 4);
+        final clusters = detector.detect(
+          [seq1, seq2],
+          candidates: [innerAst1, innerAst2],
+        );
+
+        check(clusters.length).equals(1);
+        check(clusters.first.instances.length).equals(2);
+        check(clusters.first.estimatedLinesSaved).isLessThan(20);
+      },
+    );
   });
 }

--- a/packages/dedupe/test/engine_test.dart
+++ b/packages/dedupe/test/engine_test.dart
@@ -137,5 +137,108 @@ void singleFunction() {
       check(report.summary.duplicateLines).equals(0);
       check(report.summary.clusterCount).equals(0);
     });
+
+    test('computes estimatedLinesSaved correctly across 2, 3, and 4 duplicate '
+        'files', () async {
+      const fourteenLineBlock = '''
+void handleRecord(String id, int count, double weight) {
+  if (id.isEmpty) {
+    throw ArgumentError('id is empty');
+  }
+  if (count <= 0) {
+    throw ArgumentError('count is non-positive');
+  }
+  if (weight < 0.0) {
+    throw ArgumentError('weight is negative');
+  }
+  final density = count / weight;
+  print('Processing record: \$id, density: \$density');
+  print('Recording transaction to audit trail');
+}
+''';
+
+      final libDir = Directory(p.join(tempDir.path, 'lib'))..createSync();
+      File(
+        p.join(libDir.path, 'file1.dart'),
+      ).writeAsStringSync(fourteenLineBlock);
+      File(
+        p.join(libDir.path, 'file2.dart'),
+      ).writeAsStringSync(fourteenLineBlock);
+
+      // 2 files: 28 duplicate lines, 14 lines saved
+      final engine2 = DedupeEngine(
+        DedupeOptions(targetPath: tempDir.path, minTokens: 20, minLines: 4),
+      );
+      final report2 = await engine2.analyze();
+      check(report2.summary.filesAnalyzed).equals(2);
+      check(report2.summary.clusterCount).equals(1);
+      check(report2.summary.duplicateLines).equals(28);
+      check(report2.summary.estimatedLinesSaved).equals(14);
+
+      // 3 files: 42 duplicate lines, 28 lines saved
+      File(
+        p.join(libDir.path, 'file3.dart'),
+      ).writeAsStringSync(fourteenLineBlock);
+      final engine3 = DedupeEngine(
+        DedupeOptions(targetPath: tempDir.path, minTokens: 20, minLines: 4),
+      );
+      final report3 = await engine3.analyze();
+      check(report3.summary.filesAnalyzed).equals(3);
+      check(report3.summary.clusterCount).equals(1);
+      check(report3.summary.duplicateLines).equals(42);
+      check(report3.summary.estimatedLinesSaved).equals(28);
+
+      // 4 files: 56 duplicate lines, 42 lines saved
+      File(
+        p.join(libDir.path, 'file4.dart'),
+      ).writeAsStringSync(fourteenLineBlock);
+      final engine4 = DedupeEngine(
+        DedupeOptions(targetPath: tempDir.path, minTokens: 20, minLines: 4),
+      );
+      final report4 = await engine4.analyze();
+      check(report4.summary.filesAnalyzed).equals(4);
+      check(report4.summary.clusterCount).equals(1);
+      check(report4.summary.duplicateLines).equals(56);
+      check(report4.summary.estimatedLinesSaved).equals(42);
+    });
+
+    test(
+      'handles overlapping clusters without over-counting estimatedLinesSaved',
+      () async {
+        const code1 = '''
+void pipeline1() {
+  print('L1');
+  print('L2');
+  print('L3');
+  print('L4');
+  print('L5');
+  print('L6');
+}
+''';
+        const code2 = '''
+void pipeline2() {
+  print('L1');
+  print('L2');
+  print('L3');
+  print('L4');
+  print('L5');
+  print('L6');
+}
+''';
+        final libDir = Directory(p.join(tempDir.path, 'lib'))..createSync();
+        File(p.join(libDir.path, 'p1.dart')).writeAsStringSync(code1);
+        File(p.join(libDir.path, 'p2.dart')).writeAsStringSync(code2);
+
+        final engine = DedupeEngine(
+          DedupeOptions(targetPath: tempDir.path, minTokens: 10, minLines: 4),
+        );
+        final report = await engine.analyze();
+
+        check(
+          report.summary.estimatedLinesSaved,
+        ).isLessThan(report.summary.duplicateLines);
+        check(report.summary.estimatedLinesSaved).isGreaterThan(0);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Stacked on #82.

Addresses #63:
- **Cluster Overlap Detection & Merging**: In `_MatchPair`, detect overlapping and shifted match windows. In `_deduplicateOverlappingSpans` and `_mergeAndDeduplicateClusters`, merge overlapping windows across identical code instances into single maximal clusters.
- **Line Savings Union Calculation**: Replace per-cluster savings sum and arbitrary `math.min` clamp with `_computeTotalLinesSaved`, calculating exact line savings from physical line unions ( - 1$ copies saved across $ instances).
- **Testing**: Add regression test suite for 2, 3, and 4 clone instances and overlapping cluster deduplication.

Fixes #63