### PR TITLE
release(dedupe): prepare pkg:dedupe for 0.1.0 initial release

### DIFF
--- a/packages/dedupe/CHANGELOG.md
+++ b/packages/dedupe/CHANGELOG.md
@@ -1,10 +1,14 @@
-## 0.1.0-wip
+## 0.1.0
 
 - Initial release of `pkg:dedupe`:
   - Token-level and structural clone detection across Dart and Flutter codebases.
-  - Polynomial rolling hash $k$-gram indexing and maximal clone extension.
+  - Polynomial rolling hash k-gram indexing and maximal clone extension.
   - Granular normalization filters (`--ignore-comments`, `--ignore-literals`, `--ignore-identifiers`).
+  - Persistent content-hashed disk caching (`--cache`, `--cache-dir`, `--clear-cache`).
+  - Exact line-union overlapping clone cluster deduplication and net lines saved analysis.
+  - Linear adjacent chaining and MinHash token verification for large-scale clone clusters (>50 instances).
   - Git diff integration and PR delta scanning (`--git-diff`, `--only-changed`).
   - Multi-format report generation: Markdown, JSON, GitHub Actions annotations/summaries, and terminal text.
   - Per-file duplication metrics, cluster classification, and estimated lines saved analysis.
+  - Value-semantic, immutable report models (`CloneInstance`, `DuplicateCluster`, `DedupeReport`) with full JSON serialization.
   - CLI binary entrypoint (`bin/dedupe.dart`).

--- a/packages/dedupe/README.md
+++ b/packages/dedupe/README.md
@@ -1,37 +1,40 @@
-# Dedupe
+High-performance structural code duplication and clone detection engine and CLI
+tool for Dart and Flutter.
 
-High-performance structural code duplication and clone detection engine and CLI tool for Dart and Flutter.
+## Features
 
----
+- **Token-Level & Structural Clone Detection**: Detects exact duplicates,
+  structural clones (normalized string & numeric literals), and parameterized
+  clones (renamed identifiers).
+- **Polynomial Rolling Hash Engine**: Fast k-gram indexing with maximal
+  bidirectional expansion for sub-second analysis across large monorepos.
+- **Git Diff & PR Delta Scanning**: Analyzes pull request changes against a Git
+  base ref (`--git-diff=origin/main`) and isolates newly introduced duplication
+  (`--only-changed`).
+- **Rich Multi-Format Reporting**: Outputs human-readable Markdown with
+  clickable file line links, machine-readable JSON, terminal text summaries, and
+  GitHub Actions step annotations.
+- **Deduplication Metrics**: Computes per-file and package-level duplication
+  percentages, duplicate cluster inventories, and estimated lines saved.
 
-## 🚀 Features
-
-- **Token-Level & Structural Clone Detection**: Detects exact duplicates, structural clones (normalized string & numeric literals), and parameterized clones (renamed identifiers).
-- **Polynomial Rolling Hash Engine**: Fast $k$-gram indexing with maximal bidirectional expansion for sub-second analysis across large monorepos.
-- **Git Diff & PR Delta Scanning**: Analyzes pull request changes against a Git base ref (`--git-diff=origin/main`) and isolates newly introduced duplication (`--only-changed`).
-- **Rich Multi-Format Reporting**: Outputs human-readable Markdown with clickable file line links, machine-readable JSON, terminal text summaries, and GitHub Actions step annotations.
-- **Deduplication Metrics**: Computes per-file and package-level duplication percentages, duplicate cluster inventories, and estimated lines saved.
-
----
-
-## 📦 Installation & Usage
+## Usage
 
 ### CLI Execution
 
-Run directly via `dart run`:
+Run directly using `dart run dedupe@`:
 
 ```bash
 # Full package/repository scan
-dart run dedupe
+dart run dedupe@
 
 # Scan specific directories or files
-dart run dedupe lib/src packages/core
+dart run dedupe@ lib/src packages/core
 
 # JSON output for automated pipelines / AI agents
-dart run dedupe --format=json
+dart run dedupe@ --format=json
 
 # Write machine-readable JSON report to file
-dart run dedupe --json-output=report.json
+dart run dedupe@ --json-output=report.json
 ```
 
 ### Git Diff / PR Regression Gate
@@ -40,18 +43,16 @@ Scan only modified files and evaluate delta duplication:
 
 ```bash
 # Audit PR delta against base ref
-dart run dedupe --git-diff=origin/main
+dart run dedupe@ --git-diff=origin/main
 
 # Only report clusters intersecting changed lines
-dart run dedupe --git-diff=origin/main --only-changed
+dart run dedupe@ --git-diff=origin/main --only-changed
 
 # Fail CI if duplication exceeds 5%
-dart run dedupe --git-diff=origin/main --fail-threshold=5
+dart run dedupe@ --git-diff=origin/main --fail-threshold=5
 ```
 
----
-
-## ⚙️ CLI Options Reference
+## CLI options
 
 <!-- mdformat off(prevent table wrapping) -->
 
@@ -82,9 +83,7 @@ dart run dedupe --git-diff=origin/main --fail-threshold=5
 
 <!-- mdformat on -->
 
----
-
-## 🧩 Programmatic API
+## Programmatic API
 
 ```dart
 import 'package:dedupe/dedupe.dart';

--- a/packages/dedupe/lib/src/version.dart
+++ b/packages/dedupe/lib/src/version.dart
@@ -1,2 +1,2 @@
 /// The current version of `pkg:dedupe`.
-const String dedupeVersion = '0.1.0-wip';
+const String dedupeVersion = '0.1.0';

--- a/packages/dedupe/pubspec.yaml
+++ b/packages/dedupe/pubspec.yaml
@@ -1,6 +1,8 @@
 name: dedupe
-description: High-performance code duplication and clone detection engine and CLI tool for Dart and Flutter.
-version: 0.1.0-wip
+description: >-
+  High-performance code duplication and clone detection engine and CLI tool
+  for Dart and Flutter.
+version: 0.1.0
 repository: https://github.com/kevmoo/analytica.dart/tree/main/packages/dedupe
 issue_tracker: https://github.com/kevmoo/analytica.dart/issues
 

--- a/packages/dedupe/test/cli_test.dart
+++ b/packages/dedupe/test/cli_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:checks/checks.dart';
+import 'package:dedupe/dedupe.dart';
 import 'package:dedupe/src/cli.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -45,7 +46,7 @@ void main() {
       final stdout = await proc.stdoutStream().join('\n');
       await proc.shouldExit(0);
 
-      check(stdout).contains('dedupe version: 0.1.0-wip');
+      check(stdout).contains('dedupe version: $dedupeVersion');
     });
 
     test('invalid flag exits with code 64 (usage)', () async {


### PR DESCRIPTION
Prepare package:dedupe for 0.1.0 initial release on pub.dev.

- Set version to 0.1.0 in pubspec.yaml.
- Synchronize dedupeVersion constant in lib/src/version.dart.
- Finalize initial 0.1.0 changelog with clone detection engine features, persistent disk caching, and reporting models.
- Verify static analysis and test suite.
