### PR TITLE
feat(analytica): add package:analytica/testing.dart and unify test package resolution

### DIFF
--- a/packages/analytica/CHANGELOG.md
+++ b/packages/analytica/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.2-wip
+
+- Add `package:analytica/testing.dart` with `resolvePackageDirectory`,
+  `resolvePackageFile`, and `resolvePackageExecutable` test helpers.
+
 ## 0.1.1
 
 - Add `parseCommaSeparated` utility function in `package:analytica/cli.dart`.

--- a/packages/analytica/lib/src/testing/package_resolution.dart
+++ b/packages/analytica/lib/src/testing/package_resolution.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:path/path.dart' as p;
+
+/// Resolves the root directory path of a package given a [packageUri] string
+/// (e.g. `'package:undead/undead.dart'`).
+///
+/// Traverses up from the resolved `lib/` directory to locate the package root.
+Future<String> resolvePackageDirectory(String packageUri) async {
+  final uri = Uri.parse(packageUri);
+  if (!uri.isScheme('package') || uri.pathSegments.isEmpty) {
+    throw ArgumentError.value(
+      packageUri,
+      'packageUri',
+      'Must be a valid package: URI (e.g. "package:pkg/pkg.dart").',
+    );
+  }
+
+  final resolved = await Isolate.resolvePackageUri(uri);
+  if (resolved == null) {
+    throw StateError(
+      'Could not resolve package URI: "$packageUri". '
+      'Ensure the package is declared in dependencies or dev_dependencies.',
+    );
+  }
+
+  final filePath = resolved.toFilePath();
+  final relativeInLib = uri.pathSegments.sublist(1).join('/');
+  final libDir = (relativeInLib.isNotEmpty && filePath.endsWith(relativeInLib))
+      ? filePath.substring(0, filePath.length - relativeInLib.length)
+      : p.dirname(filePath);
+
+  return p.normalize(p.join(libDir, '..'));
+}
+
+/// Resolves a [File] relative to a package root given a [packageUri] string
+/// and a [relativePath] (e.g. `'pubspec.yaml'`).
+Future<File> resolvePackageFile(String packageUri, String relativePath) async {
+  final pkgDir = await resolvePackageDirectory(packageUri);
+  return File(p.normalize(p.join(pkgDir, relativePath)));
+}
+
+/// Resolves the absolute path to an executable in `bin/` given a [packageUri]
+/// and an optional [executableName].
+///
+/// If [executableName] is omitted, defaults to the package name (the first path
+/// segment of [packageUri]).
+Future<String> resolvePackageExecutable(
+  String packageUri, [
+  String? executableName,
+]) async {
+  final pkgDir = await resolvePackageDirectory(packageUri);
+  final exec = executableName ?? Uri.parse(packageUri).pathSegments.first;
+  final binFile = File(p.join(pkgDir, 'bin', '$exec.dart'));
+  return p.normalize(binFile.path);
+}

--- a/packages/analytica/lib/testing.dart
+++ b/packages/analytica/lib/testing.dart
@@ -1,0 +1,4 @@
+/// Testing utilities for package resolution in tests and integration suites.
+library;
+
+export 'src/testing/package_resolution.dart';

--- a/packages/analytica/pubspec.yaml
+++ b/packages/analytica/pubspec.yaml
@@ -1,6 +1,6 @@
 name: analytica
 description: Core utilities, SDK discovery, Git integration, and CI reporting for Dart analysis tools.
-version: 0.1.1
+version: 0.1.2-wip
 repository: https://github.com/kevmoo/analytica.dart/tree/main/packages/analytica
 issue_tracker: https://github.com/kevmoo/analytica.dart/issues
 

--- a/packages/analytica/test/testing_test.dart
+++ b/packages/analytica/test/testing_test.dart
@@ -1,0 +1,42 @@
+import 'package:analytica/testing.dart';
+import 'package:checks/checks.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('package_resolution', () {
+    test('resolvePackageDirectory resolves package:analytica', () async {
+      final dir = await resolvePackageDirectory(
+        'package:analytica/analytica.dart',
+      );
+      check(dir).endsWith('packages/analytica');
+    });
+
+    test('resolvePackageFile locates pubspec.yaml', () async {
+      final file = await resolvePackageFile(
+        'package:analytica/analytica.dart',
+        'pubspec.yaml',
+      );
+      check(file.existsSync()).isTrue();
+      check(file.readAsStringSync()).contains('name: analytica');
+    });
+
+    test('resolvePackageExecutable locates executable in bin/', () async {
+      final binPath = await resolvePackageExecutable(
+        'package:cognitive_complexity/cognitive_complexity.dart',
+      );
+      check(binPath).endsWith('bin/cognitive_complexity.dart');
+
+      final dataFlowBin = await resolvePackageExecutable(
+        'package:cognitive_complexity/cognitive_complexity.dart',
+        'data_flow',
+      );
+      check(dataFlowBin).endsWith('bin/data_flow.dart');
+    });
+
+    test('throws ArgumentError on non-package URI', () async {
+      await check(
+        resolvePackageDirectory('file:///foo/bar.dart'),
+      ).throws<ArgumentError>();
+    });
+  });
+}

--- a/packages/cli_readme/pubspec.yaml
+++ b/packages/cli_readme/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   yaml: ^3.1.3
 
 dev_dependencies:
+  analytica: ^0.1.2-wip
   checks: ^0.3.1
   dart_flutter_team_lints: ^3.5.2
   test_descriptor: ^2.0.2

--- a/packages/cli_readme/test/cli_test.dart
+++ b/packages/cli_readme/test/cli_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
-import 'dart:isolate';
 
+import 'package:analytica/testing.dart';
 import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -11,11 +11,8 @@ void main() {
   late String binPath;
 
   setUpAll(() async {
-    final libUri = await Isolate.resolvePackageUri(
-      Uri.parse('package:cli_readme/cli_readme.dart'),
-    );
-    binPath = p.normalize(
-      p.join(p.dirname(libUri!.toFilePath()), '../bin/cli_readme.dart'),
+    binPath = await resolvePackageExecutable(
+      'package:cli_readme/cli_readme.dart',
     );
   });
 

--- a/packages/cognitive_complexity/test/cli_test.dart
+++ b/packages/cognitive_complexity/test/cli_test.dart
@@ -1,18 +1,19 @@
 import 'dart:io';
+
+import 'package:analytica/testing.dart';
 import 'package:checks/checks.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/scaffolding.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
 void main() {
-  final binPath = File('bin/cognitive_complexity.dart').existsSync()
-      ? p.normalize(p.absolute('bin/cognitive_complexity.dart'))
-      : p.normalize(
-          p.absolute(
-            'packages/cognitive_complexity/bin/cognitive_complexity.dart',
-          ),
-        );
+  late String binPath;
+
+  setUpAll(() async {
+    binPath = await resolvePackageExecutable(
+      'package:cognitive_complexity/cognitive_complexity.dart',
+    );
+  });
 
   group('CLI Integration Tests', () {
     test('Calculates complexity and displays text table report', () async {

--- a/packages/cognitive_complexity/test/comment_output_test.dart
+++ b/packages/cognitive_complexity/test/comment_output_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:analytica/testing.dart';
 import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -69,13 +70,13 @@ int _tableRowCount(String report) =>
     report.split('\n').where((l) => l.startsWith('| ')).length;
 
 void main() {
-  final binPath = File('bin/cognitive_complexity.dart').existsSync()
-      ? p.normalize(p.absolute('bin/cognitive_complexity.dart'))
-      : p.normalize(
-          p.absolute(
-            'packages/cognitive_complexity/bin/cognitive_complexity.dart',
-          ),
-        );
+  late String binPath;
+
+  setUpAll(() async {
+    binPath = await resolvePackageExecutable(
+      'package:cognitive_complexity/cognitive_complexity.dart',
+    );
+  });
 
   group('--comment-output', () {
     late String repoPath;

--- a/packages/cognitive_complexity/test/data_flow/cli_test.dart
+++ b/packages/cognitive_complexity/test/data_flow/cli_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:analytica/testing.dart';
 import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/scaffolding.dart';
@@ -10,11 +11,14 @@ import 'package:test_process/test_process.dart';
 void main() {
   // Pin subprocesses to the SDK running the tests rather than PATH's `dart`.
   final dartExe = Platform.resolvedExecutable;
-  final binPath = File('bin/data_flow.dart').existsSync()
-      ? p.normalize(p.absolute('bin/data_flow.dart'))
-      : p.normalize(
-          p.absolute('packages/cognitive_complexity/bin/data_flow.dart'),
-        );
+  late String binPath;
+
+  setUpAll(() async {
+    binPath = await resolvePackageExecutable(
+      'package:cognitive_complexity/cognitive_complexity.dart',
+      'data_flow',
+    );
+  });
 
   group('DataFlow CLI Integration', () {
     test('Displays usage help and exits with code 0 on --help', () async {

--- a/packages/dedupe/test/cli_test.dart
+++ b/packages/dedupe/test/cli_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:analytica/testing.dart';
 import 'package:checks/checks.dart';
 import 'package:dedupe/dedupe.dart';
 import 'package:dedupe/src/cli.dart';
@@ -10,9 +11,11 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
 void main() {
-  final binPath = File('bin/dedupe.dart').existsSync()
-      ? p.normalize(p.absolute('bin/dedupe.dart'))
-      : p.normalize(p.absolute('packages/dedupe/bin/dedupe.dart'));
+  late String binPath;
+
+  setUpAll(() async {
+    binPath = await resolvePackageExecutable('package:dedupe/dedupe.dart');
+  });
 
   Future<TestProcess> runDedupe(List<String> args, {String? workingDirectory}) {
     return TestProcess.start(Platform.resolvedExecutable, [

--- a/packages/dedupe/test/version_test.dart
+++ b/packages/dedupe/test/version_test.dart
@@ -1,16 +1,14 @@
-import 'dart:io';
-
+import 'package:analytica/testing.dart';
 import 'package:checks/checks.dart';
 import 'package:dedupe/src/engine.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('dedupeVersion matches pubspec.yaml', () {
-    final pubspecFile =
-        File('pubspec.yaml').existsSync() &&
-            File('pubspec.yaml').readAsStringSync().contains('name: dedupe')
-        ? File('pubspec.yaml')
-        : File('packages/dedupe/pubspec.yaml');
+  test('dedupeVersion matches pubspec.yaml', () async {
+    final pubspecFile = await resolvePackageFile(
+      'package:dedupe/dedupe.dart',
+      'pubspec.yaml',
+    );
     check(pubspecFile.existsSync()).isTrue();
 
     final content = pubspecFile.readAsStringSync();

--- a/packages/lower_bound/pubspec.yaml
+++ b/packages/lower_bound/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   pubspec_parse: ^1.5.0
 
 dev_dependencies:
+  analytica: ^0.1.2-wip
   checks: ^0.3.1
   dart_flutter_team_lints: ^3.5.2
   test: ^1.25.0

--- a/packages/lower_bound/test/cli_test.dart
+++ b/packages/lower_bound/test/cli_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:analytica/testing.dart';
 import 'package:checks/checks.dart';
 import 'package:lower_bound/src/cli.dart';
 import 'package:lower_bound/src/sdk_discovery.dart';
@@ -9,26 +10,14 @@ import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
-String _resolveBinPath() {
-  var dir = Directory.current;
-  while (true) {
-    final candidate = File(
-      p.join(dir.path, 'packages', 'lower_bound', 'bin', 'lower_bound.dart'),
-    );
-    if (candidate.existsSync()) return candidate.path;
-
-    final direct = File(p.join(dir.path, 'bin', 'lower_bound.dart'));
-    if (direct.existsSync()) return direct.path;
-
-    final parent = dir.parent;
-    if (parent.path == dir.path) break;
-    dir = parent;
-  }
-  return p.join(Directory.current.path, 'bin', 'lower_bound.dart');
-}
-
 void main() {
-  final binPath = _resolveBinPath();
+  late String binPath;
+
+  setUpAll(() async {
+    binPath = await resolvePackageExecutable(
+      'package:lower_bound/lower_bound.dart',
+    );
+  });
 
   group('CLI Options & Resolution', () {
     test('displays help with --help and exits 0', () async {

--- a/packages/undead/test/cli_test.dart
+++ b/packages/undead/test/cli_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:analytica/testing.dart';
 import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -27,9 +28,11 @@ d.DirectoryDescriptor packageConfig(String pkgName) {
 }
 
 void main() {
-  final binPath = File('bin/undead.dart').existsSync()
-      ? p.normalize(p.absolute('bin/undead.dart'))
-      : p.normalize(p.absolute('packages/undead/bin/undead.dart'));
+  late String binPath;
+
+  setUpAll(() async {
+    binPath = await resolvePackageExecutable('package:undead/undead.dart');
+  });
 
   Future<TestProcess> runUndead(List<String> args, {String? workingDirectory}) {
     return TestProcess.start(Platform.resolvedExecutable, [

--- a/packages/undead/test/version_test.dart
+++ b/packages/undead/test/version_test.dart
@@ -1,18 +1,15 @@
-import 'dart:io';
-
+import 'package:analytica/testing.dart';
 import 'package:checks/checks.dart';
 import 'package:test/test.dart';
 import 'package:undead/src/cli.dart';
 import 'package:yaml/yaml.dart';
 
 void main() {
-  test('undeadVersion matches pubspec.yaml', () {
-    final pubspecFile =
-        File('pubspec.yaml').existsSync() &&
-            (loadYaml(File('pubspec.yaml').readAsStringSync()) as YamlMap)
-                .containsKey('version')
-        ? File('pubspec.yaml')
-        : File('packages/undead/pubspec.yaml');
+  test('undeadVersion matches pubspec.yaml', () async {
+    final pubspecFile = await resolvePackageFile(
+      'package:undead/undead.dart',
+      'pubspec.yaml',
+    );
     check(pubspecFile.existsSync()).isTrue();
 
     final content = pubspecFile.readAsStringSync();

--- a/packages/undead/test/wildcards_test.dart
+++ b/packages/undead/test/wildcards_test.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
+
+import 'package:analytica/testing.dart';
 import 'package:checks/checks.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
@@ -26,9 +27,11 @@ d.DirectoryDescriptor packageConfig(String pkgName) {
 }
 
 void main() {
-  final binPath = File('bin/undead.dart').existsSync()
-      ? p.normalize(p.absolute('bin/undead.dart'))
-      : p.normalize(p.absolute('packages/undead/bin/undead.dart'));
+  late String binPath;
+
+  setUpAll(() async {
+    binPath = await resolvePackageExecutable('package:undead/undead.dart');
+  });
 
   Future<TestProcess> runUndead(List<String> args, {String? workingDirectory}) {
     return TestProcess.start(Platform.resolvedExecutable, [


### PR DESCRIPTION
- Add resolvePackageDirectory, resolvePackageFile, and
  resolvePackageExecutable to package:analytica/testing.dart.
- Bump package:analytica to 0.1.2-wip and update CHANGELOG.md.
- Add unit tests for testing utilities in test/testing_test.dart.
- Migrate tests across cli_readme, cognitive_complexity, dedupe, undead,
  and lower_bound to use package:analytica/testing.dart instead of brittle
  CWD file checks.
