### PR TITLE
feat: add --exclude to skip files matching glob patterns

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,14 @@ inputs:
     description: 'Output format: github (summary table + annotations), text, or json.'
     required: false
     default: 'github'
+  exclude:
+    description: >-
+      Comma-separated glob patterns to skip, e.g.
+      "**.g.dart,**.freezed.dart". Generated code exceeds any sensible
+      threshold and cannot be simplified by hand, so reporting it is noise.
+      Empty by default, so nothing is skipped unless you opt in.
+    required: false
+    default: ''
   max-comment-rows:
     description: >-
       Maximum table rows in the sticky PR comment, most significant first
@@ -74,6 +82,7 @@ runs:
         INPUT_FORMAT: ${{ inputs.format }}
         INPUT_TARGETS: ${{ inputs.targets }}
         INPUT_MAX_COMMENT_ROWS: ${{ inputs.max-comment-rows }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
         DIFF_ARG: ${{ steps.prepare.outputs.diff_arg }}
         ACTION_PATH: ${{ github.action_path }}
         GH_TOKEN: ${{ github.token }}
@@ -95,6 +104,14 @@ runs:
         # report for the PR comment while the step summary keeps every row.
         # Absolute path so it is independent of the scanner's cwd.
         # An array keeps the path intact even if RUNNER_TEMP contains spaces.
+        # Quoted array expansion: no word splitting, and no globbing -- the
+        # patterns are globs for the scanner, not for bash to expand against
+        # the action directory.
+        exclude_args=()
+        if [ -n "$INPUT_EXCLUDE" ]; then
+          exclude_args=(--exclude="$INPUT_EXCLUDE")
+        fi
+
         comment_args=()
         comment_file=""
         if [ "$INPUT_FORMAT" = "github" ] && [ "${INPUT_MAX_COMMENT_ROWS:-0}" -gt 0 ]; then
@@ -119,7 +136,7 @@ runs:
         (cd "$ACTION_PATH" && dart pub get >/dev/null)
         cd "$workspace"
 
-        # Execute the scanner CLI tool and capture exit code
+        # Execute the scanner CLI tool and capture exit code.
         set +e
         dart run "$ACTION_PATH/packages/cognitive_complexity/bin/cognitive_complexity.dart" \
           --threshold="$INPUT_THRESHOLD" \
@@ -127,6 +144,7 @@ runs:
           --format="$INPUT_FORMAT" \
           $DIFF_ARG \
           $fail_inc_arg \
+          "${exclude_args[@]}" \
           "${comment_args[@]}" \
           $targets
         exit_code=$?

--- a/packages/cognitive_complexity/CHANGELOG.md
+++ b/packages/cognitive_complexity/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.2.5-wip
 
+- Add `--exclude` CLI option and matching `exclude` GitHub Action input:
+  comma-separated or repeated glob patterns to skip files (empty by default).
+  Useful for generated sources such as `**.g.dart` and `**.freezed.dart`
+  (#90).
 - Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in `README.md`.
 - Update GitHub Action documentation in `README.md` to reference modular
   subdirectory path (`packages/cognitive_complexity`) and add rendered Action

--- a/packages/cognitive_complexity/README.md
+++ b/packages/cognitive_complexity/README.md
@@ -54,6 +54,7 @@ Options:
     --comment-output=<path>       With --format=github, also write a standalone report to this path, ordered by significance and capped by --max-comment-rows. Intended for posting as a PR comment while the step summary keeps the full table.
     --max-comment-rows=<count>    Maximum table rows in --comment-output (0 = unlimited). GitHub rejects comment bodies over 65536 characters.
                                   (defaults to "0")
+    --exclude=<glob>              Glob patterns to skip, comma-separated or repeated. Useful for generated sources, e.g. --exclude="**.g.dart,**.freezed.dart".
 ```
 <!-- CLI_README_END cognitive_complexity -->
 
@@ -153,6 +154,7 @@ jobs:
 | `diff-base` | _Auto_ | Git ref to compare against (e.g. `origin/main`). Auto-detects PR base. |
 | `fail-on-increase` | `false` | When `true`, blocks PR merge on complexity increases exceeding `fail-threshold`. |
 | `format` | `github` | Output format: `github` (annotations + step summary), `text`, or `json`. |
+| `exclude` | _empty_ | Comma-separated glob patterns to skip (e.g. `**.g.dart,**.freezed.dart`). |
 | `max-comment-rows` | `0` | Maximum table rows in the sticky PR comment (0 = unlimited). |
 <!-- mdformat on -->
 

--- a/packages/cognitive_complexity/action.yml
+++ b/packages/cognitive_complexity/action.yml
@@ -31,6 +31,14 @@ inputs:
     description: 'Output format: github (summary table + annotations), text, or json.'
     required: false
     default: 'github'
+  exclude:
+    description: >-
+      Comma-separated glob patterns to skip, e.g.
+      "**.g.dart,**.freezed.dart". Generated code exceeds any sensible
+      threshold and cannot be simplified by hand, so reporting it is noise.
+      Empty by default, so nothing is skipped unless you opt in.
+    required: false
+    default: ''
   max-comment-rows:
     description: >-
       Maximum table rows in the sticky PR comment, most significant first
@@ -74,6 +82,7 @@ runs:
         INPUT_FORMAT: ${{ inputs.format }}
         INPUT_TARGETS: ${{ inputs.targets }}
         INPUT_MAX_COMMENT_ROWS: ${{ inputs.max-comment-rows }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
         DIFF_ARG: ${{ steps.prepare.outputs.diff_arg }}
         ACTION_PATH: ${{ github.action_path }}
         GH_TOKEN: ${{ github.token }}
@@ -95,6 +104,14 @@ runs:
         # report for the PR comment while the step summary keeps every row.
         # Absolute path so it is independent of the scanner's cwd.
         # An array keeps the path intact even if RUNNER_TEMP contains spaces.
+        # Quoted array expansion: no word splitting, and no globbing -- the
+        # patterns are globs for the scanner, not for bash to expand against
+        # the action directory.
+        exclude_args=()
+        if [ -n "$INPUT_EXCLUDE" ]; then
+          exclude_args=(--exclude="$INPUT_EXCLUDE")
+        fi
+
         comment_args=()
         comment_file=""
         if [ "$INPUT_FORMAT" = "github" ] && [ "${INPUT_MAX_COMMENT_ROWS:-0}" -gt 0 ]; then
@@ -122,6 +139,7 @@ runs:
           --format="$INPUT_FORMAT" \
           $DIFF_ARG \
           $fail_inc_arg \
+          "${exclude_args[@]}" \
           "${comment_args[@]}" \
           $targets
         exit_code=$?

--- a/packages/cognitive_complexity/doc/cli.md
+++ b/packages/cognitive_complexity/doc/cli.md
@@ -52,6 +52,7 @@ cognitive_complexity [options] [targets]
 | `-d, --git-diff <git-ref>`     | `String` | _None_  | Compares current workspace declarations against `<git-ref>`, evaluating complexity deltas (Δ). |
 | `--fail-on-increase`           | `flag`   | `false` | When using `--git-diff`, fails if any modified function increases in complexity.               |
 | `--format <type>`              | `enum`   | `text`  | Output format: `text` (terminal), `json` (machine-readable), or `github` (GHA annotations).    |
+| `--exclude <glob>`             | `glob`   | _empty_ | Skip files matching glob patterns. Comma-separated or repeated. Useful for generated sources.  |
 | `--sdk-path <path>`            | `String` | _Auto_  | Overrides automated Dart/Flutter SDK location discovery.                                       |
 
 <!-- mdformat on -->

--- a/packages/cognitive_complexity/lib/src/complexity/cli.dart
+++ b/packages/cognitive_complexity/lib/src/complexity/cli.dart
@@ -80,6 +80,13 @@ Future<int> runCli(
       help:
           'Maximum table rows in --comment-output (0 = unlimited). GitHub '
           'rejects comment bodies over 65536 characters.',
+    )
+    ..addMultiOption(
+      'exclude',
+      valueHelp: 'glob',
+      help:
+          'Glob patterns to skip, comma-separated or repeated. Useful for '
+          'generated sources, e.g. --exclude="**.g.dart,**.freezed.dart".',
     );
 
   try {
@@ -106,6 +113,7 @@ Future<int> runCli(
     final format = argResults['format'] as String;
     final gitDiffBase = argResults['git-diff'] as String?;
     final failOnIncrease = argResults['fail-on-increase'] as bool;
+    final excludeGlobs = argResults['exclude'] as List<String>;
     final commentOutput = argResults['comment-output'] as String?;
     final maxCommentRows = parseNonNegativeInt(
       argResults['max-comment-rows'] as String,
@@ -117,6 +125,7 @@ Future<int> runCli(
       commentOutput: commentOutput,
       format: format,
       gitDiffBase: gitDiffBase,
+      excludeGlobs: excludeGlobs,
       err: stderrSink,
     );
 
@@ -132,6 +141,7 @@ Future<int> runCli(
         failOnIncrease: failOnIncrease,
         commentOutput: commentOutput,
         maxCommentRows: maxCommentRows,
+        excludeGlobs: excludeGlobs,
         out: stdoutSink,
         err: stderrSink,
       );
@@ -164,12 +174,19 @@ void _warnIgnoredFlags({
   required String? commentOutput,
   required String format,
   required String? gitDiffBase,
+  required List<String> excludeGlobs,
   required StringSink err,
 }) {
   if (failOnIncrease && gitDiffBase == null) {
     err.writeln(
       'Warning: --fail-on-increase has no effect unless --git-diff is '
       'specified.',
+    );
+  }
+
+  if (excludeGlobs.isNotEmpty && gitDiffBase == null) {
+    err.writeln(
+      'Warning: --exclude has no effect unless --git-diff is specified.',
     );
   }
 
@@ -191,11 +208,13 @@ Future<int> _handleDiffMode({
   required StringSink err,
   String? commentOutput,
   int maxCommentRows = 0,
+  List<String> excludeGlobs = const [],
 }) async {
   final deltaAnalyzer = DeltaAnalyzer();
   final summary = await deltaAnalyzer.computeDeltas(
     gitDiffBase,
     targetPaths: targets,
+    excludeGlobs: excludeGlobs,
   );
 
   if (format == 'json') {

--- a/packages/cognitive_complexity/lib/src/complexity/delta_analyzer.dart
+++ b/packages/cognitive_complexity/lib/src/complexity/delta_analyzer.dart
@@ -1,3 +1,4 @@
+import 'package:glob/glob.dart';
 import 'package:pool/pool.dart';
 import 'complexity_analyzer.dart';
 import 'git_diff_service.dart';
@@ -145,6 +146,26 @@ class DeltaSummary {
   }
 }
 
+/// Compiles [patterns] into globs, ignoring blank entries.
+///
+/// Blank entries are dropped rather than rejected: they are what a trailing
+/// comma or an empty CI variable produces, and `Glob('')` throws. A genuinely
+/// malformed pattern still throws, but as a [FormatException] naming the
+/// pattern rather than a scanner error pointing at an offset.
+List<Glob> compileExcludeGlobs(Iterable<String> patterns) {
+  final globs = <Glob>[];
+  for (final raw in patterns) {
+    final pattern = raw.trim();
+    if (pattern.isEmpty) continue;
+    try {
+      globs.add(Glob(pattern));
+    } on FormatException catch (e) {
+      throw FormatException('Invalid exclude pattern "$pattern": ${e.message}');
+    }
+  }
+  return globs;
+}
+
 /// Evaluates git diffs to calculate cognitive complexity score deltas.
 class DeltaAnalyzer {
   final ComplexityAnalyzer _analyzer = ComplexityAnalyzer();
@@ -155,15 +176,27 @@ class DeltaAnalyzer {
           gitService ?? GitDiffService(workingDirectory: workingDirectory);
 
   /// Computes complexity deltas between [baseRef] and current working tree.
+  ///
+  /// Paths matching any glob in [excludeGlobs] are skipped. Generated sources
+  /// are the motivating case: they routinely exceed any sensible threshold and
+  /// cannot be simplified by hand, so reporting them is noise.
   Future<DeltaSummary> computeDeltas(
     String baseRef, {
     List<String> targetPaths = const [],
+    List<String> excludeGlobs = const [],
   }) async {
     final mergeBase = await _gitService.getMergeBase(baseRef);
-    final modFiles = await _gitService.getModifiedDartFiles(
+    var modFiles = await _gitService.getModifiedDartFiles(
       mergeBase,
       targetPaths: targetPaths,
     );
+
+    final globs = compileExcludeGlobs(excludeGlobs);
+    if (globs.isNotEmpty) {
+      modFiles = modFiles
+          .where((f) => !globs.any((g) => g.matches(f)))
+          .toList();
+    }
     final allDeltas = <ComplexityDelta>[];
 
     final pool = Pool(8);

--- a/packages/cognitive_complexity/pubspec.yaml
+++ b/packages/cognitive_complexity/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   analytica: ^0.1.0
   analyzer: '>=12.0.0 <15.0.0'
   args: ^2.7.0
+  glob: ^2.1.3
   io: ^1.0.5
   path: ^1.9.1
   pool: ^1.5.0

--- a/packages/cognitive_complexity/test/exclude_test.dart
+++ b/packages/cognitive_complexity/test/exclude_test.dart
@@ -56,14 +56,24 @@ void main() {
 
     /// Basenames of the files the scanner reported deltas for.
     Future<Set<String>> scannedFiles(List<String> extraArgs) async {
-      final res = await Process.run(Platform.resolvedExecutable, [
-        binPath,
-        '--git-diff=HEAD~1',
-        '--fail-threshold=15',
-        '--format=json',
-        ...extraArgs,
-        'lib',
-      ], workingDirectory: repoPath);
+      final res = await Process.run(
+        Platform.resolvedExecutable,
+        [
+          binPath,
+          '--git-diff=HEAD~1',
+          '--fail-threshold=15',
+          '--format=json',
+          ...extraArgs,
+          'lib',
+        ],
+        workingDirectory: repoPath,
+        environment: {
+          // runCli re-aligns Directory.current to GITHUB_WORKSPACE when set.
+          // On GitHub Actions that points at the (shallow) checkout, yanking
+          // the scanner out of the fixture repo -- pin it to the fixture.
+          'GITHUB_WORKSPACE': repoPath,
+        },
+      );
       final out = (res.stdout as String).trim();
       if (out.isEmpty) return {};
       return RegExp(
@@ -141,11 +151,12 @@ void main() {
     });
 
     test('warns when used without --git-diff', () async {
-      final res = await Process.run(Platform.resolvedExecutable, [
-        binPath,
-        '--exclude=**.g.dart',
-        'lib',
-      ], workingDirectory: repoPath);
+      final res = await Process.run(
+        Platform.resolvedExecutable,
+        [binPath, '--exclude=**.g.dart', 'lib'],
+        workingDirectory: repoPath,
+        environment: {'GITHUB_WORKSPACE': repoPath},
+      );
       check(
         res.stderr as String,
       ).contains('--exclude has no effect unless --git-diff');

--- a/packages/cognitive_complexity/test/exclude_test.dart
+++ b/packages/cognitive_complexity/test/exclude_test.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+import 'package:checks/checks.dart';
+import 'package:cognitive_complexity/src/complexity/delta_analyzer.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+/// A declaration complex enough to be reported at any sensible threshold.
+String get _complex {
+  final buf = StringBuffer('int stub(int x) {\n');
+  for (var i = 0; i < 4; i++) {
+    final pad = '  ' * (i + 1);
+    buf
+      ..writeln('${pad}if (x > $i) {')
+      ..writeln('$pad  for (var j = 0; j < x; j++) {')
+      ..writeln('$pad    if (j % 2 == 0) x++; else x--;')
+      ..writeln('$pad  }');
+  }
+  for (var i = 3; i >= 0; i--) {
+    buf.writeln('${'  ' * (i + 1)}}');
+  }
+  return (buf
+        ..writeln('  return x;')
+        ..writeln('}'))
+      .toString();
+}
+
+void main() {
+  group('compileExcludeGlobs', () {
+    test('drops blank entries rather than throwing', () {
+      // A trailing comma or an unset CI variable produces these, and
+      // Glob('') throws.
+      check(compileExcludeGlobs(['', '  ', '**.g.dart'])).length.equals(1);
+      check(compileExcludeGlobs(const [])).isEmpty();
+    });
+
+    test('reports the offending pattern on malformed input', () {
+      check(
+          () => compileExcludeGlobs(['[unclosed']),
+        ).throws<FormatException>().has((e) => e.message, 'message')
+        ..contains('[unclosed')
+        ..contains('Invalid exclude pattern');
+    });
+  });
+
+  group('--exclude', () {
+    late String repoPath;
+    late String binPath;
+
+    Future<void> runGit(List<String> args) async {
+      final res = await Process.run('git', args, workingDirectory: repoPath);
+      if (res.exitCode != 0) {
+        fail('git ${args.join(" ")} failed:\n${res.stderr}');
+      }
+    }
+
+    /// Basenames of the files the scanner reported deltas for.
+    Future<Set<String>> scannedFiles(List<String> extraArgs) async {
+      final res = await Process.run(Platform.resolvedExecutable, [
+        binPath,
+        '--git-diff=HEAD~1',
+        '--fail-threshold=15',
+        '--format=json',
+        ...extraArgs,
+        'lib',
+      ], workingDirectory: repoPath);
+      final out = (res.stdout as String).trim();
+      if (out.isEmpty) return {};
+      return RegExp(
+        r'"file":"([^"]+)"',
+      ).allMatches(out).map((m) => p.basename(m.group(1)!)).toSet();
+    }
+
+    setUp(() async {
+      binPath = File('bin/cognitive_complexity.dart').existsSync()
+          ? p.normalize(p.absolute('bin/cognitive_complexity.dart'))
+          : p.normalize(
+              p.absolute(
+                'packages/cognitive_complexity/bin/cognitive_complexity.dart',
+              ),
+            );
+      repoPath = p.join(d.sandbox, 'repo');
+      await Directory(p.join(repoPath, 'lib')).create(recursive: true);
+
+      await runGit(['init', '-b', 'main']);
+      await runGit(['config', 'user.name', 'Tester']);
+      await runGit(['config', 'user.email', 'test@example.com']);
+      await runGit(['config', 'commit.gpgsign', 'false']);
+
+      const names = ['handwritten.dart', 'model.g.dart', 'model.freezed.dart'];
+      for (final n in names) {
+        await File(
+          p.join(repoPath, 'lib', n),
+        ).writeAsString('int stub() => 0;');
+      }
+      await runGit(['add', '.']);
+      await runGit(['commit', '-m', 'base']);
+
+      for (final n in names) {
+        await File(p.join(repoPath, 'lib', n)).writeAsString(_complex);
+      }
+      await runGit(['add', '.']);
+      await runGit(['commit', '-m', 'head']);
+    });
+
+    test('scans every changed file when no pattern is given', () async {
+      // Default is empty: opting in is required, nothing is skipped silently.
+      check(await scannedFiles([])).unorderedEquals({
+        'handwritten.dart',
+        'model.g.dart',
+        'model.freezed.dart',
+      });
+    });
+
+    test('skips files matching a single pattern', () async {
+      check(
+        await scannedFiles(['--exclude=**.g.dart']),
+      ).unorderedEquals({'handwritten.dart', 'model.freezed.dart'});
+    });
+
+    test('accepts a comma-separated list', () async {
+      check(
+        await scannedFiles(['--exclude=**.g.dart,**.freezed.dart']),
+      ).unorderedEquals({'handwritten.dart'});
+    });
+
+    test('accepts the flag repeated', () async {
+      check(
+        await scannedFiles([
+          '--exclude=**.g.dart',
+          '--exclude=**.freezed.dart',
+        ]),
+      ).unorderedEquals({'handwritten.dart'});
+    });
+
+    test('tolerates a trailing comma', () async {
+      // Produces a blank entry, which Glob('') would reject.
+      check(
+        await scannedFiles(['--exclude=**.g.dart,']),
+      ).unorderedEquals({'handwritten.dart', 'model.freezed.dart'});
+    });
+
+    test('warns when used without --git-diff', () async {
+      final res = await Process.run(Platform.resolvedExecutable, [
+        binPath,
+        '--exclude=**.g.dart',
+        'lib',
+      ], workingDirectory: repoPath);
+      check(
+        res.stderr as String,
+      ).contains('--exclude has no effect unless --git-diff');
+    });
+  });
+}


### PR DESCRIPTION
Follow-up to #48 and #49 — thanks for merging those.

Generated Dart routinely exceeds any sensible cognitive complexity threshold
and cannot be simplified by hand, so reporting it is noise. It is also a large
share of a typical Flutter codebase. 

### What this adds

`--exclude`, accepting comma-separated or repeated globs, plus a matching
`exclude` action input.

**Empty by default**, so nothing is skipped unless a caller opts in and
existing behaviour is unchanged. I deliberately did not default it to
`**.g.dart,**.freezed.dart` — that would be a behaviour change riding along
in a feature PR. 


### Dependency

Adds `glob: ^2.1.3`. Flagging it explicitly since a new dep is a review point —
happy to hand-roll a matcher instead if you would rather not take it.

