### PR TITLE
fix(dedupe): prune public exports and implement value semantics on models

### DIFF
--- a/packages/dedupe/lib/dedupe.dart
+++ b/packages/dedupe/lib/dedupe.dart
@@ -2,17 +2,11 @@
 /// Flutter packages and workspaces.
 library;
 
-export 'src/ast_extractor.dart';
-export 'src/cache.dart';
-export 'src/cli.dart';
 export 'src/delta_service.dart';
-export 'src/detector.dart';
 export 'src/engine.dart';
 export 'src/formatters/github_reporter.dart';
 export 'src/formatters/json_formatter.dart';
 export 'src/formatters/markdown_formatter.dart';
 export 'src/formatters/text_formatter.dart';
-export 'src/minhash.dart';
 export 'src/models.dart';
-export 'src/tokenizer.dart';
 export 'src/version.dart';

--- a/packages/dedupe/lib/src/models.dart
+++ b/packages/dedupe/lib/src/models.dart
@@ -16,8 +16,13 @@ const List<String> defaultDartExclusions = [
 
 /// Classification category for duplicate code clusters.
 enum CloneCategory {
+  /// Logic and control flow duplication (if statements, loops, algorithms).
   logic('logic', 'Logic & Control Flow'),
+
+  /// Data definitions, literals, maps, and declarative boilerplate.
   data('data', 'Data & Declarative Boilerplate'),
+
+  /// Structural boilerplate and scaffolding (class structures, setups).
   boilerplate('boilerplate', 'Scaffolding & Structural Boilerplate');
 
   final String jsonValue;
@@ -25,12 +30,16 @@ enum CloneCategory {
 
   const CloneCategory(this.jsonValue, this.displayName);
 
+  /// Parses a [CloneCategory] from its JSON string representation.
   static CloneCategory fromJson(String value) => switch (value) {
     'logic' => logic,
     'data' => data,
     'boilerplate' => boilerplate,
     _ => throw ArgumentError.value(value, 'value', 'Unknown CloneCategory'),
   };
+
+  /// Parses a [CloneCategory] from a string representation.
+  static CloneCategory fromString(String value) => fromJson(value);
 }
 
 /// Structural match type / bucket for clone detection.
@@ -52,6 +61,7 @@ enum CloneBucket {
 
   const CloneBucket(this.jsonValue, this.displayName);
 
+  /// Parses a [CloneBucket] from its JSON string representation.
   static CloneBucket fromJson(String value) => switch (value) {
     'identical' => identical,
     'structural' => structural,
@@ -59,19 +69,33 @@ enum CloneBucket {
     'gapped' => gapped,
     _ => throw ArgumentError.value(value, 'value', 'Unknown CloneBucket'),
   };
+
+  /// Parses a [CloneBucket] from a string representation.
+  static CloneBucket fromString(String value) => fromJson(value);
 }
 
 /// Output formatting mode for CLI and reports.
 enum OutputFormat {
+  /// Formats the report as human-readable GitHub Flavored Markdown.
   markdown('markdown'),
+
+  /// Formats the report as machine-readable JSON.
   json('json'),
+
+  /// Emits GitHub Actions workflow commands and PR review annotations.
   github('github'),
+
+  /// Formats the report as concise, plain ASCII text.
   text('text');
 
   final String jsonValue;
 
   const OutputFormat(this.jsonValue);
 
+  /// Parses an [OutputFormat] from its JSON string representation.
+  static OutputFormat fromJson(String value) => fromString(value);
+
+  /// Parses an [OutputFormat] from a string representation.
   static OutputFormat fromString(String value) => switch (value) {
     'markdown' => markdown,
     'json' => json,
@@ -82,7 +106,7 @@ enum OutputFormat {
 }
 
 /// Represents a single occurrence of duplicate code in a file.
-class CloneInstance {
+final class CloneInstance {
   final String filePath;
   final int startLine;
   final int endLine;
@@ -130,12 +154,39 @@ class CloneInstance {
   };
 
   @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CloneInstance &&
+          filePath == other.filePath &&
+          startLine == other.startLine &&
+          endLine == other.endLine &&
+          startColumn == other.startColumn &&
+          endColumn == other.endColumn &&
+          tokenCount == other.tokenCount &&
+          lineCount == other.lineCount &&
+          snippet == other.snippet &&
+          inDiff == other.inDiff;
+
+  @override
+  int get hashCode => Object.hash(
+    filePath,
+    startLine,
+    endLine,
+    startColumn,
+    endColumn,
+    tokenCount,
+    lineCount,
+    snippet,
+    inDiff,
+  );
+
+  @override
   String toString() =>
       '$filePath:$startLine-$endLine ($lineCount lines, $tokenCount tokens)';
 }
 
 /// A cluster of two or more [CloneInstance]s sharing duplicated code.
-class DuplicateCluster {
+final class DuplicateCluster {
   final String id;
   final List<CloneInstance> instances;
   final int tokenCount;
@@ -146,9 +197,9 @@ class DuplicateCluster {
   final bool intersectsDiff;
   final bool isNewlyIntroduced;
 
-  const DuplicateCluster({
+  DuplicateCluster({
     required this.id,
-    required this.instances,
+    required List<CloneInstance> instances,
     required this.tokenCount,
     required this.lineCount,
     required this.category,
@@ -156,7 +207,7 @@ class DuplicateCluster {
     required this.estimatedLinesSaved,
     this.intersectsDiff = false,
     this.isNewlyIntroduced = false,
-  });
+  }) : instances = List.unmodifiable(instances);
 
   int get instanceCount => instances.length;
 
@@ -191,13 +242,40 @@ class DuplicateCluster {
   };
 
   @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DuplicateCluster &&
+          id == other.id &&
+          _listEquals(instances, other.instances) &&
+          tokenCount == other.tokenCount &&
+          lineCount == other.lineCount &&
+          category == other.category &&
+          bucket == other.bucket &&
+          estimatedLinesSaved == other.estimatedLinesSaved &&
+          intersectsDiff == other.intersectsDiff &&
+          isNewlyIntroduced == other.isNewlyIntroduced;
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    Object.hashAll(instances),
+    tokenCount,
+    lineCount,
+    category,
+    bucket,
+    estimatedLinesSaved,
+    intersectsDiff,
+    isNewlyIntroduced,
+  );
+
+  @override
   String toString() =>
       'Cluster $id ($category, $bucket, $instanceCount instances, '
       '$estimatedLinesSaved lines saved)';
 }
 
 /// Duplication metrics for a single analyzed file.
-class FileDuplicationMetric {
+final class FileDuplicationMetric {
   final String filePath;
   final int totalLines;
   final int duplicateLines;
@@ -237,10 +315,38 @@ class FileDuplicationMetric {
     'duplicationPercentage': duplicationPercentage,
     'clusterCount': clusterCount,
   };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FileDuplicationMetric &&
+          filePath == other.filePath &&
+          totalLines == other.totalLines &&
+          duplicateLines == other.duplicateLines &&
+          totalTokens == other.totalTokens &&
+          duplicateTokens == other.duplicateTokens &&
+          duplicationPercentage == other.duplicationPercentage &&
+          clusterCount == other.clusterCount;
+
+  @override
+  int get hashCode => Object.hash(
+    filePath,
+    totalLines,
+    duplicateLines,
+    totalTokens,
+    duplicateTokens,
+    duplicationPercentage,
+    clusterCount,
+  );
+
+  @override
+  String toString() =>
+      '$filePath: $duplicateLines/$totalLines duplicate lines '
+      '(${duplicationPercentage.toStringAsFixed(1)}%)';
 }
 
 /// Aggregate summary metrics for a deduplication analysis run.
-class DedupeSummary {
+final class DedupeSummary {
   final int filesAnalyzed;
   final int totalLines;
   final int totalTokens;
@@ -296,23 +402,60 @@ class DedupeSummary {
     'estimatedLinesSaved': estimatedLinesSaved,
     if (clustersOutsideDiff > 0) 'clustersOutsideDiff': clustersOutsideDiff,
   };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DedupeSummary &&
+          filesAnalyzed == other.filesAnalyzed &&
+          totalLines == other.totalLines &&
+          totalTokens == other.totalTokens &&
+          duplicateLines == other.duplicateLines &&
+          duplicateTokens == other.duplicateTokens &&
+          duplicationPercentage == other.duplicationPercentage &&
+          diffDuplicationPercentage == other.diffDuplicationPercentage &&
+          clusterCount == other.clusterCount &&
+          cloneInstanceCount == other.cloneInstanceCount &&
+          estimatedLinesSaved == other.estimatedLinesSaved &&
+          clustersOutsideDiff == other.clustersOutsideDiff;
+
+  @override
+  int get hashCode => Object.hash(
+    filesAnalyzed,
+    totalLines,
+    totalTokens,
+    duplicateLines,
+    duplicateTokens,
+    duplicationPercentage,
+    diffDuplicationPercentage,
+    clusterCount,
+    cloneInstanceCount,
+    estimatedLinesSaved,
+    clustersOutsideDiff,
+  );
+
+  @override
+  String toString() =>
+      'DedupeSummary($filesAnalyzed files, $clusterCount clusters, '
+      '${duplicationPercentage.toStringAsFixed(1)}% duplication)';
 }
 
 /// Full analysis report produced by `pkg:dedupe`.
-class DedupeReport {
+final class DedupeReport {
   final String version;
   final String targetPath;
   final DedupeSummary summary;
   final List<DuplicateCluster> clusters;
   final List<FileDuplicationMetric> fileMetrics;
 
-  const DedupeReport({
+  DedupeReport({
     required this.version,
     required this.targetPath,
     required this.summary,
-    required this.clusters,
-    required this.fileMetrics,
-  });
+    required List<DuplicateCluster> clusters,
+    required List<FileDuplicationMetric> fileMetrics,
+  }) : clusters = List.unmodifiable(clusters),
+       fileMetrics = List.unmodifiable(fileMetrics);
 
   factory DedupeReport.fromJson(Map<String, dynamic> json) {
     final summary = DedupeSummary.fromJson(
@@ -347,6 +490,30 @@ class DedupeReport {
     'clusters': clusters.map((c) => c.toJson()).toList(),
     'fileMetrics': fileMetrics.map((f) => f.toJson()).toList(),
   };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DedupeReport &&
+          version == other.version &&
+          targetPath == other.targetPath &&
+          summary == other.summary &&
+          _listEquals(clusters, other.clusters) &&
+          _listEquals(fileMetrics, other.fileMetrics);
+
+  @override
+  int get hashCode => Object.hash(
+    version,
+    targetPath,
+    summary,
+    Object.hashAll(clusters),
+    Object.hashAll(fileMetrics),
+  );
+
+  @override
+  String toString() =>
+      'DedupeReport(version: $version, target: $targetPath, '
+      'clusters: ${clusters.length}, files: ${fileMetrics.length})';
 }
 
 /// Configuration options for duplicate code scanning.
@@ -375,16 +542,16 @@ final class DedupeOptions {
   final String? cacheDir;
   final bool clearCache;
 
-  const DedupeOptions({
+  DedupeOptions({
     required this.targetPath,
-    this.targets = const ['lib'],
+    List<String> targets = const ['lib'],
     this.minTokens = 40,
     this.minLines = 4,
     this.ignoreComments = true,
     this.ignoreLiterals = true,
     this.ignoreIdentifiers = false,
-    this.excludePatterns = defaultDartExclusions,
-    this.includePatterns = const ['**/*.dart'],
+    List<String> excludePatterns = defaultDartExclusions,
+    List<String> includePatterns = const ['**/*.dart'],
     this.gitDiffBase,
     this.onlyChanged = false,
     this.failThreshold,
@@ -399,5 +566,79 @@ final class DedupeOptions {
     this.useCache = true,
     this.cacheDir,
     this.clearCache = false,
-  });
+  }) : targets = List.unmodifiable(targets),
+       excludePatterns = List.unmodifiable(excludePatterns),
+       includePatterns = List.unmodifiable(includePatterns);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DedupeOptions &&
+          targetPath == other.targetPath &&
+          _listEquals(targets, other.targets) &&
+          minTokens == other.minTokens &&
+          minLines == other.minLines &&
+          ignoreComments == other.ignoreComments &&
+          ignoreLiterals == other.ignoreLiterals &&
+          ignoreIdentifiers == other.ignoreIdentifiers &&
+          _listEquals(excludePatterns, other.excludePatterns) &&
+          _listEquals(includePatterns, other.includePatterns) &&
+          gitDiffBase == other.gitDiffBase &&
+          onlyChanged == other.onlyChanged &&
+          failThreshold == other.failThreshold &&
+          top == other.top &&
+          categoryFilter == other.categoryFilter &&
+          bucketFilter == other.bucketFilter &&
+          format == other.format &&
+          jsonOutputPath == other.jsonOutputPath &&
+          sdkPath == other.sdkPath &&
+          includeFileTable == other.includeFileTable &&
+          includeClusters == other.includeClusters &&
+          useCache == other.useCache &&
+          cacheDir == other.cacheDir &&
+          clearCache == other.clearCache;
+
+  @override
+  int get hashCode => Object.hash(
+    targetPath,
+    Object.hashAll(targets),
+    minTokens,
+    minLines,
+    ignoreComments,
+    ignoreLiterals,
+    ignoreIdentifiers,
+    Object.hashAll(excludePatterns),
+    Object.hashAll(includePatterns),
+    gitDiffBase,
+    onlyChanged,
+    failThreshold,
+    top,
+    categoryFilter,
+    bucketFilter,
+    format,
+    jsonOutputPath,
+    sdkPath,
+    Object.hash(
+      includeFileTable,
+      includeClusters,
+      useCache,
+      cacheDir,
+      clearCache,
+    ),
+  );
+
+  @override
+  String toString() =>
+      'DedupeOptions(targetPath: $targetPath, format: $format, '
+      'minTokens: $minTokens, minLines: $minLines)';
+}
+
+bool _listEquals<T>(List<T>? a, List<T>? b) {
+  if (identical(a, b)) return true;
+  if (a == null || b == null) return false;
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
 }

--- a/packages/dedupe/test/ast_extractor_test.dart
+++ b/packages/dedupe/test/ast_extractor_test.dart
@@ -1,5 +1,6 @@
 import 'package:checks/checks.dart';
-import 'package:dedupe/dedupe.dart';
+import 'package:dedupe/src/ast_extractor.dart';
+import 'package:dedupe/src/detector.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/dedupe/test/cache_test.dart
+++ b/packages/dedupe/test/cache_test.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:checks/checks.dart';
 import 'package:dedupe/dedupe.dart';
+import 'package:dedupe/src/ast_extractor.dart';
+import 'package:dedupe/src/cache.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -23,7 +25,7 @@ void main() {
     });
 
     test('putEntry and getEntry store and load valid cache data', () {
-      const options = DedupeOptions(targetPath: '.');
+      final options = DedupeOptions(targetPath: '.');
       final cache = DedupeCacheManager(
         cacheDirPath: cacheDir,
         enabled: true,
@@ -61,7 +63,7 @@ void main() {
     });
 
     test('getEntry returns null on content hash mismatch', () {
-      const options = DedupeOptions(targetPath: '.');
+      final options = DedupeOptions(targetPath: '.');
       final cache = DedupeCacheManager(
         cacheDirPath: cacheDir,
         enabled: true,
@@ -96,8 +98,8 @@ void main() {
     });
 
     test('getEntry returns null on options mismatch', () {
-      const options1 = DedupeOptions(targetPath: '.', minTokens: 40);
-      const options2 = DedupeOptions(targetPath: '.', minTokens: 50);
+      final options1 = DedupeOptions(targetPath: '.', minTokens: 40);
+      final options2 = DedupeOptions(targetPath: '.', minTokens: 50);
 
       final cache1 = DedupeCacheManager(
         cacheDirPath: cacheDir,
@@ -137,7 +139,7 @@ void main() {
     });
 
     test('pruneStale removes deleted files from cache', () {
-      const options = DedupeOptions(targetPath: '.');
+      final options = DedupeOptions(targetPath: '.');
       final cache = DedupeCacheManager(
         cacheDirPath: cacheDir,
         enabled: true,
@@ -173,7 +175,7 @@ void main() {
     });
 
     test('pruneStale does not delete unrelated or malformed JSON files', () {
-      const options = DedupeOptions(targetPath: '.');
+      final options = DedupeOptions(targetPath: '.');
       final cache = DedupeCacheManager(
         cacheDirPath: cacheDir,
         enabled: true,
@@ -214,7 +216,7 @@ void main() {
     test(
       'clear removes only valid cache files and empty shard directories',
       () {
-        const options = DedupeOptions(targetPath: '.');
+        final options = DedupeOptions(targetPath: '.');
         final cache = DedupeCacheManager(
           cacheDirPath: cacheDir,
           enabled: true,
@@ -263,7 +265,7 @@ void main() {
       },
     );
     test('getEntry returns null on cache format version mismatch', () {
-      const options = DedupeOptions(targetPath: '.');
+      final options = DedupeOptions(targetPath: '.');
       final cache = DedupeCacheManager(
         cacheDirPath: cacheDir,
         enabled: true,
@@ -317,7 +319,7 @@ void main() {
     test(
       'getEntry returns null on SDK version or package version mismatch',
       () {
-        const options = DedupeOptions(targetPath: '.');
+        final options = DedupeOptions(targetPath: '.');
         final cache = DedupeCacheManager(
           cacheDirPath: cacheDir,
           enabled: true,
@@ -393,7 +395,7 @@ void main() {
     test(
       'getEntry gracefully handles corrupt or truncated JSON cache files',
       () {
-        const options = DedupeOptions(targetPath: '.');
+        final options = DedupeOptions(targetPath: '.');
         final cache = DedupeCacheManager(
           cacheDirPath: cacheDir,
           enabled: true,
@@ -459,7 +461,7 @@ void main() {
     );
 
     test('getEntry returns null when relPath mismatches', () {
-      const options = DedupeOptions(targetPath: '.');
+      final options = DedupeOptions(targetPath: '.');
       final cache = DedupeCacheManager(
         cacheDirPath: cacheDir,
         enabled: true,

--- a/packages/dedupe/test/delta_service_test.dart
+++ b/packages/dedupe/test/delta_service_test.dart
@@ -103,7 +103,7 @@ void main() {
           snippet: 'code',
         );
 
-        const cluster = DuplicateCluster(
+        final cluster = DuplicateCluster(
           id: 'cluster-1',
           instances: [instance1, instance2],
           tokenCount: 40,
@@ -160,7 +160,7 @@ void main() {
         snippet: 'code',
       );
 
-      const cluster = DuplicateCluster(
+      final cluster = DuplicateCluster(
         id: 'cluster-legacy',
         instances: [instance1, instance2],
         tokenCount: 40,

--- a/packages/dedupe/test/detector_test.dart
+++ b/packages/dedupe/test/detector_test.dart
@@ -1,5 +1,8 @@
 import 'package:checks/checks.dart';
 import 'package:dedupe/dedupe.dart';
+import 'package:dedupe/src/ast_extractor.dart';
+import 'package:dedupe/src/detector.dart';
+import 'package:dedupe/src/tokenizer.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/dedupe/test/formatters_test.dart
+++ b/packages/dedupe/test/formatters_test.dart
@@ -32,7 +32,7 @@ void main() {
       inDiff: false,
     );
 
-    const cluster = DuplicateCluster(
+    final cluster = DuplicateCluster(
       id: 'cluster-1',
       instances: [instance1, instance2],
       tokenCount: 45,
@@ -67,7 +67,7 @@ void main() {
       clusterCount: 1,
     );
 
-    const report = DedupeReport(
+    final report = DedupeReport(
       version: '0.1.0-wip',
       targetPath: 'packages/test',
       summary: summary,
@@ -120,7 +120,7 @@ void main() {
         estimatedLinesSaved: 0,
       );
 
-      const cleanReport = DedupeReport(
+      final cleanReport = DedupeReport(
         version: '0.1.0-wip',
         targetPath: 'clean_pkg',
         summary: cleanSummary,

--- a/packages/dedupe/test/github_reporter_test.dart
+++ b/packages/dedupe/test/github_reporter_test.dart
@@ -27,7 +27,7 @@ void main() {
       lineCount: 11,
       snippet: 'void doLogic() { print("a"); }',
     );
-    const clusterLogic = DuplicateCluster(
+    final clusterLogic = DuplicateCluster(
       id: 'cluster-logic',
       instances: [inst1A, inst1B],
       tokenCount: 40,
@@ -57,7 +57,7 @@ void main() {
       lineCount: 16,
       snippet: 'final data = [10, 20, 30];',
     );
-    const clusterData = DuplicateCluster(
+    final clusterData = DuplicateCluster(
       id: 'cluster-data',
       instances: [inst2A, inst2B],
       tokenCount: 50,
@@ -87,7 +87,7 @@ void main() {
       lineCount: 8,
       snippet: 'class BoilerB {}',
     );
-    const clusterBoiler = DuplicateCluster(
+    final clusterBoiler = DuplicateCluster(
       id: 'cluster-boiler',
       instances: [inst3A, inst3B],
       tokenCount: 30,
@@ -130,7 +130,7 @@ void main() {
       ),
     ];
 
-    const report = DedupeReport(
+    final report = DedupeReport(
       version: '0.1.0-wip',
       targetPath: 'pkg/sample',
       summary: summary,
@@ -286,7 +286,7 @@ void main() {
 
     test('propagates DedupeOptions configuration', () {
       final buffer = StringBuffer();
-      const options = DedupeOptions(
+      final options = DedupeOptions(
         targetPath: 'pkg/sample',
         top: 1,
         categoryFilter: 'logic',

--- a/packages/dedupe/test/minhash_test.dart
+++ b/packages/dedupe/test/minhash_test.dart
@@ -1,5 +1,8 @@
 import 'package:checks/checks.dart';
 import 'package:dedupe/dedupe.dart';
+import 'package:dedupe/src/ast_extractor.dart';
+import 'package:dedupe/src/detector.dart';
+import 'package:dedupe/src/minhash.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/dedupe/test/models_test.dart
+++ b/packages/dedupe/test/models_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('Models Serialization & Enums', () {
-    test('CloneCategory enum fromJson and jsonValue', () {
+    test('CloneCategory enum fromJson, fromString, and jsonValue', () {
       check(CloneCategory.logic.jsonValue).equals('logic');
       check(CloneCategory.data.jsonValue).equals('data');
       check(CloneCategory.boilerplate.jsonValue).equals('boilerplate');
@@ -15,39 +15,64 @@ void main() {
         CloneCategory.fromJson('boilerplate'),
       ).equals(CloneCategory.boilerplate);
 
+      check(CloneCategory.fromString('logic')).equals(CloneCategory.logic);
+      check(CloneCategory.fromString('data')).equals(CloneCategory.data);
+      check(
+        CloneCategory.fromString('boilerplate'),
+      ).equals(CloneCategory.boilerplate);
+
       check(() => CloneCategory.fromJson('invalid')).throws<ArgumentError>();
+      check(() => CloneCategory.fromString('invalid')).throws<ArgumentError>();
     });
 
-    test('CloneBucket enum fromJson and jsonValue', () {
+    test('CloneBucket enum fromJson, fromString, and jsonValue', () {
       check(CloneBucket.identical.jsonValue).equals('identical');
       check(CloneBucket.structural.jsonValue).equals('structural');
       check(CloneBucket.parameterized.jsonValue).equals('parameterized');
+      check(CloneBucket.gapped.jsonValue).equals('gapped');
 
       check(CloneBucket.fromJson('identical')).equals(CloneBucket.identical);
       check(CloneBucket.fromJson('structural')).equals(CloneBucket.structural);
       check(
         CloneBucket.fromJson('parameterized'),
       ).equals(CloneBucket.parameterized);
+      check(CloneBucket.fromJson('gapped')).equals(CloneBucket.gapped);
+
+      check(CloneBucket.fromString('identical')).equals(CloneBucket.identical);
+      check(
+        CloneBucket.fromString('structural'),
+      ).equals(CloneBucket.structural);
+      check(
+        CloneBucket.fromString('parameterized'),
+      ).equals(CloneBucket.parameterized);
+      check(CloneBucket.fromString('gapped')).equals(CloneBucket.gapped);
 
       check(() => CloneBucket.fromJson('invalid')).throws<ArgumentError>();
+      check(() => CloneBucket.fromString('invalid')).throws<ArgumentError>();
     });
 
-    test('OutputFormat enum fromString and jsonValue', () {
+    test('OutputFormat enum fromJson, fromString, and jsonValue', () {
       check(OutputFormat.markdown.jsonValue).equals('markdown');
       check(OutputFormat.json.jsonValue).equals('json');
       check(OutputFormat.github.jsonValue).equals('github');
       check(OutputFormat.text.jsonValue).equals('text');
+
+      check(OutputFormat.fromJson('markdown')).equals(OutputFormat.markdown);
+      check(OutputFormat.fromJson('json')).equals(OutputFormat.json);
+      check(OutputFormat.fromJson('github')).equals(OutputFormat.github);
+      check(OutputFormat.fromJson('text')).equals(OutputFormat.text);
 
       check(OutputFormat.fromString('markdown')).equals(OutputFormat.markdown);
       check(OutputFormat.fromString('json')).equals(OutputFormat.json);
       check(OutputFormat.fromString('github')).equals(OutputFormat.github);
       check(OutputFormat.fromString('text')).equals(OutputFormat.text);
 
+      check(() => OutputFormat.fromJson('invalid')).throws<ArgumentError>();
       check(() => OutputFormat.fromString('invalid')).throws<ArgumentError>();
     });
 
-    test('CloneInstance JSON roundtrip', () {
-      const instance = CloneInstance(
+    test('CloneInstance value semantics, JSON, and toString', () {
+      const instance1 = CloneInstance(
         filePath: 'lib/src/util.dart',
         startLine: 10,
         endLine: 25,
@@ -58,8 +83,34 @@ void main() {
         snippet: 'void foo() {}',
         inDiff: true,
       );
+      const instance2 = CloneInstance(
+        filePath: 'lib/src/util.dart',
+        startLine: 10,
+        endLine: 25,
+        startColumn: 1,
+        endColumn: 5,
+        tokenCount: 45,
+        lineCount: 16,
+        snippet: 'void foo() {}',
+        inDiff: true,
+      );
+      const instanceDiff = CloneInstance(
+        filePath: 'lib/src/other.dart',
+        startLine: 10,
+        endLine: 25,
+        startColumn: 1,
+        endColumn: 5,
+        tokenCount: 45,
+        lineCount: 16,
+        snippet: 'void foo() {}',
+        inDiff: true,
+      );
 
-      final json = instance.toJson();
+      check(instance1 == instance2).isTrue();
+      check(instance1.hashCode).equals(instance2.hashCode);
+      check(instance1 == instanceDiff).isFalse();
+
+      final json = instance1.toJson();
       check(json['filePath']).equals('lib/src/util.dart');
       check(json['startLine']).equals(10);
       check(json['endLine']).equals(25);
@@ -69,17 +120,12 @@ void main() {
       check(json['inDiff']).equals(true);
 
       final restored = CloneInstance.fromJson(json);
-      check(restored.filePath).equals(instance.filePath);
-      check(restored.startLine).equals(instance.startLine);
-      check(restored.endLine).equals(instance.endLine);
-      check(restored.tokenCount).equals(instance.tokenCount);
-      check(restored.lineCount).equals(instance.lineCount);
-      check(restored.snippet).equals(instance.snippet);
-      check(restored.inDiff).equals(instance.inDiff);
+      check(restored == instance1).isTrue();
+      check(restored.hashCode).equals(instance1.hashCode);
       check(restored.toString()).contains('lib/src/util.dart:10-25');
     });
 
-    test('DuplicateCluster JSON roundtrip', () {
+    test('DuplicateCluster value semantics, immutability, and JSON', () {
       const instance1 = CloneInstance(
         filePath: 'lib/a.dart',
         startLine: 1,
@@ -103,7 +149,19 @@ void main() {
         inDiff: false,
       );
 
-      const cluster = DuplicateCluster(
+      final mutableList = [instance1, instance2];
+      final cluster1 = DuplicateCluster(
+        id: 'cluster-1',
+        instances: mutableList,
+        tokenCount: 40,
+        lineCount: 10,
+        category: CloneCategory.logic,
+        bucket: CloneBucket.identical,
+        estimatedLinesSaved: 10,
+        intersectsDiff: true,
+        isNewlyIntroduced: false,
+      );
+      final cluster2 = DuplicateCluster(
         id: 'cluster-1',
         instances: [instance1, instance2],
         tokenCount: 40,
@@ -114,9 +172,28 @@ void main() {
         intersectsDiff: true,
         isNewlyIntroduced: false,
       );
+      final clusterDiff = DuplicateCluster(
+        id: 'cluster-2',
+        instances: [instance1, instance2],
+        tokenCount: 40,
+        lineCount: 10,
+        category: CloneCategory.logic,
+        bucket: CloneBucket.identical,
+        estimatedLinesSaved: 10,
+        intersectsDiff: true,
+        isNewlyIntroduced: false,
+      );
 
-      check(cluster.instanceCount).equals(2);
-      final json = cluster.toJson();
+      // Value semantics
+      check(cluster1 == cluster2).isTrue();
+      check(cluster1.hashCode).equals(cluster2.hashCode);
+      check(cluster1 == clusterDiff).isFalse();
+
+      // Defensive immutability: mutating source list does not affect cluster
+      check(cluster1.instances.length).equals(2);
+      expect(() => cluster1.instances.add(instance1), throwsUnsupportedError);
+
+      final json = cluster1.toJson();
       check(json['id']).equals('cluster-1');
       check(json['instanceCount']).equals(2);
       check(json['category']).equals('logic');
@@ -125,18 +202,14 @@ void main() {
       check(json['intersectsDiff']).equals(true);
 
       final restored = DuplicateCluster.fromJson(json);
-      check(restored.id).equals(cluster.id);
-      check(restored.instanceCount).equals(cluster.instanceCount);
-      check(restored.category).equals(cluster.category);
-      check(restored.bucket).equals(cluster.bucket);
-      check(restored.estimatedLinesSaved).equals(cluster.estimatedLinesSaved);
-      check(restored.intersectsDiff).equals(cluster.intersectsDiff);
-      check(restored.isNewlyIntroduced).equals(cluster.isNewlyIntroduced);
+      check(restored == cluster1).isTrue();
+      check(restored.hashCode).equals(cluster1.hashCode);
+      expect(() => restored.instances.add(instance1), throwsUnsupportedError);
       check(restored.toString()).contains('Cluster cluster-1');
     });
 
-    test('FileDuplicationMetric JSON roundtrip', () {
-      const metric = FileDuplicationMetric(
+    test('FileDuplicationMetric value semantics, JSON, and toString', () {
+      const metric1 = FileDuplicationMetric(
         filePath: 'lib/foo.dart',
         totalLines: 100,
         duplicateLines: 25,
@@ -145,8 +218,30 @@ void main() {
         duplicationPercentage: 25.0,
         clusterCount: 2,
       );
+      const metric2 = FileDuplicationMetric(
+        filePath: 'lib/foo.dart',
+        totalLines: 100,
+        duplicateLines: 25,
+        totalTokens: 500,
+        duplicateTokens: 120,
+        duplicationPercentage: 25.0,
+        clusterCount: 2,
+      );
+      const metricDiff = FileDuplicationMetric(
+        filePath: 'lib/bar.dart',
+        totalLines: 100,
+        duplicateLines: 25,
+        totalTokens: 500,
+        duplicateTokens: 120,
+        duplicationPercentage: 25.0,
+        clusterCount: 2,
+      );
 
-      final json = metric.toJson();
+      check(metric1 == metric2).isTrue();
+      check(metric1.hashCode).equals(metric2.hashCode);
+      check(metric1 == metricDiff).isFalse();
+
+      final json = metric1.toJson();
       check(json['filePath']).equals('lib/foo.dart');
       check(json['totalLines']).equals(100);
       check(json['duplicateLines']).equals(25);
@@ -154,16 +249,66 @@ void main() {
       check(json['clusterCount']).equals(2);
 
       final restored = FileDuplicationMetric.fromJson(json);
-      check(restored.filePath).equals(metric.filePath);
-      check(restored.totalLines).equals(metric.totalLines);
-      check(restored.duplicateLines).equals(metric.duplicateLines);
+      check(restored == metric1).isTrue();
+      check(restored.hashCode).equals(metric1.hashCode);
       check(
-        restored.duplicationPercentage,
-      ).equals(metric.duplicationPercentage);
-      check(restored.clusterCount).equals(metric.clusterCount);
+        restored.toString(),
+      ).contains('lib/foo.dart: 25/100 duplicate lines');
     });
 
-    test('DedupeReport JSON roundtrip', () {
+    test('DedupeSummary value semantics, JSON, and toString', () {
+      const summary1 = DedupeSummary(
+        filesAnalyzed: 5,
+        totalLines: 500,
+        totalTokens: 2500,
+        duplicateLines: 50,
+        duplicateTokens: 250,
+        duplicationPercentage: 10.0,
+        diffDuplicationPercentage: 12.5,
+        clusterCount: 2,
+        cloneInstanceCount: 4,
+        estimatedLinesSaved: 25,
+        clustersOutsideDiff: 1,
+      );
+      const summary2 = DedupeSummary(
+        filesAnalyzed: 5,
+        totalLines: 500,
+        totalTokens: 2500,
+        duplicateLines: 50,
+        duplicateTokens: 250,
+        duplicationPercentage: 10.0,
+        diffDuplicationPercentage: 12.5,
+        clusterCount: 2,
+        cloneInstanceCount: 4,
+        estimatedLinesSaved: 25,
+        clustersOutsideDiff: 1,
+      );
+      const summaryDiff = DedupeSummary(
+        filesAnalyzed: 6,
+        totalLines: 500,
+        totalTokens: 2500,
+        duplicateLines: 50,
+        duplicateTokens: 250,
+        duplicationPercentage: 10.0,
+        diffDuplicationPercentage: 12.5,
+        clusterCount: 2,
+        cloneInstanceCount: 4,
+        estimatedLinesSaved: 25,
+        clustersOutsideDiff: 1,
+      );
+
+      check(summary1 == summary2).isTrue();
+      check(summary1.hashCode).equals(summary2.hashCode);
+      check(summary1 == summaryDiff).isFalse();
+
+      final json = summary1.toJson();
+      final restored = DedupeSummary.fromJson(json);
+      check(restored == summary1).isTrue();
+      check(restored.hashCode).equals(summary1.hashCode);
+      check(restored.toString()).contains('DedupeSummary(5 files, 2 clusters');
+    });
+
+    test('DedupeReport value semantics, immutability, and JSON', () {
       const summary = DedupeSummary(
         filesAnalyzed: 5,
         totalLines: 500,
@@ -177,25 +322,131 @@ void main() {
         estimatedLinesSaved: 25,
         clustersOutsideDiff: 1,
       );
+      final mutableClusters = <DuplicateCluster>[];
+      final mutableMetrics = <FileDuplicationMetric>[];
 
-      const report = DedupeReport(
+      final report1 = DedupeReport(
+        version: '0.1.0-wip',
+        targetPath: 'packages/test',
+        summary: summary,
+        clusters: mutableClusters,
+        fileMetrics: mutableMetrics,
+      );
+      final report2 = DedupeReport(
         version: '0.1.0-wip',
         targetPath: 'packages/test',
         summary: summary,
         clusters: [],
         fileMetrics: [],
       );
+      final reportDiff = DedupeReport(
+        version: '0.2.0',
+        targetPath: 'packages/test',
+        summary: summary,
+        clusters: [],
+        fileMetrics: [],
+      );
 
-      final json = report.toJson();
+      check(report1 == report2).isTrue();
+      check(report1.hashCode).equals(report2.hashCode);
+      check(report1 == reportDiff).isFalse();
+
+      // Defensive immutability
+      expect(
+        () => report1.clusters.add(
+          DuplicateCluster(
+            id: 'c',
+            instances: [],
+            tokenCount: 1,
+            lineCount: 1,
+            category: CloneCategory.logic,
+            bucket: CloneBucket.identical,
+            estimatedLinesSaved: 1,
+          ),
+        ),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => report1.fileMetrics.add(
+          const FileDuplicationMetric(
+            filePath: 'f',
+            totalLines: 1,
+            duplicateLines: 0,
+            totalTokens: 1,
+            duplicateTokens: 0,
+            duplicationPercentage: 0,
+            clusterCount: 0,
+          ),
+        ),
+        throwsUnsupportedError,
+      );
+
+      final json = report1.toJson();
       check(json['version']).equals('0.1.0-wip');
       check(json['targetPath']).equals('packages/test');
 
       final restored = DedupeReport.fromJson(json);
-      check(restored.version).equals(report.version);
-      check(restored.targetPath).equals(report.targetPath);
-      check(restored.summary.filesAnalyzed).equals(5);
-      check(restored.summary.duplicationPercentage).equals(10.0);
-      check(restored.summary.diffDuplicationPercentage).equals(12.5);
+      check(restored == report1).isTrue();
+      check(restored.hashCode).equals(report1.hashCode);
+      expect(
+        () => restored.clusters.add(
+          DuplicateCluster(
+            id: 'c',
+            instances: [],
+            tokenCount: 1,
+            lineCount: 1,
+            category: CloneCategory.logic,
+            bucket: CloneBucket.identical,
+            estimatedLinesSaved: 1,
+          ),
+        ),
+        throwsUnsupportedError,
+      );
+      check(restored.toString()).contains('DedupeReport(version: 0.1.0-wip');
+    });
+
+    test('DedupeOptions value semantics, defaults, and immutability', () {
+      final mutableTargets = ['lib'];
+      final mutableExcludes = ['**/*.g.dart'];
+      final mutableIncludes = ['**/*.dart'];
+
+      final options1 = DedupeOptions(
+        targetPath: 'packages/test',
+        targets: mutableTargets,
+        excludePatterns: mutableExcludes,
+        includePatterns: mutableIncludes,
+      );
+      final options2 = DedupeOptions(
+        targetPath: 'packages/test',
+        targets: ['lib'],
+        excludePatterns: ['**/*.g.dart'],
+        includePatterns: ['**/*.dart'],
+      );
+      final optionsDiff = DedupeOptions(
+        targetPath: 'packages/other',
+        targets: ['lib'],
+        excludePatterns: ['**/*.g.dart'],
+        includePatterns: ['**/*.dart'],
+      );
+
+      check(options1 == options2).isTrue();
+      check(options1.hashCode).equals(options2.hashCode);
+      check(options1 == optionsDiff).isFalse();
+
+      // Defensive immutability
+      expect(() => options1.targets.add('bin'), throwsUnsupportedError);
+      expect(
+        () => options1.excludePatterns.add('*.tmp'),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => options1.includePatterns.add('*.dart'),
+        throwsUnsupportedError,
+      );
+
+      check(
+        options1.toString(),
+      ).contains('DedupeOptions(targetPath: packages/test');
     });
   });
 }

--- a/packages/dedupe/test/tokenizer_test.dart
+++ b/packages/dedupe/test/tokenizer_test.dart
@@ -1,5 +1,5 @@
 import 'package:checks/checks.dart';
-import 'package:dedupe/dedupe.dart';
+import 'package:dedupe/src/tokenizer.dart';
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
## Summary

Stacked on #83.

Addresses #62:
- **Prune Public Export Surface**: Re-export only public API contracts (`models.dart`, `engine.dart`, `delta_service.dart`, `version.dart`, and formatters) from `lib/dedupe.dart`. Drop internal engine implementation details (`cli.dart`, `tokenizer.dart`, `ast_extractor.dart`, `detector.dart`, `minhash.dart`, `cache.dart`).
- **Value Semantics**: Implement `operator ==` and `hashCode` on all public model classes (`CloneInstance`, `DuplicateCluster`, `FileDuplicationMetric`, `DedupeSummary`, `DedupeReport`, `DedupeOptions`).
- **Defensive Collection Immutability**: Wrap list properties with `List.unmodifiable` across constructors and `fromJson` factories.
- **Class Modifiers & Documentation**: Add `final class` to public models and document all enum values in `CloneBucket`, `CloneCategory`, and `OutputFormat`.
- **Testing**: Add model tests validating equality, hash codes, and immutability assertions.

Fixes #62