### PR TITLE
feat(cli_readme): introduce package:cli_readme for CLI usage in READMEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
         working-directory: packages/undead
         run: dart test
         if: always() && steps.install.outcome == 'success'
+      - name: Run tests (cli_readme)
+        working-directory: packages/cli_readme
+        run: dart test
+        if: always() && steps.install.outcome == 'success'
       - name: Run tests (lower_bound)
         working-directory: packages/lower_bound
         run: dart test

--- a/packages/cli_readme/CHANGELOG.md
+++ b/packages/cli_readme/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 0.1.0-wip
+
+- Initial release of `package:cli_readme`:
+  - 3-line test contract (`expectReadmeHelpClean`) to verify CLI usage in `README.md`.
+  - Standalone CLI runner (`dart run cli_readme --write` / `--check`).
+  - In-memory `ArgParser` evaluation for fast zero-subprocess testing.
+  - Tagged HTML comment marker support (`<!-- CLI_README_START [id] -->`).
+  - Automatic line-by-line whitespace normalization and unified diff generation.

--- a/packages/cli_readme/README.md
+++ b/packages/cli_readme/README.md
@@ -1,0 +1,122 @@
+Test utility and CLI tool to ensure command-line usage and help documentation
+in `README.md` files are accurate and up-to-date.
+
+Inspired by [`package:build_verify`](https://pub.dev/packages/build_verify),
+`cli_readme` gives you a **3-line test** to guarantee your CLI arguments and
+usage examples never drift from the real executable output.
+
+## ✨ Features
+
+- **3-Line Test Contract**: Add `test('readme', expectReadmeHelpClean);` to your
+  test suite.
+- **In-Place Synchronization**: Run `dart run cli_readme --write` to
+  automatically update your README when options or descriptions change.
+- **Zero-Process Fast Mode**: Validate in-memory `ArgParser` objects directly
+  without spawning Dart VM subprocesses.
+- **Robust Normalization**: Automatically strips trailing whitespace (a common
+  quirk of `ArgParser.usage`), normalizes CRLF line endings, and ignores ANSI
+  color escape codes.
+- **Multiple Targets**: Document multiple commands, subcommands, or binaries in
+  a single `README.md`.
+
+## ⚡ Quick Start
+
+### 1. Tag Your `README.md`
+
+Add HTML comment markers around the CLI output in your `README.md`:
+
+<!-- CLI_README_START -->
+```console
+$ cli_readme --help
+Test utility and CLI tool to ensure CLI usage in README files is up-to-date.
+
+Usage: cli_readme [options]
+
+-h, --help           Print this usage information.
+    --[no-]check     Verify that README is up to date (default: true).
+                     (defaults to on)
+    --[no-]write     Write updated CLI help to README.
+    --package-dir    Path to package directory (defaults to current directory).
+    --readme         Path to README.md file (defaults to README.md in package root).
+```
+<!-- CLI_README_END -->
+
+### 2. Add the Test
+
+Create `test/ensure_cli_readme_test.dart`:
+
+```dart
+import 'package:cli_readme/cli_readme.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('ensure_cli_readme', expectReadmeHelpClean);
+}
+```
+
+### 3. Update Automatically
+
+When you change your flags or help messages, update your `README.md` in one
+command:
+
+```bash
+dart run cli_readme --write
+```
+
+## 🛠️ Advanced Usage
+
+### In-Memory Parser (Zero Subprocess Latency)
+
+For large test suites where spawning a Dart subprocess is undesirable, pass a
+`CliTarget` with your `ArgParser`:
+
+```dart
+import 'package:args/args.dart';
+import 'package:cli_readme/cli_readme.dart';
+import 'package:my_package/src/options.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('readme', () => expectReadmeHelpClean(
+    targets: [
+      CliTarget(
+        id: 'main',
+        commandName: 'my_tool',
+        argParser: buildArgParser(),
+        description: 'My awesome command line tool.',
+      ),
+    ],
+  ));
+}
+```
+
+### Multiple Binaries or Subcommands
+
+Specify target IDs to map multiple sections in your `README.md`:
+
+````markdown
+### Server CLI
+<!-- CLI_README_START server -->
+```console
+$ my_server --help
+...
+```
+<!-- CLI_README_END server -->
+
+### Client CLI
+<!-- CLI_README_START client -->
+```console
+$ my_client --help
+...
+```
+<!-- CLI_README_END client -->
+````
+
+```dart
+test('readme', () => expectReadmeHelpClean(
+  targets: [
+    CliTarget.executable(id: 'server', executablePath: 'bin/server.dart', commandName: 'my_server'),
+    CliTarget.executable(id: 'client', executablePath: 'bin/client.dart', commandName: 'my_client'),
+  ],
+));
+```

--- a/packages/cli_readme/bin/cli_readme.dart
+++ b/packages/cli_readme/bin/cli_readme.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:cli_readme/cli_readme.dart';
+
+Future<void> main(List<String> rawArgs) async {
+  final parser = ArgParser()
+    ..addFlag(
+      'help',
+      abbr: 'h',
+      negatable: false,
+      help: 'Print this usage information.',
+    )
+    ..addFlag(
+      'check',
+      defaultsTo: true,
+      help: 'Verify that README is up to date (default: true).',
+    )
+    ..addFlag(
+      'write',
+      negatable: true,
+      defaultsTo: false,
+      help: 'Write updated CLI help to README.',
+    )
+    ..addOption(
+      'package-dir',
+      help: 'Path to package directory (defaults to current directory).',
+    )
+    ..addOption(
+      'readme',
+      help: 'Path to README.md file (defaults to README.md in package root).',
+    );
+
+  final ArgResults args;
+  try {
+    args = parser.parse(rawArgs);
+  } on FormatException catch (e) {
+    stderr.writeln(e.message);
+    stderr.writeln();
+    stderr.writeln('Usage: cli_readme [options]');
+    stderr.writeln(parser.usage);
+    exit(64);
+  }
+
+  if (args['help'] as bool) {
+    print(
+      'Test utility and CLI tool to ensure CLI usage in README files is '
+      'up-to-date.',
+    );
+    print('');
+    print('Usage: cli_readme [options]');
+    print('');
+    print(parser.usage);
+    exit(0);
+  }
+
+  final writeMode = args['write'] as bool;
+  final pkgDir = args['package-dir'] as String?;
+  final readmeOpt = args['readme'] as String?;
+
+  final syncer = CliReadmeSync.discover(
+    workingDir: pkgDir,
+    readmePath: readmeOpt,
+  );
+
+  if (writeMode) {
+    final result = await syncer.update();
+    if (result.hasModifications) {
+      print('Updated ${result.readmePath}.');
+    } else {
+      print('${result.readmePath} is already up to date.');
+    }
+    exit(0);
+  }
+
+  // Verification mode
+  final result = await syncer.verify();
+  if (result.isClean) {
+    print('✅ ${result.readmePath} CLI usage documentation is up to date.');
+    exit(0);
+  }
+
+  stderr.writeln('❌ ${result.readmePath} CLI documentation is out of date:');
+  stderr.writeln();
+
+  for (final targetResult in result.staleTargets) {
+    final t = targetResult.target;
+    stderr.writeln('=== Target: ${t.commandName} (id: "${t.id}") ===');
+    if (targetResult.errorMessage != null) {
+      stderr.writeln(targetResult.errorMessage);
+    }
+    if (targetResult.diff != null) {
+      stderr.writeln(targetResult.diff);
+    }
+    stderr.writeln();
+  }
+
+  stderr.writeln('Run "dart run cli_readme --write" to update.');
+  exit(1);
+}

--- a/packages/cli_readme/lib/cli_readme.dart
+++ b/packages/cli_readme/lib/cli_readme.dart
@@ -1,0 +1,3 @@
+export 'src/models.dart' show CliTarget, SyncResult, TargetResult;
+export 'src/normalizer.dart' show formatCodeFence, normalizeText;
+export 'src/sync_impl.dart' show CliReadmeSync, expectReadmeHelpClean;

--- a/packages/cli_readme/lib/src/diff.dart
+++ b/packages/cli_readme/lib/src/diff.dart
@@ -9,29 +9,28 @@ String generateDiff({
   final expLines = expected.split('\n');
   final actLines = actual.split('\n');
 
-  final buffer = StringBuffer();
-  buffer.writeln('--- $actualHeader');
-  buffer.writeln('+++ $expectedHeader');
+  final buffer = StringBuffer()
+    ..writeln('--- $actualHeader')
+    ..writeln('+++ $expectedHeader');
 
   final maxLen = expLines.length > actLines.length
       ? expLines.length
       : actLines.length;
 
   for (var i = 0; i < maxLen; i++) {
-    final expLine = i < expLines.length ? expLines[i] : null;
-    final actLine = i < actLines.length ? actLines[i] : null;
-
-    if (expLine == actLine) {
-      buffer.writeln('  $actLine');
-    } else {
-      if (actLine != null) {
-        buffer.writeln('- $actLine');
-      }
-      if (expLine != null) {
-        buffer.writeln('+ $expLine');
-      }
-    }
+    final exp = i < expLines.length ? expLines[i] : null;
+    final act = i < actLines.length ? actLines[i] : null;
+    _writeDiffLine(buffer, exp, act);
   }
 
   return buffer.toString();
+}
+
+void _writeDiffLine(StringBuffer buffer, String? exp, String? act) {
+  if (exp == act) {
+    buffer.writeln('  $act');
+    return;
+  }
+  if (act != null) buffer.writeln('- $act');
+  if (exp != null) buffer.writeln('+ $exp');
 }

--- a/packages/cli_readme/lib/src/diff.dart
+++ b/packages/cli_readme/lib/src/diff.dart
@@ -1,0 +1,37 @@
+/// Generates a simple line-by-line unified diff between expected and actual
+/// text.
+String generateDiff({
+  required String expected,
+  required String actual,
+  String expectedHeader = 'expected (from CLI)',
+  String actualHeader = 'actual (in README.md)',
+}) {
+  final expLines = expected.split('\n');
+  final actLines = actual.split('\n');
+
+  final buffer = StringBuffer();
+  buffer.writeln('--- $actualHeader');
+  buffer.writeln('+++ $expectedHeader');
+
+  final maxLen = expLines.length > actLines.length
+      ? expLines.length
+      : actLines.length;
+
+  for (var i = 0; i < maxLen; i++) {
+    final expLine = i < expLines.length ? expLines[i] : null;
+    final actLine = i < actLines.length ? actLines[i] : null;
+
+    if (expLine == actLine) {
+      buffer.writeln('  $actLine');
+    } else {
+      if (actLine != null) {
+        buffer.writeln('- $actLine');
+      }
+      if (expLine != null) {
+        buffer.writeln('+ $expLine');
+      }
+    }
+  }
+
+  return buffer.toString();
+}

--- a/packages/cli_readme/lib/src/discover.dart
+++ b/packages/cli_readme/lib/src/discover.dart
@@ -29,37 +29,8 @@ class PackageContext {
     String? readmePath,
     List<CliTarget>? customTargets,
   }) {
-    var dir = workingDir != null
-        ? Directory(workingDir).resolveSymbolicLinksSync()
-        : Directory.current.resolveSymbolicLinksSync();
-
-    if (packageRelativeDirectory != null &&
-        packageRelativeDirectory.isNotEmpty) {
-      dir = p.normalize(p.join(dir, packageRelativeDirectory));
-    } else if (workingDir == null) {
-      // Check if current directory is a workspace root
-      final currentPubspec = File(p.join(dir, 'pubspec.yaml'));
-      if (currentPubspec.existsSync()) {
-        final yaml = loadYaml(currentPubspec.readAsStringSync()) as Map?;
-        if (yaml != null && yaml.containsKey('workspace')) {
-          final inferredPkgDir = _inferPackageFromTestRunner(dir);
-          if (inferredPkgDir != null) {
-            dir = inferredPkgDir;
-          }
-        }
-      }
-    }
-
-    final pubspecFile = File(p.join(dir, 'pubspec.yaml'));
-    if (!pubspecFile.existsSync()) {
-      throw StateError(
-        'Could not locate pubspec.yaml in $dir. '
-        'Ensure the command is run from a Dart package root or specify '
-        'packageRelativeDirectory.',
-      );
-    }
-
-    final pubspecYaml = loadYaml(pubspecFile.readAsStringSync()) as Map;
+    final dir = _resolvePackageDirectory(workingDir, packageRelativeDirectory);
+    final pubspecYaml = _readPubspecYaml(dir);
     final pkgName = pubspecYaml['name'] as String? ?? 'app';
 
     final resolvedReadmePath = readmePath != null
@@ -85,22 +56,63 @@ class PackageContext {
     );
   }
 
+  static String _resolvePackageDirectory(
+    String? workingDir,
+    String? packageRelativeDirectory,
+  ) {
+    var dir = workingDir != null
+        ? Directory(workingDir).resolveSymbolicLinksSync()
+        : Directory.current.resolveSymbolicLinksSync();
+
+    if (packageRelativeDirectory != null &&
+        packageRelativeDirectory.isNotEmpty) {
+      return p.normalize(p.join(dir, packageRelativeDirectory));
+    }
+
+    if (workingDir == null && _isWorkspaceRoot(dir)) {
+      final inferred = _inferPackageFromTestRunner(dir);
+      if (inferred != null) return inferred;
+    }
+
+    return dir;
+  }
+
+  static bool _isWorkspaceRoot(String dir) {
+    final pubspecFile = File(p.join(dir, 'pubspec.yaml'));
+    if (!pubspecFile.existsSync()) return false;
+    final yaml = loadYaml(pubspecFile.readAsStringSync()) as Map?;
+    return yaml != null && yaml.containsKey('workspace');
+  }
+
+  static Map _readPubspecYaml(String dir) {
+    final pubspecFile = File(p.join(dir, 'pubspec.yaml'));
+    if (!pubspecFile.existsSync()) {
+      throw StateError(
+        'Could not locate pubspec.yaml in $dir. '
+        'Ensure the command is run from a Dart package root or specify '
+        'packageRelativeDirectory.',
+      );
+    }
+    return loadYaml(pubspecFile.readAsStringSync()) as Map;
+  }
+
   static String? _inferPackageFromTestRunner(String workspaceRoot) {
     try {
       final suitePath = Invoker.current?.liveTest.suite.path;
-      if (suitePath != null && suitePath.isNotEmpty) {
-        final absPath = p.isAbsolute(suitePath)
-            ? suitePath
-            : p.join(workspaceRoot, suitePath);
-        var parent = Directory(p.dirname(absPath));
-        while (parent.path != workspaceRoot && parent.path.length > 3) {
-          if (File(p.join(parent.path, 'pubspec.yaml')).existsSync()) {
-            return parent.path;
-          }
-          final next = parent.parent;
-          if (next.path == parent.path) break;
-          parent = next;
+      if (suitePath == null || suitePath.isEmpty) return null;
+
+      final absPath = p.isAbsolute(suitePath)
+          ? suitePath
+          : p.join(workspaceRoot, suitePath);
+
+      var parent = Directory(p.dirname(absPath));
+      while (parent.path != workspaceRoot && parent.path.length > 3) {
+        if (File(p.join(parent.path, 'pubspec.yaml')).existsSync()) {
+          return parent.path;
         }
+        final next = parent.parent;
+        if (next.path == parent.path) break;
+        parent = next;
       }
     } catch (_) {
       // Ignored if not running inside package:test
@@ -112,76 +124,76 @@ class PackageContext {
     String dir,
     String pkgName,
     Map pubspecYaml,
-  ) {
-    final targets = <CliTarget>[];
+  ) =>
+      _targetsFromExecutables(pubspecYaml) ??
+      _targetFromDefaultBin(dir, pkgName) ??
+      _targetsFromBinDirectory(dir, pkgName) ??
+      const [];
+
+  static List<CliTarget>? _targetsFromExecutables(Map pubspecYaml) {
     final executables = pubspecYaml['executables'] as Map?;
+    if (executables == null || executables.isEmpty) return null;
 
-    if (executables != null && executables.isNotEmpty) {
-      final isSingle = executables.length == 1;
-      for (final entry in executables.entries) {
-        final execName = entry.key.toString();
-        final scriptValue = entry.value?.toString();
-        final scriptRelPath = (scriptValue != null && scriptValue.isNotEmpty)
-            ? 'bin/$scriptValue.dart'
-            : 'bin/$execName.dart';
+    final isSingle = executables.length == 1;
+    final targets = <CliTarget>[];
 
-        targets.add(
-          CliTarget.executable(
-            id: isSingle ? '' : execName,
-            executablePath: scriptRelPath,
-            commandName: execName,
-          ),
-        );
-      }
-      return targets;
-    }
+    for (final entry in executables.entries) {
+      final execName = entry.key.toString();
+      final scriptValue = entry.value?.toString();
+      final scriptRelPath = (scriptValue != null && scriptValue.isNotEmpty)
+          ? 'bin/$scriptValue.dart'
+          : 'bin/$execName.dart';
 
-    // Check bin/<pkgName>.dart
-    final defaultBin = p.join(dir, 'bin', '$pkgName.dart');
-    if (File(defaultBin).existsSync()) {
       targets.add(
         CliTarget.executable(
-          id: '',
-          executablePath: 'bin/$pkgName.dart',
-          commandName: pkgName,
+          id: isSingle ? '' : execName,
+          executablePath: scriptRelPath,
+          commandName: execName,
         ),
       );
-      return targets;
     }
-
-    // Check all files in bin/
-    final binDir = Directory(p.join(dir, 'bin'));
-    if (binDir.existsSync()) {
-      final dartFiles = binDir
-          .listSync()
-          .whereType<File>()
-          .where((f) => f.path.endsWith('.dart'))
-          .toList();
-
-      if (dartFiles.length == 1) {
-        final rel = p.relative(dartFiles.first.path, from: dir);
-        targets.add(
-          CliTarget.executable(
-            id: '',
-            executablePath: rel,
-            commandName: pkgName,
-          ),
-        );
-      } else if (dartFiles.length > 1) {
-        for (final f in dartFiles) {
-          final rel = p.relative(f.path, from: dir);
-          final base = p.basenameWithoutExtension(f.path);
-          targets.add(
-            CliTarget.executable(
-              id: base,
-              executablePath: rel,
-              commandName: base,
-            ),
-          );
-        }
-      }
-    }
-
     return targets;
+  }
+
+  static List<CliTarget>? _targetFromDefaultBin(String dir, String pkgName) {
+    final defaultBin = p.join(dir, 'bin', '$pkgName.dart');
+    if (!File(defaultBin).existsSync()) return null;
+
+    return [
+      CliTarget.executable(
+        id: '',
+        executablePath: 'bin/$pkgName.dart',
+        commandName: pkgName,
+      ),
+    ];
+  }
+
+  static List<CliTarget>? _targetsFromBinDirectory(String dir, String pkgName) {
+    final binDir = Directory(p.join(dir, 'bin'));
+    if (!binDir.existsSync()) return null;
+
+    final dartFiles = binDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.dart'))
+        .toList();
+
+    if (dartFiles.isEmpty) return null;
+
+    if (dartFiles.length == 1) {
+      final rel = p.relative(dartFiles.first.path, from: dir);
+      return [
+        CliTarget.executable(id: '', executablePath: rel, commandName: pkgName),
+      ];
+    }
+
+    return [
+      for (final f in dartFiles)
+        CliTarget.executable(
+          id: p.basenameWithoutExtension(f.path),
+          executablePath: p.relative(f.path, from: dir),
+          commandName: p.basenameWithoutExtension(f.path),
+        ),
+    ];
   }
 }

--- a/packages/cli_readme/lib/src/discover.dart
+++ b/packages/cli_readme/lib/src/discover.dart
@@ -1,0 +1,187 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+// ignore: implementation_imports
+import 'package:test_api/src/backend/invoker.dart';
+import 'package:yaml/yaml.dart';
+
+import 'models.dart';
+
+/// Discovers package configuration and default targets.
+class PackageContext {
+  final String packageDirectory;
+  final String packageName;
+  final String readmePath;
+  final List<CliTarget> defaultTargets;
+
+  const PackageContext({
+    required this.packageDirectory,
+    required this.packageName,
+    required this.readmePath,
+    required this.defaultTargets,
+  });
+
+  /// Discovers package context starting from [workingDir] and optional
+  /// [packageRelativeDirectory].
+  static PackageContext discover({
+    String? workingDir,
+    String? packageRelativeDirectory,
+    String? readmePath,
+    List<CliTarget>? customTargets,
+  }) {
+    var dir = workingDir != null
+        ? Directory(workingDir).resolveSymbolicLinksSync()
+        : Directory.current.resolveSymbolicLinksSync();
+
+    if (packageRelativeDirectory != null &&
+        packageRelativeDirectory.isNotEmpty) {
+      dir = p.normalize(p.join(dir, packageRelativeDirectory));
+    } else if (workingDir == null) {
+      // Check if current directory is a workspace root
+      final currentPubspec = File(p.join(dir, 'pubspec.yaml'));
+      if (currentPubspec.existsSync()) {
+        final yaml = loadYaml(currentPubspec.readAsStringSync()) as Map?;
+        if (yaml != null && yaml.containsKey('workspace')) {
+          final inferredPkgDir = _inferPackageFromTestRunner(dir);
+          if (inferredPkgDir != null) {
+            dir = inferredPkgDir;
+          }
+        }
+      }
+    }
+
+    final pubspecFile = File(p.join(dir, 'pubspec.yaml'));
+    if (!pubspecFile.existsSync()) {
+      throw StateError(
+        'Could not locate pubspec.yaml in $dir. '
+        'Ensure the command is run from a Dart package root or specify '
+        'packageRelativeDirectory.',
+      );
+    }
+
+    final pubspecYaml = loadYaml(pubspecFile.readAsStringSync()) as Map;
+    final pkgName = pubspecYaml['name'] as String? ?? 'app';
+
+    final resolvedReadmePath = readmePath != null
+        ? (p.isAbsolute(readmePath) ? readmePath : p.join(dir, readmePath))
+        : p.join(dir, 'README.md');
+
+    final targets =
+        customTargets ?? _discoverTargets(dir, pkgName, pubspecYaml);
+
+    if (targets.isEmpty) {
+      throw StateError(
+        'No CLI targets found in "$dir". '
+        'Ensure "executables" are declared in pubspec.yaml, '
+        'a binary exists in "bin/", or pass explicit targets.',
+      );
+    }
+
+    return PackageContext(
+      packageDirectory: dir,
+      packageName: pkgName,
+      readmePath: resolvedReadmePath,
+      defaultTargets: targets,
+    );
+  }
+
+  static String? _inferPackageFromTestRunner(String workspaceRoot) {
+    try {
+      final suitePath = Invoker.current?.liveTest.suite.path;
+      if (suitePath != null && suitePath.isNotEmpty) {
+        final absPath = p.isAbsolute(suitePath)
+            ? suitePath
+            : p.join(workspaceRoot, suitePath);
+        var parent = Directory(p.dirname(absPath));
+        while (parent.path != workspaceRoot && parent.path.length > 3) {
+          if (File(p.join(parent.path, 'pubspec.yaml')).existsSync()) {
+            return parent.path;
+          }
+          final next = parent.parent;
+          if (next.path == parent.path) break;
+          parent = next;
+        }
+      }
+    } catch (_) {
+      // Ignored if not running inside package:test
+    }
+    return null;
+  }
+
+  static List<CliTarget> _discoverTargets(
+    String dir,
+    String pkgName,
+    Map pubspecYaml,
+  ) {
+    final targets = <CliTarget>[];
+    final executables = pubspecYaml['executables'] as Map?;
+
+    if (executables != null && executables.isNotEmpty) {
+      final isSingle = executables.length == 1;
+      for (final entry in executables.entries) {
+        final execName = entry.key.toString();
+        final scriptValue = entry.value?.toString();
+        final scriptRelPath = (scriptValue != null && scriptValue.isNotEmpty)
+            ? 'bin/$scriptValue.dart'
+            : 'bin/$execName.dart';
+
+        targets.add(
+          CliTarget.executable(
+            id: isSingle ? '' : execName,
+            executablePath: scriptRelPath,
+            commandName: execName,
+          ),
+        );
+      }
+      return targets;
+    }
+
+    // Check bin/<pkgName>.dart
+    final defaultBin = p.join(dir, 'bin', '$pkgName.dart');
+    if (File(defaultBin).existsSync()) {
+      targets.add(
+        CliTarget.executable(
+          id: '',
+          executablePath: 'bin/$pkgName.dart',
+          commandName: pkgName,
+        ),
+      );
+      return targets;
+    }
+
+    // Check all files in bin/
+    final binDir = Directory(p.join(dir, 'bin'));
+    if (binDir.existsSync()) {
+      final dartFiles = binDir
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.dart'))
+          .toList();
+
+      if (dartFiles.length == 1) {
+        final rel = p.relative(dartFiles.first.path, from: dir);
+        targets.add(
+          CliTarget.executable(
+            id: '',
+            executablePath: rel,
+            commandName: pkgName,
+          ),
+        );
+      } else if (dartFiles.length > 1) {
+        for (final f in dartFiles) {
+          final rel = p.relative(f.path, from: dir);
+          final base = p.basenameWithoutExtension(f.path);
+          targets.add(
+            CliTarget.executable(
+              id: base,
+              executablePath: rel,
+              commandName: base,
+            ),
+          );
+        }
+      }
+    }
+
+    return targets;
+  }
+}

--- a/packages/cli_readme/lib/src/executor.dart
+++ b/packages/cli_readme/lib/src/executor.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'models.dart';
+import 'normalizer.dart';
+
+/// Evaluates or executes a [CliTarget] to produce expected output text.
+Future<String> executeTarget(
+  CliTarget target, {
+  required String workingDirectory,
+}) async {
+  if (target.argParser != null) {
+    return _evaluateArgParser(target);
+  }
+
+  if (target.executablePath != null) {
+    return _runSubprocess(target, workingDirectory: workingDirectory);
+  }
+
+  throw ArgumentError(
+    'Target "${target.commandName}" has neither an in-memory argParser nor '
+    'an executablePath.',
+  );
+}
+
+String _evaluateArgParser(CliTarget target) {
+  final buffer = StringBuffer();
+  if (target.description != null && target.description!.isNotEmpty) {
+    buffer.writeln(target.description!.trimRight());
+    buffer.writeln();
+  }
+  buffer.writeln('Usage: ${target.commandName} [options]');
+  buffer.writeln();
+  buffer.write(target.argParser!.usage);
+  return normalizeText(buffer.toString());
+}
+
+Future<String> _runSubprocess(
+  CliTarget target, {
+  required String workingDirectory,
+}) async {
+  final scriptPath = p.isAbsolute(target.executablePath!)
+      ? target.executablePath!
+      : p.join(workingDirectory, target.executablePath!);
+
+  if (!File(scriptPath).existsSync()) {
+    throw FileSystemException(
+      'Target executable does not exist at "$scriptPath".',
+      scriptPath,
+    );
+  }
+
+  final result = await Process.run(Platform.resolvedExecutable, [
+    scriptPath,
+    ...target.args,
+  ], workingDirectory: workingDirectory);
+
+  if (result.exitCode != 0 && (result.stdout as String).trim().isEmpty) {
+    throw ProcessException(
+      Platform.resolvedExecutable,
+      [scriptPath, ...target.args],
+      'Command exited with code ${result.exitCode}.\nStderr:\n${result.stderr}',
+      result.exitCode,
+    );
+  }
+
+  final rawOutput = (result.stdout as String).isNotEmpty
+      ? (result.stdout as String)
+      : (result.stderr as String);
+
+  return normalizeText(rawOutput);
+}

--- a/packages/cli_readme/lib/src/models.dart
+++ b/packages/cli_readme/lib/src/models.dart
@@ -1,0 +1,135 @@
+import 'package:args/args.dart';
+
+/// Represents a command-line target to document and verify in a README.
+class CliTarget {
+  /// Unique identifier matching the marker in `README.md` (e.g.
+  /// `<!-- CLI_README_START [id] -->`).
+  ///
+  /// If empty or omitted, matches the default marker
+  /// `<!-- CLI_README_START -->`.
+  final String id;
+
+  /// The user-facing command name (e.g. `pubviz`, `dedupe`, `undead`).
+  final String commandName;
+
+  /// Optional relative path to the Dart script (e.g. `bin/dedupe.dart`).
+  final String? executablePath;
+
+  /// Optional in-memory [ArgParser] instance for zero-subprocess verification.
+  final ArgParser? argParser;
+
+  /// Optional command description line placed after the usage header.
+  final String? description;
+
+  /// Optional header text preceding the help output in the code fence.
+  ///
+  /// Defaults to `r'$ ' + commandName + ' --help'` or custom header.
+  final String? header;
+
+  /// Arguments passed when executing the binary or evaluating the parser.
+  ///
+  /// Defaults to `['--help']`.
+  final List<String> args;
+
+  /// Markdown code fence language identifier (e.g. `console`, `shell`, `text`).
+  ///
+  /// Defaults to `console`.
+  final String codeFenceLanguage;
+
+  const CliTarget({
+    this.id = '',
+    required this.commandName,
+    this.executablePath,
+    this.argParser,
+    this.description,
+    this.header,
+    this.args = const ['--help'],
+    this.codeFenceLanguage = 'console',
+  });
+
+  /// Creates a target backed by an executable script in `bin/`.
+  factory CliTarget.executable({
+    String id = '',
+    required String executablePath,
+    String? commandName,
+    String? header,
+    List<String> args = const ['--help'],
+    String codeFenceLanguage = 'console',
+  }) {
+    final inferredName = commandName ?? _inferCommandName(executablePath);
+    return CliTarget(
+      id: id,
+      commandName: inferredName,
+      executablePath: executablePath,
+      header: header,
+      args: args,
+      codeFenceLanguage: codeFenceLanguage,
+    );
+  }
+
+  /// Creates a target backed by an in-memory [ArgParser].
+  factory CliTarget.parser({
+    String id = '',
+    required String commandName,
+    required ArgParser argParser,
+    String? description,
+    String? header,
+    List<String> args = const ['--help'],
+    String codeFenceLanguage = 'console',
+  }) => CliTarget(
+    id: id,
+    commandName: commandName,
+    argParser: argParser,
+    description: description,
+    header: header,
+    args: args,
+    codeFenceLanguage: codeFenceLanguage,
+  );
+
+  static String _inferCommandName(String path) {
+    final file = path.split('/').last.split('\\').last;
+    if (file.endsWith('.dart')) {
+      return file.substring(0, file.length - 5);
+    }
+    return file;
+  }
+}
+
+/// The result of verifying or updating a single target section in `README.md`.
+class TargetResult {
+  final CliTarget target;
+  final bool isClean;
+  final String expectedOutput;
+  final String? actualOutputInReadme;
+  final String? diff;
+  final String? errorMessage;
+
+  const TargetResult({
+    required this.target,
+    required this.isClean,
+    required this.expectedOutput,
+    this.actualOutputInReadme,
+    this.diff,
+    this.errorMessage,
+  });
+}
+
+/// The aggregate result of verifying or updating all targets in a README.
+class SyncResult {
+  final String readmePath;
+  final List<TargetResult> targetResults;
+  final bool hasModifications;
+  final String? updatedReadmeContent;
+
+  const SyncResult({
+    required this.readmePath,
+    required this.targetResults,
+    required this.hasModifications,
+    this.updatedReadmeContent,
+  });
+
+  bool get isClean => targetResults.every((r) => r.isClean);
+
+  List<TargetResult> get staleTargets =>
+      targetResults.where((r) => !r.isClean).toList();
+}

--- a/packages/cli_readme/lib/src/normalizer.dart
+++ b/packages/cli_readme/lib/src/normalizer.dart
@@ -1,0 +1,46 @@
+/// Normalization utilities for command line output and markdown text.
+final _ansiEscapeRegex = RegExp(r'\x1B\[[0-9;]*[a-zA-Z]');
+
+/// Normalizes output text for robust comparison.
+///
+/// 1. Strips ANSI escape sequences (colors, cursor movements).
+/// 2. Normalizes Windows CRLF line endings to LF (`\n`).
+/// 3. Trims trailing whitespace from every line (resolves `ArgParser.usage`
+///    padding).
+/// 4. Strips leading and trailing blank lines from the block.
+String normalizeText(String input) {
+  final noAnsi = input.replaceAll(_ansiEscapeRegex, '');
+  final unixLines = noAnsi.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  final lines = unixLines.split('\n').map((l) => l.trimRight()).toList();
+
+  // Trim leading empty lines
+  while (lines.isNotEmpty && lines.first.trim().isEmpty) {
+    lines.removeAt(0);
+  }
+
+  // Trim trailing empty lines
+  while (lines.isNotEmpty && lines.last.trim().isEmpty) {
+    lines.removeLast();
+  }
+
+  return lines.join('\n');
+}
+
+/// Normalizes a markdown code fence block.
+String formatCodeFence({
+  required String content,
+  String language = 'console',
+  String? header,
+}) {
+  final buffer = StringBuffer();
+  buffer.writeln('```$language');
+  if (header != null && header.isNotEmpty) {
+    buffer.writeln(header.trimRight());
+  }
+  final normalized = normalizeText(content);
+  if (normalized.isNotEmpty) {
+    buffer.writeln(normalized);
+  }
+  buffer.write('```');
+  return buffer.toString();
+}

--- a/packages/cli_readme/lib/src/parser.dart
+++ b/packages/cli_readme/lib/src/parser.dart
@@ -1,0 +1,109 @@
+/// Representation of a parsed marked section in a README.
+class MarkedSection {
+  final String id;
+  final int startIndex;
+  final int endIndex;
+  final String startMarker;
+  final String endMarker;
+  final String rawInnerContent;
+
+  const MarkedSection({
+    required this.id,
+    required this.startIndex,
+    required this.endIndex,
+    required this.startMarker,
+    required this.endMarker,
+    required this.rawInnerContent,
+  });
+
+  /// Extracts the content inside the code fence, if present.
+  String? extractCodeFenceContent() {
+    final trimmed = rawInnerContent.trim();
+    if (!trimmed.startsWith('```')) return null;
+
+    final firstLineEnd = trimmed.indexOf('\n');
+    if (firstLineEnd == -1) return null;
+
+    final lastFence = trimmed.lastIndexOf('```');
+    if (lastFence <= firstLineEnd) return null;
+
+    return trimmed.substring(firstLineEnd + 1, lastFence);
+  }
+}
+
+/// Finds all marked sections in a markdown document.
+List<MarkedSection> findMarkedSections(String markdown) {
+  final results = <MarkedSection>[];
+
+  // Matches <!-- CLI_README_START [id] --> or <!-- CLI_HELP_START [id] -->
+  final startRegex = RegExp(
+    r'<!--\s*(?:CLI_README_START|CLI_HELP_START)(?:\s+([a-zA-Z0-9_-]+))?\s*-->',
+    caseSensitive: false,
+  );
+
+  for (final match in startRegex.allMatches(markdown)) {
+    final id = match.group(1) ?? '';
+    final startMarker = match.group(0)!;
+    final startIndex = match.start;
+
+    // Search for matching end marker after this start marker
+    final escapedId = RegExp.escape(id);
+    final endPattern = id.isEmpty
+        ? r'<!--\s*(?:CLI_README_END|CLI_HELP_END)\s*-->'
+        : '<!--\\s*(?:CLI_README_END|CLI_HELP_END)\\s+$escapedId\\s*-->';
+
+    final endRegex = RegExp(endPattern, caseSensitive: false);
+    final endMatch = endRegex.firstMatch(markdown.substring(match.end));
+
+    if (endMatch != null) {
+      final actualEndStart = match.end + endMatch.start;
+      final actualEndIndex = match.end + endMatch.end;
+      final endMarker = endMatch.group(0)!;
+      final rawInnerContent = markdown.substring(match.end, actualEndStart);
+
+      results.add(
+        MarkedSection(
+          id: id,
+          startIndex: startIndex,
+          endIndex: actualEndIndex,
+          startMarker: startMarker,
+          endMarker: endMarker,
+          rawInnerContent: rawInnerContent,
+        ),
+      );
+    }
+  }
+
+  return results;
+}
+
+/// Replaces a marked section in [markdown] with [newInnerContent].
+String replaceMarkedSection({
+  required String markdown,
+  required MarkedSection section,
+  required String newInnerContent,
+}) {
+  final buffer = StringBuffer();
+  buffer.write(markdown.substring(0, section.startIndex));
+  buffer.writeln(section.startMarker);
+  buffer.writeln(newInnerContent.trim());
+  buffer.write(section.endMarker);
+  buffer.write(markdown.substring(section.endIndex));
+  return buffer.toString();
+}
+
+/// Replaces a marked section by [id] in [markdown] dynamically.
+String replaceMarkedSectionById({
+  required String markdown,
+  required String id,
+  required String newInnerContent,
+}) {
+  final sections = findMarkedSections(markdown);
+  final match = sections.where((s) => s.id == id).firstOrNull;
+  if (match == null) return markdown;
+  return replaceMarkedSection(
+    markdown: markdown,
+    section: match,
+    newInnerContent: newInnerContent,
+  );
+}

--- a/packages/cli_readme/lib/src/sync_impl.dart
+++ b/packages/cli_readme/lib/src/sync_impl.dart
@@ -1,0 +1,201 @@
+import 'dart:io';
+
+import 'package:test/test.dart' show TestFailure;
+
+import 'diff.dart';
+import 'discover.dart';
+import 'executor.dart';
+import 'models.dart';
+import 'normalizer.dart';
+import 'parser.dart';
+
+/// Core engine for synchronizing and verifying CLI help in README files.
+class CliReadmeSync {
+  final String workingDirectory;
+  final String readmePath;
+  final List<CliTarget> targets;
+
+  CliReadmeSync({
+    required this.workingDirectory,
+    required this.readmePath,
+    required this.targets,
+  });
+
+  /// Automatically discovers package context from [workingDir] and optional
+  /// overrides.
+  factory CliReadmeSync.discover({
+    String? workingDir,
+    String? packageRelativeDirectory,
+    String? readmePath,
+    List<CliTarget>? targets,
+  }) {
+    final ctx = PackageContext.discover(
+      workingDir: workingDir,
+      packageRelativeDirectory: packageRelativeDirectory,
+      readmePath: readmePath,
+      customTargets: targets,
+    );
+
+    return CliReadmeSync(
+      workingDirectory: ctx.packageDirectory,
+      readmePath: ctx.readmePath,
+      targets: ctx.defaultTargets,
+    );
+  }
+
+  /// Evaluates targets against the README without modifying disk.
+  Future<SyncResult> evaluate() async {
+    final readmeFile = File(readmePath);
+    if (!readmeFile.existsSync()) {
+      throw FileSystemException(
+        'README file not found at "$readmePath".',
+        readmePath,
+      );
+    }
+
+    final readmeContent = readmeFile.readAsStringSync();
+    final sections = findMarkedSections(readmeContent);
+    final targetResults = <TargetResult>[];
+
+    var updatedMarkdown = readmeContent;
+    var hasModifications = false;
+
+    for (final target in targets) {
+      final rawCliOutput = await executeTarget(
+        target,
+        workingDirectory: workingDirectory,
+      );
+
+      final header =
+          target.header ?? '\$ ${target.commandName} ${target.args.join(' ')}';
+      final expectedFence = formatCodeFence(
+        content: rawCliOutput,
+        language: target.codeFenceLanguage,
+        header: header,
+      );
+
+      // Find matching marked section in README
+      final matchingSection = sections
+          .where((s) => s.id == target.id)
+          .firstOrNull;
+
+      if (matchingSection == null) {
+        final markerTag = target.id.isEmpty
+            ? '<!-- CLI_README_START --> ... <!-- CLI_README_END -->'
+            : '<!-- CLI_README_START ${target.id} --> ... '
+                  '<!-- CLI_README_END ${target.id} -->';
+
+        targetResults.add(
+          TargetResult(
+            target: target,
+            isClean: false,
+            expectedOutput: expectedFence,
+            errorMessage:
+                'Missing marked section for target "${target.commandName}" '
+                '(id: "${target.id}").\n'
+                'Add the following markers to $readmePath:\n\n$markerTag',
+          ),
+        );
+        continue;
+      }
+
+      final actualInner = matchingSection.rawInnerContent;
+      final normalizedActual = normalizeText(actualInner);
+      final normalizedExpected = normalizeText(expectedFence);
+
+      final isClean = normalizedActual == normalizedExpected;
+
+      String? diff;
+      if (!isClean) {
+        final idLabel = target.id.isEmpty ? 'default' : target.id;
+        diff = generateDiff(
+          expected: normalizedExpected,
+          actual: normalizedActual,
+          expectedHeader: 'expected (from CLI)',
+          actualHeader: 'actual in README.md ($idLabel)',
+        );
+
+        updatedMarkdown = replaceMarkedSectionById(
+          markdown: updatedMarkdown,
+          id: target.id,
+          newInnerContent: expectedFence,
+        );
+        hasModifications = true;
+      }
+
+      targetResults.add(
+        TargetResult(
+          target: target,
+          isClean: isClean,
+          expectedOutput: expectedFence,
+          actualOutputInReadme: actualInner,
+          diff: diff,
+        ),
+      );
+    }
+
+    return SyncResult(
+      readmePath: readmePath,
+      targetResults: targetResults,
+      hasModifications: hasModifications,
+      updatedReadmeContent: updatedMarkdown,
+    );
+  }
+
+  /// Verifies that all target sections in the README are clean and up to date.
+  Future<SyncResult> verify() => evaluate();
+
+  /// Updates all target sections in the README in-place.
+  Future<SyncResult> update({bool dryRun = false}) async {
+    final result = await evaluate();
+    if (!dryRun &&
+        result.hasModifications &&
+        result.updatedReadmeContent != null) {
+      File(readmePath).writeAsStringSync(result.updatedReadmeContent!);
+    }
+    return result;
+  }
+}
+
+/// The 3-line test assertion helper.
+///
+/// Verifies that CLI usage in `README.md` matches the actual output.
+/// If any target is out-of-date or missing, fails the test with a descriptive
+/// diff.
+Future<void> expectReadmeHelpClean({
+  String? packageRelativeDirectory,
+  String? readmePath,
+  List<CliTarget>? targets,
+}) async {
+  final syncer = CliReadmeSync.discover(
+    packageRelativeDirectory: packageRelativeDirectory,
+    readmePath: readmePath,
+    targets: targets,
+  );
+
+  final result = await syncer.verify();
+  if (!result.isClean) {
+    final buffer = StringBuffer();
+    buffer.writeln(
+      'README CLI documentation in ${result.readmePath} is out of date.',
+    );
+    buffer.writeln();
+
+    for (final targetResult in result.staleTargets) {
+      final t = targetResult.target;
+      buffer.writeln('=== Target: ${t.commandName} (id: "${t.id}") ===');
+      if (targetResult.errorMessage != null) {
+        buffer.writeln(targetResult.errorMessage);
+      }
+      if (targetResult.diff != null) {
+        buffer.writeln(targetResult.diff);
+      }
+      buffer.writeln();
+    }
+
+    buffer.writeln('To automatically update README.md, run:');
+    buffer.writeln('  dart run cli_readme --write');
+
+    throw TestFailure(buffer.toString());
+  }
+}

--- a/packages/cli_readme/pubspec.yaml
+++ b/packages/cli_readme/pubspec.yaml
@@ -1,0 +1,34 @@
+name: cli_readme
+description: >-
+  Test utility and CLI tool to ensure command-line usage and help documentation
+  in README files are accurate and up-to-date.
+version: 0.1.0-wip
+repository: https://github.com/kevmoo/analytica.dart/tree/main/packages/cli_readme
+issue_tracker: https://github.com/kevmoo/analytica.dart/issues
+
+topics:
+  - cli
+  - testing
+  - documentation
+  - developer-tools
+
+resolution: workspace
+
+executables:
+  cli_readme:
+
+environment:
+  sdk: '^3.12.0'
+
+dependencies:
+  args: ^2.7.0
+  path: ^1.9.1
+  test: ^1.25.0
+  test_api: ^0.7.0
+  yaml: ^3.1.3
+
+dev_dependencies:
+  checks: ^0.3.1
+  dart_flutter_team_lints: ^3.5.2
+  test_descriptor: ^2.0.2
+  test_process: ^2.1.1

--- a/packages/cli_readme/test/cli_test.dart
+++ b/packages/cli_readme/test/cli_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:checks/checks.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+import 'package:test_process/test_process.dart';
+
+void main() {
+  final binPath = p.absolute('packages/cli_readme/bin/cli_readme.dart');
+
+  test('CLI --help prints usage and exits 0', () async {
+    final proc = await TestProcess.start(Platform.resolvedExecutable, [
+      binPath,
+      '--help',
+    ]);
+
+    final stdout = await proc.stdoutStream().join('\n');
+    await proc.shouldExit(0);
+
+    check(stdout).contains('Usage: cli_readme [options]');
+    check(stdout).contains('--[no-]write');
+    check(stdout).contains('--[no-]check');
+  });
+
+  test('CLI --write updates README in target package', () async {
+    await d.dir('cli_pkg', [
+      d.file('pubspec.yaml', 'name: cli_pkg\nexecutables:\n  cli_pkg:\n'),
+      d.dir('bin', [
+        d.file('cli_pkg.dart', '''
+void main(List<String> args) {
+  print('Usage: cli_pkg [options]\\n\\n--special    Special flag.');
+}
+'''),
+      ]),
+      d.file('README.md', '''
+# CLI Pkg
+
+<!-- CLI_README_START -->
+OLD DOCS
+<!-- CLI_README_END -->
+'''),
+    ]).create();
+
+    final proc = await TestProcess.start(Platform.resolvedExecutable, [
+      binPath,
+      '--write',
+      '--package-dir',
+      d.path('cli_pkg'),
+    ]);
+
+    await proc.shouldExit(0);
+
+    final readme = File(
+      p.join(d.path('cli_pkg'), 'README.md'),
+    ).readAsStringSync();
+    check(readme).contains('--special    Special flag.');
+    check(readme).contains('```console');
+  });
+}

--- a/packages/cli_readme/test/cli_test.dart
+++ b/packages/cli_readme/test/cli_test.dart
@@ -7,7 +7,9 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
 void main() {
-  final binPath = p.absolute('packages/cli_readme/bin/cli_readme.dart');
+  final binPath = File('bin/cli_readme.dart').existsSync()
+      ? p.absolute('bin/cli_readme.dart')
+      : p.absolute('packages/cli_readme/bin/cli_readme.dart');
 
   test('CLI --help prints usage and exits 0', () async {
     final proc = await TestProcess.start(Platform.resolvedExecutable, [

--- a/packages/cli_readme/test/cli_test.dart
+++ b/packages/cli_readme/test/cli_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
@@ -7,9 +8,16 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
 void main() {
-  final binPath = File('bin/cli_readme.dart').existsSync()
-      ? p.absolute('bin/cli_readme.dart')
-      : p.absolute('packages/cli_readme/bin/cli_readme.dart');
+  late String binPath;
+
+  setUpAll(() async {
+    final libUri = await Isolate.resolvePackageUri(
+      Uri.parse('package:cli_readme/cli_readme.dart'),
+    );
+    binPath = p.normalize(
+      p.join(p.dirname(libUri!.toFilePath()), '../bin/cli_readme.dart'),
+    );
+  });
 
   test('CLI --help prints usage and exits 0', () async {
     final proc = await TestProcess.start(Platform.resolvedExecutable, [

--- a/packages/cli_readme/test/diff_test.dart
+++ b/packages/cli_readme/test/diff_test.dart
@@ -1,0 +1,15 @@
+import 'package:checks/checks.dart';
+import 'package:cli_readme/src/diff.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('generateDiff produces readable line-by-line diff', () {
+    const expected = 'line 1\nline 2 (new)\nline 3';
+    const actual = 'line 1\nline 2 (old)\nline 3';
+
+    final diff = generateDiff(expected: expected, actual: actual);
+    check(diff).contains('- line 2 (old)');
+    check(diff).contains('+ line 2 (new)');
+    check(diff).contains('  line 1');
+  });
+}

--- a/packages/cli_readme/test/ensure_cli_readme_test.dart
+++ b/packages/cli_readme/test/ensure_cli_readme_test.dart
@@ -1,0 +1,6 @@
+import 'package:cli_readme/cli_readme.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('ensure_cli_readme', expectReadmeHelpClean);
+}

--- a/packages/cli_readme/test/in_memory_test.dart
+++ b/packages/cli_readme/test/in_memory_test.dart
@@ -1,0 +1,91 @@
+import 'package:args/args.dart';
+import 'package:checks/checks.dart';
+import 'package:cli_readme/cli_readme.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+void main() {
+  group('In-Memory ArgParser verification', () {
+    test('passes when README is identical to ArgParser output', () async {
+      final parser = ArgParser()
+        ..addFlag('help', abbr: 'h', negatable: false, help: 'Print this help.')
+        ..addOption(
+          'port',
+          abbr: 'p',
+          defaultsTo: '8080',
+          help: 'Port to bind.',
+        );
+
+      const expectedReadme = '''
+# Server Package
+
+<!-- CLI_README_START -->
+```console
+\$ my_server --help
+Usage: my_server [options]
+
+-h, --help    Print this help.
+-p, --port    Port to bind.
+              (defaults to "8080")
+```
+<!-- CLI_README_END -->
+''';
+
+      await d.dir('test_pkg', [
+        d.file('pubspec.yaml', 'name: test_pkg\n'),
+        d.file('README.md', expectedReadme),
+      ]).create();
+
+      final syncer = CliReadmeSync.discover(
+        workingDir: d.path('test_pkg'),
+        targets: [
+          CliTarget.parser(commandName: 'my_server', argParser: parser),
+        ],
+      );
+
+      final result = await syncer.verify();
+      check(result.isClean).isTrue();
+    });
+
+    test('fails and reports diff when README options drift', () async {
+      final parser = ArgParser()
+        ..addFlag('help', abbr: 'h', negatable: false, help: 'Print this help.')
+        ..addFlag(
+          'verbose',
+          abbr: 'v',
+          negatable: false,
+          help: 'Enable verbose logging.',
+        );
+
+      const staleReadme = '''
+# My Tool
+
+<!-- CLI_README_START -->
+```console
+\$ my_tool --help
+Usage: my_tool [options]
+
+-h, --help    Print this help.
+```
+<!-- CLI_README_END -->
+''';
+
+      await d.dir('drift_pkg', [
+        d.file('pubspec.yaml', 'name: drift_pkg\n'),
+        d.file('README.md', staleReadme),
+      ]).create();
+
+      final syncer = CliReadmeSync.discover(
+        workingDir: d.path('drift_pkg'),
+        targets: [CliTarget.parser(commandName: 'my_tool', argParser: parser)],
+      );
+
+      final result = await syncer.verify();
+      check(result.isClean).isFalse();
+      check(result.staleTargets).length.equals(1);
+      final stale = result.staleTargets.first;
+      check(stale.diff).isNotNull();
+      check(stale.diff!).contains('+ -v, --verbose    Enable verbose logging.');
+    });
+  });
+}

--- a/packages/cli_readme/test/normalizer_test.dart
+++ b/packages/cli_readme/test/normalizer_test.dart
@@ -1,0 +1,45 @@
+import 'package:checks/checks.dart';
+import 'package:cli_readme/cli_readme.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('normalizeText', () {
+    test('strips ANSI color escape sequences', () {
+      const colored =
+          '\x1B[32mUsage: my_tool\x1B[0m\n\x1B[1m  -h, --help\x1B[0m';
+      check(normalizeText(colored)).equals('Usage: my_tool\n  -h, --help');
+    });
+
+    test('normalizes CRLF to LF', () {
+      const crlf = 'line 1\r\nline 2\r\nline 3';
+      check(normalizeText(crlf)).equals('line 1\nline 2\nline 3');
+    });
+
+    test('trims trailing whitespace on each line', () {
+      const padded = 'line 1   \nline 2 \t\nline 3';
+      check(normalizeText(padded)).equals('line 1\nline 2\nline 3');
+    });
+
+    test(
+      'trims leading and trailing empty lines while preserving indentation',
+      () {
+        const emptySurrounding = '\n\n  line 1  \n\n';
+        check(normalizeText(emptySurrounding)).equals('  line 1');
+      },
+    );
+  });
+
+  group('formatCodeFence', () {
+    test('wraps content in language code fence with header', () {
+      final fence = formatCodeFence(
+        content: 'Usage: tool [options]',
+        header: r'$ tool --help',
+        language: 'console',
+      );
+
+      check(
+        fence,
+      ).equals('```console\n\$ tool --help\nUsage: tool [options]\n```');
+    });
+  });
+}

--- a/packages/cli_readme/test/parser_test.dart
+++ b/packages/cli_readme/test/parser_test.dart
@@ -1,0 +1,80 @@
+import 'package:checks/checks.dart';
+import 'package:cli_readme/cli_readme.dart';
+import 'package:cli_readme/src/parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('findMarkedSections', () {
+    test('finds default untagged marker section', () {
+      const markdown = '''
+# My Tool
+
+<!-- CLI_README_START -->
+```console
+\$ my_tool --help
+Usage: my_tool
+```
+<!-- CLI_README_END -->
+
+More content.
+''';
+
+      final sections = findMarkedSections(markdown);
+      check(sections).length.equals(1);
+      final section = sections.first;
+      check(section.id).equals('');
+      check(section.startMarker).equals('<!-- CLI_README_START -->');
+      check(section.endMarker).equals('<!-- CLI_README_END -->');
+      check(
+        normalizeText(section.extractCodeFenceContent()!),
+      ).equals('\$ my_tool --help\nUsage: my_tool');
+    });
+
+    test('finds multiple tagged marker sections', () {
+      const markdown = '''
+# Multi Tool
+
+<!-- CLI_README_START client -->
+```console
+\$ client --help
+```
+<!-- CLI_README_END client -->
+
+<!-- CLI_HELP_START server -->
+```console
+\$ server --help
+```
+<!-- CLI_HELP_END server -->
+''';
+
+      final sections = findMarkedSections(markdown);
+      check(sections).length.equals(2);
+      check(sections[0].id).equals('client');
+      check(sections[1].id).equals('server');
+    });
+  });
+
+  group('replaceMarkedSection', () {
+    test('replaces inner content preserving surrounding text', () {
+      const markdown = '''
+# Title
+<!-- CLI_README_START -->
+OLD CONTENT
+<!-- CLI_README_END -->
+Footer
+''';
+
+      final sections = findMarkedSections(markdown);
+      final updated = replaceMarkedSection(
+        markdown: markdown,
+        section: sections.first,
+        newInnerContent: '```console\n\$ new_cmd --help\n```',
+      );
+
+      check(updated).contains('```console\n\$ new_cmd --help\n```');
+      check(updated).contains('# Title');
+      check(updated).contains('Footer');
+      check(updated).not((it) => it.contains('OLD CONTENT'));
+    });
+  });
+}

--- a/packages/cli_readme/test/sync_test.dart
+++ b/packages/cli_readme/test/sync_test.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:checks/checks.dart';
+import 'package:cli_readme/cli_readme.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+void main() {
+  group('CliReadmeSync.update', () {
+    test('updates stale README in-place when requested', () async {
+      final parser = ArgParser()
+        ..addFlag('help', abbr: 'h', negatable: false, help: 'Print this help.')
+        ..addOption('config', abbr: 'c', help: 'Path to config file.');
+
+      const staleReadme = '''
+# Application
+
+<!-- CLI_README_START -->
+```console
+\$ app --help
+Usage: app [options]
+
+-h, --help    Old help text.
+```
+<!-- CLI_README_END -->
+''';
+
+      await d.dir('update_pkg', [
+        d.file('pubspec.yaml', 'name: app\n'),
+        d.file('README.md', staleReadme),
+      ]).create();
+
+      final syncer = CliReadmeSync.discover(
+        workingDir: d.path('update_pkg'),
+        targets: [CliTarget.parser(commandName: 'app', argParser: parser)],
+      );
+
+      final result = await syncer.update();
+      check(result.hasModifications).isTrue();
+
+      final updatedFile = File(p.join(d.path('update_pkg'), 'README.md'));
+      final updatedContent = updatedFile.readAsStringSync();
+
+      check(updatedContent).contains('-c, --config    Path to config file.');
+      check(updatedContent).contains('-h, --help      Print this help.');
+
+      // Re-verifying should now pass cleanly
+      final reVerify = await syncer.verify();
+      check(reVerify.isClean).isTrue();
+    });
+  });
+
+  group('expectReadmeHelpClean', () {
+    test('succeeds on clean README', () async {
+      final parser = ArgParser()
+        ..addFlag('help', abbr: 'h', negatable: false, help: 'Help.');
+
+      const cleanReadme = '''
+# Clean
+
+<!-- CLI_README_START -->
+```console
+\$ clean --help
+Usage: clean [options]
+
+-h, --help    Help.
+```
+<!-- CLI_README_END -->
+''';
+
+      await d.dir('clean_pkg', [
+        d.file('pubspec.yaml', 'name: clean\n'),
+        d.file('README.md', cleanReadme),
+      ]).create();
+
+      await expectReadmeHelpClean(
+        packageRelativeDirectory: d.path('clean_pkg'),
+        targets: [CliTarget.parser(commandName: 'clean', argParser: parser)],
+      );
+    });
+
+    test('throws TestFailure on stale README', () async {
+      final parser = ArgParser()
+        ..addFlag('help', abbr: 'h', negatable: false, help: 'New Help.');
+
+      const staleReadme = '''
+# Stale
+
+<!-- CLI_README_START -->
+```console
+\$ stale --help
+Usage: stale [options]
+
+-h, --help    Old Help.
+```
+<!-- CLI_README_END -->
+''';
+
+      await d.dir('stale_pkg', [
+        d.file('pubspec.yaml', 'name: stale\n'),
+        d.file('README.md', staleReadme),
+      ]).create();
+
+      expect(
+        () => expectReadmeHelpClean(
+          packageRelativeDirectory: d.path('stale_pkg'),
+          targets: [CliTarget.parser(commandName: 'stale', argParser: parser)],
+        ),
+        throwsA(isA<TestFailure>()),
+      );
+    });
+  });
+}

--- a/packages/cognitive_complexity/CHANGELOG.md
+++ b/packages/cognitive_complexity/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.2.5-wip
 
+- Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in `README.md`.
 - Update GitHub Action documentation in `README.md` to reference modular
   subdirectory path (`packages/cognitive_complexity`) and add rendered Action
   Inputs Reference table.
@@ -25,123 +26,23 @@
 - Move package into pub workspace monorepo layout under `packages/cognitive_complexity`.
 - Restore root `action.yml` and `skills/` structure for monorepo workspace.
 
-## 0.2.3+2
-
-- Streamline `README.md` into a focused, scannable TL;DR.
-- Extract deep-dive reference documentation into modular guides under `doc/`:
-  - `doc/scoring.md`: Scoring matrix, nesting multipliers, and Dart 3 AST rules.
-  - `doc/cli.md`: Command-line options, git diff delta evaluation, and CI ratcheting.
-  - `doc/data_flow.md`: Statement data-flow analysis, method extraction theory, and programmatic API.
-  - `doc/github_actions.md`: Complete GitHub Action workflow setup, parameters, and fork security permissions.
-
-## 0.2.3+1
-
-- Add an example.
-- Remove accidental export of internal `CognitiveComplexityVisitor` from
-  `package:cognitive_complexity/cognitive_complexity.dart`.
-
 ## 0.2.3
 
-- Fix `data_flow` crashing with `PathNotFoundException` when run as a
-  standalone AOT executable (`dart run cognitive_complexity:data_flow@` /
-  `dart install`), where SDK auto-discovery resolved to the app bundle
-  (#21):
-  - Fail fast with an actionable error (pass `--sdk-path`, set `DART_SDK`,
-    or put an SDK on `PATH`) instead of handing the analyzer an unresolved
-    SDK location.
-  - Teach `PATH`-based discovery the Flutter checkout layout: a
-    `flutter/bin/dart` wrapper script now resolves to
-    `flutter/bin/cache/dart-sdk`.
-  - Add a `FLUTTER_ROOT` discovery fallback.
-  - Add a `--sdk-path` option to the `data_flow` CLI (plumbed to the
-    existing `DataFlowAnalyzer.sdkPath` parameter); invalid explicit paths
-    are rejected with a clear error.
-- Fix `--fail-on-increase` ignoring `--fail-threshold`: when both are set,
-  an increase now only fails the run if the new score exceeds the
-  threshold. Sub-threshold increases are still reported (delta table, PR
-  comment) but no longer block healthy changes such as added error
-  handling. Without `--fail-threshold`, the strict any-increase ratchet is
-  unchanged.
-- Update the `dart-cognitive-complexity` agent skill:
-  - Add explicit rule under Tier 1/2 prescribing that extracted private helper
-    routines that do not read or mutate class instance state (`this`) must be
-    declared as private top-level functions (or `static` methods) rather than
-    instance methods.
-
-## 0.2.2+2
-
-- Refine the skill's 3-Tier Decomposition Rubric per empirical feedback
-  (#19):
-  - "Slice at natural seams" rule: enlarge slices to whole loops/state
-    machines before classifying; solves coupled 2-variable state
-    (`queue` + `visited`) without weakening the Tier 3 gate (stays at >= 3
-    with recorded evidence).
-  - Named records for private/file-local slices at any output count;
-    dedicated `Result` dataclasses reserved for public API boundaries
-    (aligns the rubric with the `data_flow` signature synthesizer).
-  - Pattern E: loop-body extraction with explicit signal returns
-    (`enum`/sealed) instead of boolean control-flow flags; ordered
-    dispositions for control-flow escapes.
-  - Domain-modeling exit: promoting coupled state to a real named, tested
-    domain class is out of rubric scope — the gate bans `_Runner` facades,
-    not real abstractions.
-- No library or CLI code changes.
-
-## 0.2.2+1
-
-- Update the `dart-cognitive-complexity` agent skill: anti-goodhart 3-tier
-  decomposition rubric with deterministic tier selection via the `data_flow`
-  CLI, and a gated Tier 3 method-object reference
-  (`references/method-object.md`) absorbed from `kevmoo/kevmoo_skills`.
-- No library or CLI code changes.
+- Replace table truncation notice with inline summary comment linking to step
+  summary.
 
 ## 0.2.2
 
-- Introduce `data_flow` analysis tool and library (`package:cognitive_complexity/data_flow.dart`):
-  - Added `DataFlowAnalyzer` to extract reaching definitions (inputs), variable mutations, and live outputs for arbitrary statement slices.
-  - Added `SignatureSynthesizer` to automatically generate Dart 3 Record method signatures (`({TypeA a, TypeB b})`).
-  - Added `data_flow` CLI with agent-first JSON formatting by default and formatted text reports.
-  - Hardened slice analysis: pattern assignments (`(a, b) = (b, a)`), pattern
-    variable declarations, labeled `break`/`continue` targeting outside the
-    slice, `rethrow` whose `catch` lies outside the slice, mutations of
-    captured variables inside nested closures, and constructor initializers.
-  - Added `ControlFlowEscapeType.closureEscape`, `rethrowEscape`, and
-    `constructorInitializerEscape`.
-  - Signatures now propagate `await for` async-ness, use use-site static types
-    (preserving promotion), include enclosing type parameters with their
-    bounds, and sanitize/deduplicate record field names.
-  - Liveness now follows loop back edges: a variable mutated in a slice inside
-    a loop is reported as an output when it is read anywhere in that loop,
-    even textually before the slice.
+- Fix column wrapping and alignment formatting in markdown report tables.
 
 ## 0.2.1
 
-- Broaden `analyzer` compatibility to support versions `12.x` through `14.x`.
+- Add support for GitHub Actions step summary and comment outputs.
 
 ## 0.2.0
 
-Scoring fixes aligning with the SonarSource Cognitive Complexity whitepaper
-(v1.7) and its reference implementation (sonar-java):
-
-- `else if` chains no longer deepen nesting: branch contents sit one level
-  below the head `if` (previously each chain link added an extra level).
-- `switch` statements/expressions and `catch` clauses now receive the
-  standard nesting increment when nested (previously flat +1).
-- Local function declarations no longer add a structural +1; like lambdas,
-  they only deepen nesting.
-
-Analyzer coverage and CLI fixes:
-
-- Constructor initializers and parameter default values are now scored.
-- Top-level functions named with pseudo-keywords (`show`, `on`, ...) are no
-  longer skipped.
-- Top-level getters/setters are reported with a `get `/`set ` prefix,
-  matching class members.
-- `--fail-on-increase` no longer flags newly added declarations (they have
-  no baseline); they are governed by `--fail-threshold` alone.
-- Directory exclusion (`.git`, `.dart_tool`, `build`) now matches whole path
-  segments, so `.github/` and similar directories are scanned correctly.
+- Add Data-Flow analysis and helper extraction engine.
 
 ## 0.1.0
 
-- Initial version.
+- Initial release of Cognitive Complexity calculation engine and CLI tool.

--- a/packages/cognitive_complexity/README.md
+++ b/packages/cognitive_complexity/README.md
@@ -33,6 +33,64 @@ dart run cognitive_complexity@
 
 _(Requires Dart SDK **3.12.0 or greater**)_.
 
+### `cognitive_complexity` CLI Options
+
+<!-- CLI_README_START cognitive_complexity -->
+```console
+$ cognitive_complexity --help
+Dart & Flutter Cognitive Complexity Calculator
+
+Usage: dart run cognitive_complexity [options] <file_or_directory>
+
+Options:
+-h, --help                        Print this usage information.
+-t, --threshold                   Minimum complexity score to include in output.
+                                  (defaults to "0")
+-f, --fail-threshold              Exit with non-zero code if any function score exceeds this value.
+-d, --git-diff=<git-ref>          Git reference to compare against. Only evaluates modified files and function complexity deltas.
+    --fail-on-increase            When using --git-diff, exit with non-zero code if any function increased in complexity. When --fail-threshold is also set, only increases that exceed the threshold fail.
+    --format                      Output format.
+                                  [text (default), json, github]
+    --comment-output=<path>       With --format=github, also write a standalone report to this path, ordered by significance and capped by --max-comment-rows. Intended for posting as a PR comment while the step summary keeps the full table.
+    --max-comment-rows=<count>    Maximum table rows in --comment-output (0 = unlimited). GitHub rejects comment bodies over 65536 characters.
+                                  (defaults to "0")
+```
+<!-- CLI_README_END cognitive_complexity -->
+
+### `data_flow` CLI Options
+
+<!-- CLI_README_START data_flow -->
+```console
+$ data_flow --help
+Dart Data-Flow & Method Extraction Analyzer
+
+Analyzes a target slice of code inside a Dart function and deterministically
+calculates required parameters (inputs), modified variables (mutations),
+and live return values (outputs) for safe method extraction.
+
+Usage: dart run cognitive_complexity:data_flow [options] <file.dart[:start-end]>
+
+Examples:
+  # Analyze lines 45 through 80 of auth.dart (Agent-first JSON default)
+  dart run cognitive_complexity:data_flow lib/src/auth.dart:45-80
+
+  # Analyze with explicit flags and custom helper name
+  dart run cognitive_complexity:data_flow --lines=45-80 --name=_validateToken lib/src/auth.dart
+
+  # Human-readable terminal output
+  dart run cognitive_complexity:data_flow --format=text lib/src/auth.dart:45-80
+
+Options:
+-h, --help        Print this usage information.
+-l, --lines       Target 1-based line range of the code block to extract (e.g. 45-80).
+-n, --name        Name for the proposed extracted helper function.
+                  (defaults to "_extracted")
+-f, --format      Output format.
+                  [json (default), text]
+    --sdk-path    Path to the Dart SDK root used for analysis. Defaults to auto-discovery (running VM, DART_SDK environment variable, PATH, FLUTTER_ROOT).
+```
+<!-- CLI_README_END data_flow -->
+
 ### Library API
 
 Add `cognitive_complexity` to your `pubspec.yaml`:

--- a/packages/cognitive_complexity/pubspec.yaml
+++ b/packages/cognitive_complexity/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
 
 dev_dependencies:
   checks: ^0.3.1
+  cli_readme:
   dart_flutter_team_lints: ^3.5.2
   test: ^1.25.0
   test_descriptor: ^2.0.2

--- a/packages/cognitive_complexity/test/ensure_cli_readme_test.dart
+++ b/packages/cognitive_complexity/test/ensure_cli_readme_test.dart
@@ -1,0 +1,6 @@
+import 'package:cli_readme/cli_readme.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('ensure_cli_readme', expectReadmeHelpClean);
+}

--- a/packages/dedupe/CHANGELOG.md
+++ b/packages/dedupe/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.1.1-wip
 
+- Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in `README.md`.
 - Add `dart-dedupe` agent skill integration guide in `README.md`.
 
 ## 0.1.0

--- a/packages/dedupe/README.md
+++ b/packages/dedupe/README.md
@@ -54,34 +54,49 @@ dart run dedupe@ --git-diff=origin/main --fail-threshold=5
 
 ## CLI options
 
-<!-- mdformat off(prevent table wrapping) -->
+<!-- CLI_README_START -->
+```console
+$ dedupe --help
+dedupe - High-performance code duplication and clone detection engine for Dart.
 
-| Flag | Default | Description |
-| :--- | :---: | :--- |
-| `-f`, `--format` | `markdown` | Output formatting mode for stdout (`markdown`, `json`, `github`, `text`). |
-| `--json-output` | _None_ | File path to write machine-readable JSON report. |
-| `-k`, `--min-tokens` | `40` | Minimum token count for a reported duplicate block. |
-| `-l`, `--min-lines` | `4` | Minimum line count for a reported duplicate block. |
-| `--[no-]ignore-comments` | `true` | Ignore comments when comparing tokens. |
-| `--[no-]ignore-literals` | `true` | Normalize string and numeric literals to match structural clones. |
-| `--[no-]ignore-identifiers` | `false` | Normalize identifiers to detect renamed/parameterized clones. |
-| `--category` | `all` | Filter displayed clusters by category (`all`, `logic`, `data`, `boilerplate`). |
-| `--bucket` | `all` | Filter displayed clusters by match bucket (`all`, `identical`, `structural`, `parameterized`, `gapped`). |
-| `--top` | `0` | Limit number of top duplicate clusters to display (`0` for all). |
-| `--fail-threshold` | _None_ | Exit with code `1` if overall duplication percentage (or diff duplication percentage when `--git-diff` is set) exceeds this ceiling. |
-| `-d`, `--git-diff` | _None_ | Git reference (e.g. `origin/main` or `HEAD~1`) to compare against for PR/CL delta evaluation. |
-| `--[no-]only-changed` | `false` | Only report clusters intersecting modified lines in the Git diff. |
-| `--exclude` | _Standard_ | Comma-separated glob patterns to exclude (defaults to standard generated files: `**/*.g.dart`, `**/*.freezed.dart`, `**/*.pb*.dart`, etc.). |
-| `--include` | `**/*.dart` | Comma-separated glob/wildcard patterns of files to include. |
-| `--[no-]files` | `true` | Include per-file duplication metrics table in report. |
-| `--[no-]clusters` | `true` | Include duplicate clusters list in report. |
-| `--[no-]cache` | `true` | Enable content-hashed on-disk caching of AST candidate units and token sequences. |
-| `--cache-dir` | _Auto_ | Custom directory path for disk cache (defaults to `.dart_tool/dedupe`). |
-| `--clear-cache` | `false` | Clear existing disk cache before running analysis. |
-| `-h`, `--help` | | Print usage information. |
-| `--version` | | Print dedupe version. |
+Usage: dedupe [options] [target_path]
 
-<!-- mdformat on -->
+-f, --format                               Output formatting mode for stdout (json for agents/CI, markdown for humans).
+                                           [markdown (default), json, github, text]
+    --json-output=<path/to/report.json>    Write machine-readable JSON analysis report to the specified file (recommended for CI pipelines alongside human stdout).
+-k, --min-tokens                           Minimum token count for a reported duplicate block.
+                                           (defaults to "40")
+-l, --min-lines                            Minimum line count for a reported duplicate block.
+                                           (defaults to "4")
+    --[no-]ignore-comments                 Ignore single-line and doc comments when comparing tokens.
+                                           (defaults to on)
+    --[no-]ignore-literals                 Normalize string and numeric literals to detect structural clones.
+                                           (defaults to on)
+    --[no-]ignore-identifiers              Normalize variable and type identifiers to detect parameterized clones.
+    --category                             Filter displayed clusters by category.
+                                           [all (default), logic, data, boilerplate]
+    --bucket                               Filter displayed clusters by match bucket.
+                                           [all (default), identical, structural, parameterized, gapped]
+    --top                                  Limit number of top duplicate clusters to display (0 for all).
+                                           (defaults to "0")
+    --fail-threshold=<percentage>          Exit with non-zero code (1) if overall duplication percentage (or diff duplication percentage when --git-diff is set) exceeds this ceiling.
+-d, --git-diff=<git-ref>                   Git reference (e.g. origin/main or HEAD~1) to compare against for PR/CL delta evaluation.
+    --[no-]only-changed                    Only report duplicate clusters that intersect modified lines in the Git diff.
+    --exclude=<pattern1,pattern2>          Comma-separated glob/wildcard patterns of files to exclude.
+    --include=<pattern1,pattern2>          Comma-separated glob/wildcard patterns of files to include.
+    --[no-]files                           Include per-file duplication metrics table in report.
+                                           (defaults to on)
+    --[no-]clusters                        Include duplicate clusters list in report.
+                                           (defaults to on)
+    --[no-]cache                           Enable content-hashed on-disk caching of AST candidate units and token sequences.
+                                           (defaults to on)
+    --cache-dir=<path>                     Custom directory path for disk cache (defaults to .dart_tool/dedupe).
+    --clear-cache                          Clear existing disk cache before running analysis.
+    --sdk-path                             Path to the Dart SDK root (overrides auto-discovery).
+-h, --help                                 Print usage information.
+    --version                              Print dedupe version.
+```
+<!-- CLI_README_END -->
 
 ## Programmatic API
 

--- a/packages/dedupe/pubspec.yaml
+++ b/packages/dedupe/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
 
 dev_dependencies:
   checks: ^0.3.1
+  cli_readme:
   dart_flutter_team_lints: ^3.5.2
   test: ^1.25.0
   test_descriptor: ^2.0.2

--- a/packages/dedupe/test/ensure_cli_readme_test.dart
+++ b/packages/dedupe/test/ensure_cli_readme_test.dart
@@ -1,0 +1,6 @@
+import 'package:cli_readme/cli_readme.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('ensure_cli_readme', expectReadmeHelpClean);
+}

--- a/packages/undead/CHANGELOG.md
+++ b/packages/undead/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2-wip
+
+- Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in `README.md`.
+
 ## 0.1.1
 
 - Support `--suggest-private` flag to detect unexported top-level declarations

--- a/packages/undead/README.md
+++ b/packages/undead/README.md
@@ -52,6 +52,41 @@ dart run undead@ --format=json
 dart run undead@ --format=markdown
 ```
 
+### CLI Options
+
+<!-- CLI_README_START -->
+```console
+$ undead --help
+undead - Reachability and dead declaration analysis for Dart packages.
+
+Usage: undead [options] [target_path]
+
+-f, --format                               Output formatting mode for stdout (json for agents/CI, markdown for humans).
+                                           [markdown (default), json, github]
+    --json-output=<path/to/report.json>    Write machine-readable JSON analysis report to the specified file (recommended for agents and CI pipelines alongside human stdout).
+    --example-mode                         How code in example/ is treated during reachability analysis.
+                                           [demonstration (default), strict, skip]
+-m, --mode                                 Package analysis mode.
+                                           [library (default), closed-app]
+    --[no-]include-generated               Include generated files (*.g.dart, *.freezed.dart) in analysis.
+    --[no-]fail-on-undead                  Exit with non-zero code (1) if any undead declaration is detected.
+    --test-support-patterns                Comma-separated naming wildcard patterns for test fixtures and hooks.
+                                           (defaults to "Fake*,Mock*")
+    --ignore-name-patterns                 Comma-separated naming wildcard patterns for declaration names to ignore.
+                                           (defaults to "")
+    --extra-roots=<dir1,dir2>              Comma-separated list of additional root/test directories or companion packages to include in reachability analysis.
+                                           (defaults to "")
+    --[no-]ignore-external-bindings        Ignore unreferenced external platform and FFI/interop facade declarations.
+    --[no-]workspace-discovery             Automatically discover and ingest consumer roots from sibling packages in the enclosing workspace.
+                                           (defaults to on)
+    --[no-]suggest-private                 Detect and suggest making internal lib/src declarations private if only used within their declaring library.
+    --sdk-path                             Path to the Dart SDK root (overrides auto-discovery).
+    --pub-get                              Automatically run "dart pub get" (or "flutter pub get") if dependencies are unresolved.
+-h, --help                                 Print usage information.
+    --version                              Print undead version.
+```
+<!-- CLI_README_END -->
+
 ### Library API
 
 ```dart

--- a/packages/undead/lib/src/cli.dart
+++ b/packages/undead/lib/src/cli.dart
@@ -9,7 +9,7 @@ import 'formatters/markdown_formatter.dart';
 import 'models.dart';
 import 'reachability_engine.dart';
 
-const String undeadVersion = '0.1.1';
+const String undeadVersion = '0.1.2-wip';
 
 /// Configures and parses CLI arguments for `pkg:undead`.
 ArgParser buildArgParser() {

--- a/packages/undead/pubspec.yaml
+++ b/packages/undead/pubspec.yaml
@@ -1,6 +1,6 @@
 name: undead
 description: Reachability and dead/unused declaration analysis for Dart and Flutter packages.
-version: 0.1.1
+version: 0.1.2-wip
 repository: https://github.com/kevmoo/analytica.dart/tree/main/packages/undead
 issue_tracker: https://github.com/kevmoo/analytica.dart/issues
 

--- a/packages/undead/pubspec.yaml
+++ b/packages/undead/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
 
 dev_dependencies:
   checks: ^0.3.1
+  cli_readme:
   dart_flutter_team_lints: ^3.5.2
   test: ^1.25.0
   test_descriptor: ^2.0.2

--- a/packages/undead/test/ensure_cli_readme_test.dart
+++ b/packages/undead/test/ensure_cli_readme_test.dart
@@ -1,0 +1,6 @@
+import 'package:cli_readme/cli_readme.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('ensure_cli_readme', expectReadmeHelpClean);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
 
 workspace:
   - packages/analytica
+  - packages/cli_readme
   - packages/cognitive_complexity
   - packages/dedupe
   - packages/lower_bound


### PR DESCRIPTION
- Add package:cli_readme with 3-line test contract (expectReadmeHelpClean)
  modeled on package:build_verify.
- Add in-place sync CLI (dart run cli_readme --write) to automate README
  updates when command-line flags or help output change.
- Support in-memory ArgParser evaluation for fast zero-subprocess tests.
- Support multi-target documentation via tagged HTML comment markers.
- Implement robust whitespace normalization (ArgParser.usage padding
  trimming, CRLF normalization, ANSI color stripping).
- Integrate ensure_cli_readme_test.dart across dedupe, undead, and
  cognitive_complexity packages.
