### PR TITLE
release(analytica): prepare pkg:analytica for 0.1.1 release

### DIFF
--- a/packages/analytica/CHANGELOG.md
+++ b/packages/analytica/CHANGELOG.md
@@ -1,6 +1,11 @@
-## 0.1.1-wip
+## 0.1.1
 
-- Added `parseCommaSeparated` utility function in `package:analytica/cli.dart`.
+- Add `parseCommaSeparated` utility function in `package:analytica/cli.dart`.
+- Fix `extractNodeName` and `_findFirstIdentifier` in
+  `package:analytica/analyzer.dart` to ignore doc comment symbol references
+  when ASTs lack element resolution (#80).
+- Fix `WildcardPattern` in `package:analytica/analyzer.dart` to correctly
+  support `**/` recursive directory glob matching.
 
 ## 0.1.0
 

--- a/packages/analytica/pubspec.yaml
+++ b/packages/analytica/pubspec.yaml
@@ -1,7 +1,14 @@
 name: analytica
 description: Core utilities, SDK discovery, Git integration, and CI reporting for Dart analysis tools.
-version: 0.1.1-wip
+version: 0.1.1
 repository: https://github.com/kevmoo/analytica.dart/tree/main/packages/analytica
+issue_tracker: https://github.com/kevmoo/analytica.dart/issues
+
+topics:
+  - static-analysis
+  - code-quality
+  - cli
+
 
 resolution: workspace
 


### PR DESCRIPTION
Prepare package:analytica for 0.1.1 release on pub.dev.

- Bump version to 0.1.1.
- Add issue_tracker and topics metadata to pubspec.yaml.
- Document parseCommaSeparated, AST doc comment symbol shadowing fix (#80), and wildcard glob matcher fix in CHANGELOG.md.
