### PR TITLE
release(undead): prepare pkg:undead for 0.1.1 release

### DIFF
--- a/packages/undead/CHANGELOG.md
+++ b/packages/undead/CHANGELOG.md
@@ -1,7 +1,11 @@
-## 0.1.1-wip
+## 0.1.1
 
 - Support `--suggest-private` flag to detect unexported top-level declarations
-  that can be made library-private.
+  that can be made library-private (#45).
+- Add `suggestPrivate` option to `UndeadOptions`,
+  `UndeadReport.privateCandidatesFound`,
+  `UndeadClassification.privateCandidate`, and `SuggestedAction.makePrivate`.
+- Require `package:analytica ^0.1.1`.
 
 ## 0.1.0
 

--- a/packages/undead/lib/src/cli.dart
+++ b/packages/undead/lib/src/cli.dart
@@ -9,7 +9,7 @@ import 'formatters/markdown_formatter.dart';
 import 'models.dart';
 import 'reachability_engine.dart';
 
-const String undeadVersion = '0.1.1-wip';
+const String undeadVersion = '0.1.1';
 
 /// Configures and parses CLI arguments for `pkg:undead`.
 ArgParser buildArgParser() {

--- a/packages/undead/pubspec.yaml
+++ b/packages/undead/pubspec.yaml
@@ -1,7 +1,14 @@
 name: undead
 description: Reachability and dead/unused declaration analysis for Dart and Flutter packages.
-version: 0.1.1-wip
+version: 0.1.1
 repository: https://github.com/kevmoo/analytica.dart/tree/main/packages/undead
+issue_tracker: https://github.com/kevmoo/analytica.dart/issues
+
+topics:
+  - static-analysis
+  - code-quality
+  - linter
+  - cli
 
 resolution: workspace
 
@@ -12,7 +19,7 @@ environment:
   sdk: '^3.12.0'
 
 dependencies:
-  analytica: ^0.1.0
+  analytica: ^0.1.1
   analyzer: '>=12.0.0 <15.0.0'
   args: ^2.7.0
   io: ^1.0.5

--- a/packages/undead/test/cli_test.dart
+++ b/packages/undead/test/cli_test.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 import 'dart:io';
+
 import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
-import 'package:undead/src/cli.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
+import 'package:undead/src/cli.dart';
 
 d.DirectoryDescriptor packageConfig(String pkgName) {
   return d.dir('.dart_tool', [

--- a/packages/undead/test/cli_test.dart
+++ b/packages/undead/test/cli_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+import 'package:undead/src/cli.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
@@ -57,7 +58,7 @@ void main() {
       final stdout = await proc.stdoutStream().join('\n');
       await proc.shouldExit(0);
 
-      check(stdout).contains('undead version: 0.1.1-wip');
+      check(stdout).contains('undead version: $undeadVersion');
     });
 
     test('--mode accepts closed-app', () async {


### PR DESCRIPTION
Prepare package:undead for 0.1.1 release on pub.dev.

- Bump version to 0.1.1.
- Require package:analytica ^0.1.1.
- Add issue_tracker and topics metadata to pubspec.yaml.
- Synchronize undeadVersion constant in cli.dart.
- Document --suggest-private CLI flag and programmatic API additions in CHANGELOG.md.
