### PR TITLE
feat(repo): deprecate root action and reorganize monorepo readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kevin Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,78 +1,98 @@
 # Analytica
 
-Monorepo workspace for Dart static analysis, Cognitive Complexity metrics, data-flow refactoring, dead code detection, and structural duplicate code detection.
+[![CI](https://github.com/kevmoo/analytica.dart/actions/workflows/ci.yml/badge.svg)](https://github.com/kevmoo/analytica.dart/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+
+A unified suite of high-performance static analysis engines, CLI tools, GitHub Actions, and AI Agent Skills for Dart and Flutter repositories.
 
 ---
 
-## 🚀 GitHub Action: Dart Cognitive Complexity Audit
-
-Automated Cognitive Complexity calculator and Git diff regression scanner for Dart and Flutter repositories.
-
-### Quick Start Workflow
-
-Add `.github/workflows/complexity.yml` to your repository:
-
-```yaml
-name: Cognitive Complexity Audit
-
-on:
-  pull_request:
-    branches: [main]
-
-jobs:
-  audit:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # Required for sticky PR comment summaries
-      contents: read
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0 # Full history required for diff-base comparison
-
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@v1
-
-      - name: Run Complexity Scanner
-        uses: kevmoo/analytica.dart@main
-        with:
-          diff-base: origin/${{ github.base_ref }}
-          fail-threshold: 15
-          fail-on-increase: true
-```
-
-### Action Inputs Reference
+## 📦 Published Packages
 
 <!-- mdformat off(prevent table wrapping) -->
-
-| Input | Default | Description |
+| Package | Pub | Description |
 | :--- | :---: | :--- |
-| `targets` | `lib` | Space-separated list of directories or files to scan. |
-| `threshold` | `0` | Minimum score required to include a declaration in summary tables. |
-| `fail-threshold` | `15` | Maximum complexity ceiling allowed before failing the build. |
-| `diff-base` | _Auto_ | Git ref to compare against (e.g. `origin/main`). Auto-detects PR base. |
-| `fail-on-increase` | `false` | When `true`, blocks PR merge on complexity increases exceeding `fail-threshold`. |
-| `format` | `github` | Output format: `github` (annotations + step summary), `text`, or `json`. |
-
+| [`cognitive_complexity`](packages/cognitive_complexity/) | [![pub package](https://img.shields.io/pub/v/cognitive_complexity.svg)](https://pub.dev/packages/cognitive_complexity) | Algorithmic Cognitive Complexity calculation and AST data-flow analysis library and CLI. |
+| [`dedupe`](packages/dedupe/) | [![pub package](https://img.shields.io/pub/v/dedupe.svg)](https://pub.dev/packages/dedupe) | High-performance token, structural, and parameterized code clone detection engine and CLI. |
+| [`undead`](packages/undead/) | [![pub package](https://img.shields.io/pub/v/undead.svg)](https://pub.dev/packages/undead) | Whole-program reachability and dead declaration analysis for packages and closed apps. |
+| [`lower_bound`](packages/lower_bound/) | [![pub package](https://img.shields.io/pub/v/lower_bound.svg)](https://pub.dev/packages/lower_bound) | Automated Dart dependency lower-bound validator and synthetic runtime isolation engine. |
+| [`analytica`](packages/analytica/) | [![pub package](https://img.shields.io/pub/v/analytica.svg)](https://pub.dev/packages/analytica) | Shared SDK discovery, AST analyzer extensions, Git diff utilities, and CI reporting. |
 <!-- mdformat on -->
 
 ---
 
-## 📦 Workspace Packages
+## 🚀 GitHub Actions
 
-* [`cognitive_complexity`](packages/cognitive_complexity/): Algorithmic Cognitive Complexity scoring engine, CLI tool, and data-flow analyzer.
-* [`dedupe`](packages/dedupe/): High-performance code duplication and clone detection engine and CLI tool.
-* [`undead`](packages/undead/): Whole-program dead declaration and reachability analysis engine and CLI tool.
-* [`analytica`](packages/analytica/): Shared CLI utilities, SDK discovery, AST analyzer extensions, and Git diff utilities.
+Modular composite actions to automate code quality, complexity ceilings, and dependency checks in your CI workflows:
+
+### 1. Cognitive Complexity Audit
+
+Calculates Cognitive Complexity scores on pull requests and prevents complexity regressions:
+
+```yaml
+- name: Run Complexity Scanner
+  uses: kevmoo/analytica.dart/packages/cognitive_complexity@main
+  with:
+    diff-base: origin/${{ github.base_ref }}
+    fail-threshold: 15
+    fail-on-increase: true
+```
+
+👉 [Cognitive Complexity Action Documentation & Inputs Reference](packages/cognitive_complexity/action.yml)
+
+### 2. Dependency Lower-Bound Validator
+
+Validates that declared dependency lower bounds resolve and build against synthetic minimums:
+
+```yaml
+- name: Validate Dependency Lower Bounds
+  uses: kevmoo/analytica.dart/packages/lower_bound@main
+  with:
+    fail-on-error: true
+```
+
+👉 [Lower-Bound Action Documentation & Inputs Reference](packages/lower_bound/action.yml)
 
 ---
 
 ## 🧠 AI Agent Skills
 
-* [`dart-cognitive-complexity`](skills/dart-cognitive-complexity/): Agent skill for automated complexity triage, pattern-matching refactoring, and method extraction.
-* [`dart-dedupe`](skills/dart-dedupe/): Agent skill for structural code duplication audits, clone triage, and safe deduplication refactoring.
-* [`dart-undead`](skills/dart-undead/): Agent skill for deterministic dead code audits, reachability analysis, and safe deletion protocols.
+Specialized agent skills and protocols for AI coding assistants (Cursor, Claude Code, Gemini CLI, Jetski):
+
+Install via `npx skills`:
+
+```bash
+# Cognitive Complexity triage, pattern-matching refactoring, and method extraction
+npx skills add kevmoo/analytica.dart --skill dart-cognitive-complexity
+
+# Structural code duplication audits, clone triage, and safe deduplication
+npx skills add kevmoo/analytica.dart --skill dart-dedupe
+
+# Deterministic dead code reachability audits and safe declaration pruning
+npx skills add kevmoo/analytica.dart --skill dart-undead
+```
+
+Or run `npx skills add kevmoo/analytica.dart` for an interactive selection menu.
+
+---
+
+## ⚡ CLI Quick Run
+
+Execute any tool on-demand without global installation via `dart run <package>@`:
+
+```bash
+# Evaluate cognitive complexity
+dart run cognitive_complexity@ --threshold 15 lib/
+
+# Audit structural code duplication
+dart run dedupe@ --git-diff=origin/main
+
+# Scan for unreachable / dead declarations
+dart run undead@
+
+# Validate dependency lower bounds
+dart run lower_bound@
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -30,100 +30,20 @@ A unified suite of high-performance static analysis engines, CLI tools, GitHub A
 
 ## 🚀 GitHub Actions
 
-Modular composite actions to automate code quality, complexity ceilings, and dependency validation in CI workflows:
+Modular composite GitHub Actions are maintained and documented in their respective package directories:
 
-### 1. Cognitive Complexity Audit
-
-Calculates Cognitive Complexity scores on pull requests and prevents complexity regressions.
-
-Add `.github/workflows/complexity.yml` to your repository:
-
-```yaml
-name: Cognitive Complexity Audit
-
-on:
-  pull_request:
-    branches: [main]
-
-jobs:
-  audit:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # Required for sticky PR comment summaries
-      contents: read
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0 # Full history required for diff-base merge-base comparison
-
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@v1
-
-      - name: Run Complexity Scanner
-        uses: kevmoo/analytica.dart/packages/cognitive_complexity@main
-        with:
-          diff-base: origin/${{ github.base_ref }}
-          fail-threshold: 15
-          fail-on-increase: true
-```
-
-👉 [Cognitive Complexity Action Inputs Reference & Documentation](packages/cognitive_complexity/README.md#action-inputs-reference)
-
-### 2. Dependency Lower-Bound Validator
-
-Validates that declared dependency lower bounds resolve and build against synthetic minimums.
-
-Add `.github/workflows/lower_bound.yml` to your repository:
-
-```yaml
-name: Dependency Lower-Bound Validation
-
-on:
-  pull_request:
-
-jobs:
-  validate:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # Required for sticky PR comment summaries
-      contents: read
-    steps:
-      - name: Checkout Codebase
-        uses: actions/checkout@v7
-
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@v1
-
-      - name: Validate Dependency Lower Bounds
-        uses: kevmoo/analytica.dart/packages/lower_bound@main
-        with:
-          format: 'github'
-          fail-on-error: 'true'
-```
-
-👉 [Lower-Bound Action Inputs Reference & Documentation](packages/lower_bound/README.md#action-inputs-reference)
+* [**Cognitive Complexity Audit**](packages/cognitive_complexity/README.md#github-actions) (`packages/cognitive_complexity`): Calculates Cognitive Complexity scores on pull requests and flags regressions.
+* [**Dependency Lower-Bound Validator**](packages/lower_bound/README.md#github-action) (`packages/lower_bound`): Validates that declared dependency lower bounds resolve and build against synthetic minimums.
 
 ---
 
 ## 🧠 AI Agent Skills
 
-Specialized agent skills and protocols for AI coding assistants (Cursor, Claude Code, Gemini CLI, Jetski):
+Specialized agent skills are maintained in the [`skills/`](skills/) directory and documented alongside their companion packages:
 
-Install via `npx skills`:
-
-```bash
-# Cognitive Complexity triage, pattern-matching refactoring, and method extraction
-npx skills add kevmoo/analytica.dart --skill dart-cognitive-complexity
-
-# Structural code duplication audits, clone triage, and safe deduplication
-npx skills add kevmoo/analytica.dart --skill dart-dedupe
-
-# Deterministic dead code reachability audits and safe declaration pruning
-npx skills add kevmoo/analytica.dart --skill dart-undead
-```
-
-Or run `npx skills add kevmoo/analytica.dart` for an interactive selection menu.
+* [**`dart-cognitive-complexity`**](skills/dart-cognitive-complexity/SKILL.md) (documented in [`cognitive_complexity`](packages/cognitive_complexity/README.md#ai-agent-integration)): Complexity scoring, triage, and AST pattern matching refactoring.
+* [**`dart-dedupe`**](skills/dart-dedupe/SKILL.md) (documented in [`dedupe`](packages/dedupe/README.md#ai-agent-integration)): Structural code duplication audits, clone triage, and safe deduplication.
+* [**`dart-undead`**](skills/dart-undead/SKILL.md) (documented in [`undead`](packages/undead/README.md#ai-agent-integration)): Deterministic dead code reachability audits and safe declaration pruning.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Modular composite GitHub Actions are maintained and documented in their respecti
 
 Specialized agent skills are maintained in the [`skills/`](skills/) directory and documented alongside their companion packages:
 
-* [**`dart-cognitive-complexity`**](skills/dart-cognitive-complexity/SKILL.md) (documented in [`cognitive_complexity`](packages/cognitive_complexity/README.md#ai-agent-integration)): Complexity scoring, triage, and AST pattern matching refactoring.
-* [**`dart-dedupe`**](skills/dart-dedupe/SKILL.md) (documented in [`dedupe`](packages/dedupe/README.md#ai-agent-integration)): Structural code duplication audits, clone triage, and safe deduplication.
-* [**`dart-undead`**](skills/dart-undead/SKILL.md) (documented in [`undead`](packages/undead/README.md#ai-agent-integration)): Deterministic dead code reachability audits and safe declaration pruning.
+* [**`dart-cognitive-complexity`**](skills/dart-cognitive-complexity/SKILL.md) (documented in [`cognitive_complexity`](packages/cognitive_complexity/README.md#-ai-agent-integration)): Complexity scoring, triage, and AST pattern matching refactoring.
+* [**`dart-dedupe`**](skills/dart-dedupe/SKILL.md) (documented in [`dedupe`](packages/dedupe/README.md#-ai-agent-integration)): Structural code duplication audits, clone triage, and safe deduplication.
+* [**`dart-undead`**](skills/dart-undead/SKILL.md) (documented in [`undead`](packages/undead/README.md#-ai-agent-integration)): Deterministic dead code reachability audits and safe declaration pruning.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Analytica
 
 [![CI](https://github.com/kevmoo/analytica.dart/actions/workflows/ci.yml/badge.svg)](https://github.com/kevmoo/analytica.dart/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 A unified suite of high-performance static analysis engines, CLI tools, GitHub Actions, and AI Agent Skills for Dart and Flutter repositories.
 
@@ -15,43 +15,94 @@ A unified suite of high-performance static analysis engines, CLI tools, GitHub A
 | [`cognitive_complexity`](packages/cognitive_complexity/) | [![pub package](https://img.shields.io/pub/v/cognitive_complexity.svg)](https://pub.dev/packages/cognitive_complexity) | Algorithmic Cognitive Complexity calculation and AST data-flow analysis library and CLI. |
 | [`dedupe`](packages/dedupe/) | [![pub package](https://img.shields.io/pub/v/dedupe.svg)](https://pub.dev/packages/dedupe) | High-performance token, structural, and parameterized code clone detection engine and CLI. |
 | [`undead`](packages/undead/) | [![pub package](https://img.shields.io/pub/v/undead.svg)](https://pub.dev/packages/undead) | Whole-program reachability and dead declaration analysis for packages and closed apps. |
-| [`lower_bound`](packages/lower_bound/) | [![pub package](https://img.shields.io/pub/v/lower_bound.svg)](https://pub.dev/packages/lower_bound) | Automated Dart dependency lower-bound validator and synthetic runtime isolation engine. |
 | [`analytica`](packages/analytica/) | [![pub package](https://img.shields.io/pub/v/analytica.svg)](https://pub.dev/packages/analytica) | Shared SDK discovery, AST analyzer extensions, Git diff utilities, and CI reporting. |
+<!-- mdformat on -->
+
+### 🚧 In Development
+
+<!-- mdformat off(prevent table wrapping) -->
+| Package | Version | Description |
+| :--- | :---: | :--- |
+| [`lower_bound`](packages/lower_bound/) | `0.1.0-wip` | Automated Dart dependency lower-bound validator and synthetic runtime isolation engine. |
 <!-- mdformat on -->
 
 ---
 
 ## 🚀 GitHub Actions
 
-Modular composite actions to automate code quality, complexity ceilings, and dependency checks in your CI workflows:
+Modular composite actions to automate code quality, complexity ceilings, and dependency validation in CI workflows:
 
 ### 1. Cognitive Complexity Audit
 
-Calculates Cognitive Complexity scores on pull requests and prevents complexity regressions:
+Calculates Cognitive Complexity scores on pull requests and prevents complexity regressions.
+
+Add `.github/workflows/complexity.yml` to your repository:
 
 ```yaml
-- name: Run Complexity Scanner
-  uses: kevmoo/analytica.dart/packages/cognitive_complexity@main
-  with:
-    diff-base: origin/${{ github.base_ref }}
-    fail-threshold: 15
-    fail-on-increase: true
+name: Cognitive Complexity Audit
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Required for sticky PR comment summaries
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # Full history required for diff-base merge-base comparison
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+
+      - name: Run Complexity Scanner
+        uses: kevmoo/analytica.dart/packages/cognitive_complexity@main
+        with:
+          diff-base: origin/${{ github.base_ref }}
+          fail-threshold: 15
+          fail-on-increase: true
 ```
 
-👉 [Cognitive Complexity Action Documentation & Inputs Reference](packages/cognitive_complexity/action.yml)
+👉 [Cognitive Complexity Action Inputs Reference & Documentation](packages/cognitive_complexity/README.md#action-inputs-reference)
 
 ### 2. Dependency Lower-Bound Validator
 
-Validates that declared dependency lower bounds resolve and build against synthetic minimums:
+Validates that declared dependency lower bounds resolve and build against synthetic minimums.
+
+Add `.github/workflows/lower_bound.yml` to your repository:
 
 ```yaml
-- name: Validate Dependency Lower Bounds
-  uses: kevmoo/analytica.dart/packages/lower_bound@main
-  with:
-    fail-on-error: true
+name: Dependency Lower-Bound Validation
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Required for sticky PR comment summaries
+      contents: read
+    steps:
+      - name: Checkout Codebase
+        uses: actions/checkout@v7
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+
+      - name: Validate Dependency Lower Bounds
+        uses: kevmoo/analytica.dart/packages/lower_bound@main
+        with:
+          format: 'github'
+          fail-on-error: 'true'
 ```
 
-👉 [Lower-Bound Action Documentation & Inputs Reference](packages/lower_bound/action.yml)
+👉 [Lower-Bound Action Inputs Reference & Documentation](packages/lower_bound/README.md#action-inputs-reference)
 
 ---
 
@@ -89,9 +140,6 @@ dart run dedupe@ --git-diff=origin/main
 
 # Scan for unreachable / dead declarations
 dart run undead@
-
-# Validate dependency lower bounds
-dart run lower_bound@
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -1,55 +1,32 @@
-name: 'Dart Cognitive Complexity Audit'
-description: 'Deterministic Cognitive Complexity calculator and Git diff regression scanner for Dart and Flutter repositories.'
+name: 'Analytica (Deprecated Root Action)'
+description: 'The root action entrypoint is deprecated. Use packages/<tool> instead.'
 author: 'kevmoo'
 
 branding:
-  icon: 'trending-up'
-  color: 'blue'
-
-inputs:
-  targets:
-    description: 'Space-separated list of target files or directories to analyze.'
-    required: false
-    default: 'lib'
-  threshold:
-    description: 'Minimum complexity score to display in reports.'
-    required: false
-    default: '0'
-  fail-threshold:
-    description: 'Exit with non-zero status if any function score exceeds this ceiling.'
-    required: false
-    default: '15'
-  diff-base:
-    description: 'Git ref (e.g. origin/main) to compare against. Auto-detects PR base by default.'
-    required: false
-    default: ''
-  fail-on-increase:
-    description: 'Exit with non-zero status if any function increased in complexity over diff-base.'
-    required: false
-    default: 'false'
-  format:
-    description: 'Output format: github (summary table + annotations), text, or json.'
-    required: false
-    default: 'github'
-  max-comment-rows:
-    description: >-
-      Maximum table rows in the sticky PR comment, most significant first
-      (0 = unlimited). The step summary always keeps the full table. GitHub
-      rejects comment bodies over 65536 characters, so an uncapped table on a
-      large diff fails to post.
-    required: false
-    default: '0'
+  icon: 'alert-triangle'
+  color: 'red'
 
 runs:
   using: 'composite'
   steps:
-    - name: Delegate to Cognitive Complexity Action
-      uses: ./packages/cognitive_complexity
-      with:
-        targets: ${{ inputs.targets }}
-        threshold: ${{ inputs.threshold }}
-        fail-threshold: ${{ inputs.fail-threshold }}
-        diff-base: ${{ inputs.diff-base }}
-        fail-on-increase: ${{ inputs.fail-on-increase }}
-        format: ${{ inputs.format }}
-        max-comment-rows: ${{ inputs.max-comment-rows }}
+    - name: Deprecation Notice
+      shell: bash
+      run: |
+        echo "::error title=Deprecated Action Entrypoint::The root action 'kevmoo/analytica.dart' has been deprecated in favor of modular subdirectory actions."
+        echo ""
+        echo "=================================================================================="
+        echo "🚨 ACTION CONFIGURATION UPDATE REQUIRED"
+        echo "=================================================================================="
+        echo "The root action 'uses: kevmoo/analytica.dart@...' is no longer supported."
+        echo ""
+        echo "Please update your workflow configuration to use the specific tool:"
+        echo ""
+        echo "  • Cognitive Complexity:"
+        echo "      uses: kevmoo/analytica.dart/packages/cognitive_complexity@main"
+        echo ""
+        echo "  • Dependency Lower-Bound Validator:"
+        echo "      uses: kevmoo/analytica.dart/packages/lower_bound@main"
+        echo ""
+        echo "For documentation, visit: https://github.com/kevmoo/analytica.dart"
+        echo "=================================================================================="
+        exit 1

--- a/packages/cognitive_complexity/CHANGELOG.md
+++ b/packages/cognitive_complexity/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.5-wip
+
+- Update GitHub Action documentation in `README.md` to reference modular
+  subdirectory path (`packages/cognitive_complexity`) and add rendered Action
+  Inputs Reference table.
+
 ## 0.2.4
 
 - Fix `action.yml` monorepo auto-detection to evaluate default `lib` vs

--- a/packages/cognitive_complexity/README.md
+++ b/packages/cognitive_complexity/README.md
@@ -55,18 +55,48 @@ void main() {
 Add automated complexity audits to `.github/workflows/complexity.yml`:
 
 ```yaml
-- uses: actions/checkout@v7
-  with:
-    fetch-depth: 0
+name: Cognitive Complexity Audit
 
-- uses: dart-lang/setup-dart@v1
+on:
+  pull_request:
+    branches: [main]
 
-- uses: kevmoo/analytica.dart/packages/cognitive_complexity@main
-  with:
-    diff-base: origin/${{ github.base_ref }}
-    fail-threshold: 15
-    fail-on-increase: true
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Required for sticky PR comment summaries
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # Full history required for diff-base merge-base comparison
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+
+      - name: Run Complexity Scanner
+        uses: kevmoo/analytica.dart/packages/cognitive_complexity@main
+        with:
+          diff-base: origin/${{ github.base_ref }}
+          fail-threshold: 15
+          fail-on-increase: true
 ```
+
+#### Action Inputs Reference
+
+<!-- mdformat off(prevent table wrapping) -->
+| Input | Default | Description |
+| :--- | :---: | :--- |
+| `targets` | `lib` | Space-separated list of directories or files to scan. |
+| `threshold` | `0` | Minimum score required to include a declaration in summary tables. |
+| `fail-threshold` | `15` | Maximum complexity ceiling allowed before failing the build. |
+| `diff-base` | _Auto_ | Git ref to compare against (e.g. `origin/main`). Auto-detects PR base. |
+| `fail-on-increase` | `false` | When `true`, blocks PR merge on complexity increases exceeding `fail-threshold`. |
+| `format` | `github` | Output format: `github` (annotations + step summary), `text`, or `json`. |
+| `max-comment-rows` | `0` | Maximum table rows in the sticky PR comment (0 = unlimited). |
+<!-- mdformat on -->
 
 ## 🧠 AI Agent Integration
 

--- a/packages/cognitive_complexity/README.md
+++ b/packages/cognitive_complexity/README.md
@@ -61,7 +61,7 @@ Add automated complexity audits to `.github/workflows/complexity.yml`:
 
 - uses: dart-lang/setup-dart@v1
 
-- uses: kevmoo/analytica.dart@main
+- uses: kevmoo/analytica.dart/packages/cognitive_complexity@main
   with:
     diff-base: origin/${{ github.base_ref }}
     fail-threshold: 15

--- a/packages/cognitive_complexity/pubspec.yaml
+++ b/packages/cognitive_complexity/pubspec.yaml
@@ -2,7 +2,7 @@ name: cognitive_complexity
 description: >-
   Algorithmic Cognitive Complexity calculation and Data-Flow analysis library
   and CLI tools for Dart and Flutter.
-version: 0.2.4
+version: 0.2.5-wip
 repository: https://github.com/kevmoo/analytica.dart/tree/main/packages/cognitive_complexity
 issue_tracker: https://github.com/kevmoo/analytica.dart/issues
 

--- a/packages/dedupe/CHANGELOG.md
+++ b/packages/dedupe/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1-wip
+
+- Add `dart-dedupe` agent skill integration guide in `README.md`.
+
 ## 0.1.0
 
 - Initial release of `pkg:dedupe`:

--- a/packages/dedupe/README.md
+++ b/packages/dedupe/README.md
@@ -107,3 +107,11 @@ void main() async {
   }
 }
 ```
+
+## 🧠 AI Agent Integration
+
+This repository packages an agent skill (`dart-dedupe`) to train AI pair programmers on structural code duplication audits, clone triage, and safe deduplication refactoring:
+
+```bash
+npx skills add kevmoo/analytica.dart --skill dart-dedupe
+```

--- a/packages/dedupe/lib/src/version.dart
+++ b/packages/dedupe/lib/src/version.dart
@@ -1,2 +1,2 @@
 /// The current version of `pkg:dedupe`.
-const String dedupeVersion = '0.1.0';
+const String dedupeVersion = '0.1.1-wip';

--- a/packages/dedupe/pubspec.yaml
+++ b/packages/dedupe/pubspec.yaml
@@ -2,7 +2,7 @@ name: dedupe
 description: >-
   High-performance code duplication and clone detection engine and CLI tool
   for Dart and Flutter.
-version: 0.1.0
+version: 0.1.1-wip
 repository: https://github.com/kevmoo/analytica.dart/tree/main/packages/dedupe
 issue_tracker: https://github.com/kevmoo/analytica.dart/issues
 

--- a/packages/lower_bound/README.md
+++ b/packages/lower_bound/README.md
@@ -59,9 +59,41 @@ dart run lower_bound --comment-output=comment.md --max-comment-rows=10
 Add `lower_bound` to your GitHub Actions workflow:
 
 ```yaml
-- name: Validate Dependency Lower Bounds
-  uses: kevmoo/analytica.dart/packages/lower_bound@main
-  with:
-    format: 'github'
-    fail-on-error: 'true'
+name: Dependency Lower-Bound Validation
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Required for sticky PR comment summaries
+      contents: read
+    steps:
+      - name: Checkout Codebase
+        uses: actions/checkout@v7
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+
+      - name: Validate Dependency Lower Bounds
+        uses: kevmoo/analytica.dart/packages/lower_bound@main
+        with:
+          format: 'github'
+          fail-on-error: 'true'
 ```
+
+#### Action Inputs Reference
+
+<!-- mdformat off(prevent table wrapping) -->
+| Input | Default | Description |
+| :--- | :---: | :--- |
+| `package-path` | `.` | Path to target package or workspace root to validate. |
+| `targets` | `lib,bin` | Comma-separated list of target directories or files to analyze. |
+| `allow-local-siblings` | `false` | Allow unreleased local sibling packages via path overrides. |
+| `sdk` | _None_ | Simulate specific Dart SDK version during pub resolution. |
+| `fail-on-error` | `true` | Exit with non-zero status if lower bound validation fails. |
+| `format` | `github` | Output format: `github` (summary table + annotations), `text`, or `json`. |
+| `max-comment-rows` | `0` | Maximum table rows in the sticky PR comment (0 = unlimited). |
+<!-- mdformat on -->


### PR DESCRIPTION
Deprecates the legacy root action in favor of modular package-level actions, and reorganizes the root README to showcase the published packages, actions, and agent skills.

* Replace root `action.yml` delegation with a fast-fail step providing explicit migration syntax
* Update `packages/cognitive_complexity/README.md` to reference `packages/cognitive_complexity`
* Overhaul root `README.md` to feature the published package matrix, GitHub Action catalog, and AI Agent Skills one-liner installation commands

Fixes #93
