### PR TITLE
feat(skills): pin published package version constraints and enforce sync gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 ## Workspace Structure
 
-- This repository is a Dart pub workspace monorepo containing multiple packages under `packages/`:
+- This repository is a Dart pub workspace monorepo containing multiple packages
+  under `packages/`:
   - `packages/analytica`
   - `packages/cognitive_complexity`
   - `packages/dedupe`
@@ -10,20 +11,29 @@
 
 ## Testing Instructions
 
-- Leverage multi-core execution by running package test suites concurrently in parallel across all packages:
+- Leverage multi-core execution by running package test suites concurrently in
+  parallel across all packages:
   ```bash
   pids=(); for pkg in packages/*; do [ -d "$pkg/test" ] && (echo "Starting $pkg..." && cd "$pkg" && dart test) & pids+=($!); done; status=0; for pid in "${pids[@]}"; do wait "$pid" || status=1; done; exit $status
   ```
-- To run tests for an individual package: `(cd packages/<package_name> && dart test)`.
+- To run tests for an individual package:
+  `(cd packages/<package_name> && dart test)`.
 
 ## Code Quality & Verification
 
 - Run `dart format --output=none --set-exit-if-changed .` before committing.
 - Run `dart analyze --fatal-infos` across the workspace.
-- Update `CHANGELOG.md` in the affected package under `packages/<package_name>/CHANGELOG.md` before landing.
+- Update `CHANGELOG.md` in the affected package under
+  `packages/<package_name>/CHANGELOG.md` before landing.
 
 ## Skill / Package Synchronization Invariant
 
-- **Strict Gating for Skill Updates**: Never commit or deploy updates to `skills/*/SKILL.md` (or external skill repositories) that reference new CLI flags, changed argument schemas, or bumped version constraints until the corresponding package release has been published and is resolvable on `pub.dev`.
-- **Pinned Version Formats in Skills**: Always format remote execution commands in `SKILL.md` with explicit SemVer constraints matching published versions (e.g. `dart run cognitive_complexity@^0.2.4`, `dart run dedupe@^0.1.0`, `dart run undead@^0.1.1`).
-
+- **Strict Gating for Skill Updates**: Never commit or deploy updates to
+  `skills/*/SKILL.md` (or external skill repositories) that reference new CLI
+  flags, changed argument schemas, or bumped version constraints until the
+  corresponding package release has been published and is resolvable on
+  `pub.dev`.
+- **Pinned Version Formats in Skills**: Always format remote execution commands
+  in `SKILL.md` with explicit SemVer constraints matching published versions
+  (e.g. `dart run cognitive_complexity@^0.2.4`, `dart run dedupe@^0.1.0`,
+  `dart run undead@^0.1.1`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,9 @@
 - Run `dart format --output=none --set-exit-if-changed .` before committing.
 - Run `dart analyze --fatal-infos` across the workspace.
 - Update `CHANGELOG.md` in the affected package under `packages/<package_name>/CHANGELOG.md` before landing.
+
+## Skill / Package Synchronization Invariant
+
+- **Strict Gating for Skill Updates**: Never commit or deploy updates to `skills/*/SKILL.md` (or external skill repositories) that reference new CLI flags, changed argument schemas, or bumped version constraints until the corresponding package release has been published and is resolvable on `pub.dev`.
+- **Pinned Version Formats in Skills**: Always format remote execution commands in `SKILL.md` with explicit SemVer constraints matching published versions (e.g. `dart run cognitive_complexity@^0.2.4`, `dart run dedupe@^0.1.0`, `dart run undead@^0.1.1`).
+

--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -43,7 +43,7 @@ Rely on deterministic evaluation to target structures matching these indicators:
 Execute the official package CLI directly in the terminal to retrieve exact
 complexity scores deterministically without LLM arithmetic or AST interpretation.
 
-> **SDK Compatibility Note**: Executing `dart run cognitive_complexity@` requires
+> **SDK Compatibility Note**: Executing `dart run cognitive_complexity@^0.2.4` requires
 > Dart SDK version **3.12.0 or greater** installed in the host environment. Verify
 > compatibility via `dart --version` before initiating scans.
 
@@ -54,7 +54,7 @@ When the user references a discrete component (e.g., "check complexity in
 `lib/src/auth/`" or "audit `order_service.dart`"), pass explicit targets:
 
 ```bash
-dart run cognitive_complexity@ --threshold 15 lib/src/auth/
+dart run cognitive_complexity@^0.2.4 --threshold 15 lib/src/auth/
 ```
 
 ### Scope 2: Delta (Pull Request, Branch, or Pre-flight Audit)
@@ -62,7 +62,7 @@ When reviewing a feature branch, active commit stack, or PR, avoid full-project
 scanning. Isolate evaluation strictly to modified declarations against trunk:
 
 ```bash
-dart run cognitive_complexity@ --git-diff origin/main --fail-threshold 15 --fail-on-increase
+dart run cognitive_complexity@^0.2.4 --git-diff origin/main --fail-threshold 15 --fail-on-increase
 ```
 
 With both flags set, only increases that exceed the threshold fail — healthy
@@ -76,10 +76,10 @@ When invoked without targeting parameters ("scan my project for complexity" or
 
 ```bash
 # Production logic target (threshold 15)
-dart run cognitive_complexity@ --threshold 15 lib/
+dart run cognitive_complexity@^0.2.4 --threshold 15 lib/
 
 # Test harness target (threshold 40)
-dart run cognitive_complexity@ --threshold 40 test/
+dart run cognitive_complexity@^0.2.4 --threshold 40 test/
 ```
 
 ---
@@ -246,7 +246,7 @@ statement-level data-flow analyzer (on-demand form; same SDK 3.12.0+
 requirement as the scanner) on each line slice you intend to extract:
 
 ```bash
-dart run cognitive_complexity:data_flow@ lib/src/my_file.dart:45-80
+dart run cognitive_complexity:data_flow@^0.2.4 lib/src/my_file.dart:45-80
 ```
 
 Its report (`inputs`, `mutations`, live `outputs`, control-flow escapes, and
@@ -398,7 +398,7 @@ when the loop body alone is the hotspot.
 
 Run these verification commands before committing refactored code:
 
-1. **Complexity Audit**: Run `dart run cognitive_complexity@
+1. **Complexity Audit**: Run `dart run cognitive_complexity@^0.2.4
    --fail-threshold 15 <refactored files>` scoped to the files you touched.
    Pre-existing breaches elsewhere in the project do not invalidate the
    refactor.
@@ -448,7 +448,7 @@ To reproduce or re-evaluate cognitive complexity scores:
 
 <!-- If statement data-flow analysis was used during decomposition: -->
 ```bash
-dart run cognitive_complexity:data_flow@ {file}:{start_line}-{end_line}
+dart run cognitive_complexity:data_flow@^0.2.4 {file}:{start_line}-{end_line}
 ```
 ````
 

--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -5,8 +5,8 @@ description: >-
   deterministic CLI tooling and architectural refactoring patterns (exhaustive
   pattern matching, guard clauses, method decomposition). Use when reviewing
   codebase readability, remediating high-complexity warnings, or analyzing
-  structural code health. Don't use for general code formatting, simple syntactic
-  lints, or non-Dart/Flutter repositories.
+  structural code health. Don't use for general code formatting, simple
+  syntactic lints, or non-Dart/Flutter repositories.
 license: Apache-2.0
 key_features:
   - Automated CLI evaluation
@@ -27,13 +27,15 @@ and punishes declarative table switches), Cognitive Complexity measures the
 mental friction required for a human engineer to read and simulate control flow.
 Rely on deterministic evaluation to target structures matching these indicators:
 
-* **Deeply Nested Control Flow**: Functions exhibiting multiple layers of enclosing
-  conditionals (`if`, `for`, `while`), where horizontal indentation obscures logic.
-* **Convoluted Conditional Trees**: Functions employing verbose `if-else` or
+- **Deeply Nested Control Flow**: Functions exhibiting multiple layers of
+  enclosing conditionals (`if`, `for`, `while`), where horizontal indentation
+  obscures logic.
+- **Convoluted Conditional Trees**: Functions employing verbose `if-else` or
   `else if` chains instead of modern Dart 3 exhaustive pattern matching or
   table-driven switch expressions.
-* **Monolithic Method Bodies**: Functions breaching operational threshold ceilings.
-* **God Classes**: Logic classes exceeding structural line-count targets
+- **Monolithic Method Bodies**: Functions breaching operational threshold
+  ceilings.
+- **God Classes**: Logic classes exceeding structural line-count targets
   (excluding declarative Flutter `build` methods).
 
 ---
@@ -41,15 +43,18 @@ Rely on deterministic evaluation to target structures matching these indicators:
 ## 2. Automated Execution & Scope Resolution
 
 Execute the official package CLI directly in the terminal to retrieve exact
-complexity scores deterministically without LLM arithmetic or AST interpretation.
+complexity scores deterministically without LLM arithmetic or AST
+interpretation.
 
-> **SDK Compatibility Note**: Executing `dart run cognitive_complexity@^0.2.4` requires
-> Dart SDK version **3.12.0 or greater** installed in the host environment. Verify
-> compatibility via `dart --version` before initiating scans.
+> **SDK Compatibility Note**: Executing `dart run cognitive_complexity@^0.2.4`
+> requires Dart SDK version **3.12.0 or greater** installed in the host
+> environment. Verify compatibility via `dart --version` before initiating
+> scans.
 
 Select the execution scope based on the user's task instructions:
 
 ### Scope 1: Targeted (Specific File, Directory, or Class)
+
 When the user references a discrete component (e.g., "check complexity in
 `lib/src/auth/`" or "audit `order_service.dart`"), pass explicit targets:
 
@@ -58,6 +63,7 @@ dart run cognitive_complexity@^0.2.4 --threshold 15 lib/src/auth/
 ```
 
 ### Scope 2: Delta (Pull Request, Branch, or Pre-flight Audit)
+
 When reviewing a feature branch, active commit stack, or PR, avoid full-project
 scanning. Isolate evaluation strictly to modified declarations against trunk:
 
@@ -71,6 +77,7 @@ blocking. Omit `--fail-threshold` only when a strict any-increase ratchet is
 explicitly desired.
 
 ### Scope 3: Whole-Project (Default Naked Invocation)
+
 When invoked without targeting parameters ("scan my project for complexity" or
 `/cognitive-complexity`), audit the standard source and test roots:
 
@@ -86,13 +93,13 @@ dart run cognitive_complexity@^0.2.4 --threshold 40 test/
 
 ## 3. Actionable Thresholds & Calibration
 
-* **Production Logic Functions**: Target score `<= 15`. Functions exceeding 15 points
-  mandate architectural refactoring.
-* **Test Methods (`_test.dart`)**: Target score `<= 40`. Test suites tolerate higher
-  setup sequences before decomposition is required.
-* **Class Size Ceiling**: Logic classes (services, domain objects, controllers)
+- **Production Logic Functions**: Target score `<= 15`. Functions exceeding 15
+  points mandate architectural refactoring.
+- **Test Methods (`_test.dart`)**: Target score `<= 40`. Test suites tolerate
+  higher setup sequences before decomposition is required.
+- **Class Size Ceiling**: Logic classes (services, domain objects, controllers)
   should remain `<= 150` non-comment lines.
-* **Flutter UI Calibration**: Do not enforce the 150 LOC class ceiling on
+- **Flutter UI Calibration**: Do not enforce the 150 LOC class ceiling on
   declarative Flutter `build` methods, as widget wrappers consume vertical space
   without increasing cognitive logic load. Instead, enforce a **Widget Tree
   Nesting Ceiling** of maximum 5 horizontal indentation levels before extracting
@@ -107,18 +114,24 @@ to autonomously refactor the entire repository. To prevent unwanted diff bloat
 and preserve historical code stability, adhere to a strict 2-stage workflow:
 
 ### Stage 1: Read-Only Audit & Reporting (Mandatory Stop)
-When threshold breaches are detected, **do not mutate code immediately**.
-Output a ranked Markdown **Complexity Triage Report** directly in chat (or to an
+
+When threshold breaches are detected, **do not mutate code immediately**. Output
+a ranked Markdown **Complexity Triage Report** directly in chat (or to an
 artifact for extensive findings) containing:
-* Flagged function name and clickable file local path.
-* Current complexity score versus operational ceiling.
-* Recommended refactoring strategy (Pattern A, B, D, E, or a Pattern C tier) and unit test status.
+
+- Flagged function name and clickable file local path.
+- Current complexity score versus operational ceiling.
+- Recommended refactoring strategy (Pattern A, B, D, E, or a Pattern C tier) and
+  unit test status.
 
 ### Stage 2: Interactive User Selection (Confirmation Gate)
+
 Pause execution and prompt the user (via interactive choice or chat) to select
 the desired sequencing:
-1. **(Recommended) Refactor Top Hotspot Only**: Target the single highest-scoring
-   declaration first, verify via unit tests, and present diffs cleanly.
+
+1. **(Recommended) Refactor Top Hotspot Only**: Target the single
+   highest-scoring declaration first, verify via unit tests, and present diffs
+   cleanly.
 2. **Selective Batch Refactor**: Remediate a user-specified subset of functions.
 3. **Report-Only / Exit**: Acknowledge complexity scores without code mutation.
 
@@ -130,20 +143,22 @@ the desired sequencing:
 
 ## 5. Pre-Refactoring Assessment & Test Coverage Gate
 
-High cognitive complexity strongly correlates with brittle, untested legacy logic.
-Before undertaking structural refactoring on flagged functions, enforce this
-verification baseline:
+High cognitive complexity strongly correlates with brittle, untested legacy
+logic. Before undertaking structural refactoring on flagged functions, enforce
+this verification baseline:
 
 1. **Test Harness Mapping**: Confirm an accompanying unit test file exists for
    the target declaration (e.g., `lib/src/foo.dart` -> `test/foo_test.dart`).
 2. **Coverage Audit & Execution**:
-   * If the **`dart-collect-coverage`** companion skill is available in your
+   - If the **`dart-collect-coverage`** companion skill is available in your
      agent runtime, invoke it to check line and branch coverage on the targeted
      declarations.
-   * At minimum, execute the relevant test suite (`dart test test/foo_test.dart`)
-     to confirm a passing green regression baseline before touching code.
+   - At minimum, execute the relevant test suite
+     (`dart test test/foo_test.dart`) to confirm a passing green regression
+     baseline before touching code.
 3. **Low-Coverage Safety Gate**: If tests are missing or coverage around the
    flagged function is inadequate, pause execution and explicitly warn the user:
+
    > ⚠️ **Low Test Coverage Warning**: Function `<name>` in `<path>` lacks unit
    > test coverage. Structural refactoring risks silent behavioral regression.
 
@@ -155,17 +170,18 @@ verification baseline:
 
 ## 6. Dart Refactoring Patterns
 
-When remediation is required for declarations flagged by the scanner, apply these
-Dart-specific architectural refactorings:
+When remediation is required for declarations flagged by the scanner, apply
+these Dart-specific architectural refactorings:
 
 ### Pattern A: Replace Nested If-Else with Dart 3 Switch Expression
 
 In Dart 3, an entire exhaustive switch expression incurs a single base penalty,
-regardless of how many pattern arms it contains. Converting deeply nested `if-else`
-trees into declarative tables removes repeated branching penalties and flattens
-nesting.
+regardless of how many pattern arms it contains. Converting deeply nested
+`if-else` trees into declarative tables removes repeated branching penalties and
+flattens nesting.
 
 #### Before: Nested Conditional Ladders (Score: 11)
+
 ```dart
 int resolveTimeout(String protocol, bool isSecure, int retryCount) {
   if (protocol == 'http') {
@@ -186,6 +202,7 @@ int resolveTimeout(String protocol, bool isSecure, int retryCount) {
 ```
 
 #### After: Table-Driven Switch Expression (Score: 1)
+
 ```dart
 int resolveTimeout(String protocol, bool isSecure, int retryCount) =>
     switch ((protocol, isSecure, retryCount)) {
@@ -207,6 +224,7 @@ Invert conditional checks into early guard return statements
 multiplication from subsequent downstream logic.
 
 #### Before: Pyramid of Nesting (Score: 11)
+
 ```dart
 Future<void> syncPayload(User? user, Payload? data) async {
   if (user != null) {
@@ -222,6 +240,7 @@ Future<void> syncPayload(User? user, Payload? data) async {
 ```
 
 #### After: Early Exit Guard Clauses (Score: 5)
+
 ```dart
 Future<void> syncPayload(User? user, Payload? data) async {
   if (user == null || !user.hasPermission) return;
@@ -237,101 +256,103 @@ Future<void> syncPayload(User? user, Payload? data) async {
 
 ### Pattern C: The 3-Tier Decomposition Rubric (Anti-Goodhart)
 
-**Anti-Goodhart Guardrail**: Do NOT blindly wrap monolithic functions in single-use runner classes with mutable instance variables just to bring scores below 15. Reducing the metric must never sacrifice transparent data flow or hide bugs.
+**Anti-Goodhart Guardrail**: Do NOT blindly wrap monolithic functions in
+single-use runner classes with mutable instance variables just to bring scores
+below 15. Reducing the metric must never sacrifice transparent data flow or hide
+bugs.
 
 #### Deterministic Tier Selection via `data_flow`
 
 Do not eyeball which tier a candidate slice belongs to. Run the companion
-statement-level data-flow analyzer (on-demand form; same SDK 3.12.0+
-requirement as the scanner) on each line slice you intend to extract:
+statement-level data-flow analyzer (on-demand form; same SDK 3.12.0+ requirement
+as the scanner) on each line slice you intend to extract:
 
 ```bash
 dart run cognitive_complexity:data_flow@^0.2.4 lib/src/my_file.dart:45-80
 ```
 
-Its report (`inputs`, `mutations`, live `outputs`, control-flow escapes, and
-a synthesized Dart 3 record signature) selects the tier.
+Its report (`inputs`, `mutations`, live `outputs`, control-flow escapes, and a
+synthesized Dart 3 record signature) selects the tier.
 
-**Slice at natural seams first.** If a slice reports control-flow escapes or
-a tightly coupled pair of mutable variables (`queue` + `visited`,
-`buffer` + `cursor`), the usual culprit is the slice boundary, not the code.
-Enlarge the slice to the whole loop or state machine and re-run `data_flow`:
-escapes targeting a loop inside the slice stop being escapes, coupled state
-becomes interior, and the enlarged slice usually extracts cleanly as
-Tier 1/2.
+**Slice at natural seams first.** If a slice reports control-flow escapes or a
+tightly coupled pair of mutable variables (`queue` + `visited`, `buffer` +
+`cursor`), the usual culprit is the slice boundary, not the code. Enlarge the
+slice to the whole loop or state machine and re-run `data_flow`: escapes
+targeting a loop inside the slice stop being escapes, coupled state becomes
+interior, and the enlarged slice usually extracts cleanly as Tier 1/2.
 
 These bullets are the ONLY selection rules:
 
-* **Cleanly extractable, ≤ 1 live output, ≤ 3 inputs** → Tier 2: extract a
+- **Cleanly extractable, ≤ 1 live output, ≤ 3 inputs** → Tier 2: extract a
   standard private helper returning that value. If the helper does not read or
   mutate class instance state (`this`), declare it as a private top-level
   function (or static method) rather than an instance method.
-* **Cleanly extractable, 2+ live outputs** → Tier 1: extract a static or
-  top-level function and use the synthesized named record signature
-  verbatim. Private, file-local slices use named records at ANY output
-  count — do NOT mint single-use `_XxxResult` dataclasses for them. Reserve
-  a dedicated `Result` dataclass for values that cross a public API or
-  library boundary, or that need methods or invariants. If the helper does not
-  read or mutate class instance state (`this`), declare it as a private
-  top-level function (or static method) rather than an instance method. *Advisory*:
-  5+ live outputs usually means the slice is cut at the wrong seam — try a
-  different boundary before shipping a wide record.
-* **Control-flow escapes** → apply in preference order:
+- **Cleanly extractable, 2+ live outputs** → Tier 1: extract a static or
+  top-level function and use the synthesized named record signature verbatim.
+  Private, file-local slices use named records at ANY output count — do NOT mint
+  single-use `_XxxResult` dataclasses for them. Reserve a dedicated `Result`
+  dataclass for values that cross a public API or library boundary, or that need
+  methods or invariants. If the helper does not read or mutate class instance
+  state (`this`), declare it as a private top-level function (or static method)
+  rather than an instance method. _Advisory_: 5+ live outputs usually means the
+  slice is cut at the wrong seam — try a different boundary before shipping a
+  wide record.
+- **Control-flow escapes** → apply in preference order:
   1. Enlarge the slice to include the whole loop (natural seams, above) and
      re-run the analysis.
-  2. If the loop *body* is itself the hotspot, extract it with an explicit
+  2. If the loop _body_ is itself the hotspot, extract it with an explicit
      signal return (Pattern E) — never a `shouldBreak` boolean flag.
-  3. Use guard-clause inversion (Pattern B) when the escape exists only to
-     skip nested conditions — it fixes nesting, not escapes.
-  `yield` is none of these: restructure the generator before attempting any
-  extraction.
-* **Tier 3 gate (mutation-web check)** → Tier 3 requires recorded evidence,
-  not judgment. Run `data_flow` on at least two distinct candidate slices of
-  the function. Tier 3 is permitted ONLY if the intersection of their
-  `mutations` variable names contains 3 or more entries — i.e. the same
-  mutable variables thread through every candidate extraction. Paste the
-  JSON reports into the Triage Report as evidence; without that evidence,
-  stay in Tier 1/2. A recurring 2-variable coupling never qualifies:
-  enlarge the slice, or take the domain-modeling exit (below).
+  3. Use guard-clause inversion (Pattern B) when the escape exists only to skip
+     nested conditions — it fixes nesting, not escapes. `yield` is none of
+     these: restructure the generator before attempting any extraction.
+- **Tier 3 gate (mutation-web check)** → Tier 3 requires recorded evidence, not
+  judgment. Run `data_flow` on at least two distinct candidate slices of the
+  function. Tier 3 is permitted ONLY if the intersection of their `mutations`
+  variable names contains 3 or more entries — i.e. the same mutable variables
+  thread through every candidate extraction. Paste the JSON reports into the
+  Triage Report as evidence; without that evidence, stay in Tier 1/2. A
+  recurring 2-variable coupling never qualifies: enlarge the slice, or take the
+  domain-modeling exit (below).
 
-When choosing how to reduce complexity on a large Dart function, follow this **3-Tier Decision Hierarchy**:
+When choosing how to reduce complexity on a large Dart function, follow this
+**3-Tier Decision Hierarchy**:
 
 1. **Tier 1 — Pure Functional Decomposition (first choice)**: static or
    top-level functions returning Dart 3 named records
    (`final (:data, :errors) = _stepOne(input);`); a dedicated `Result` /
-   `Response` dataclass only where the value crosses a public API or
-   library boundary or needs methods/invariants. All extracted helpers that
-   do not access class instance state (`this`) MUST be declared as private
-   top-level functions (or static methods) to guarantee referential
-   transparency and prevent temporal coupling.
-2. **Tier 2 — Standard Extract Method (second choice)**: standard private
-   helper methods or top-level private functions taking <= 3 arguments.
-3. **Tier 3 — Encapsulated Method Object (last resort)**: permitted only
-   when the mutation-web check above passes with recorded evidence. Then
-   read [references/method-object.md](references/method-object.md) for the
-   extraction mechanics and mandatory idioms. Do not load or apply it
-   speculatively.
+   `Response` dataclass only where the value crosses a public API or library
+   boundary or needs methods/invariants. All extracted helpers that do not
+   access class instance state (`this`) MUST be declared as private top-level
+   functions (or static methods) to guarantee referential transparency and
+   prevent temporal coupling.
+2. **Tier 2 — Standard Extract Method (second choice)**: standard private helper
+   methods or top-level private functions taking <= 3 arguments.
+3. **Tier 3 — Encapsulated Method Object (last resort)**: permitted only when
+   the mutation-web check above passes with recorded evidence. Then read
+   [references/method-object.md](references/method-object.md) for the extraction
+   mechanics and mandatory idioms. Do not load or apply it speculatively.
 
 **Domain-modeling exit**: when the same tightly coupled mutable state keeps
 resurfacing across a function (a parser's `buffer` + `cursor`, a traversal's
 `queue` + `visited`), the code may be asking to become a real, cohesively
-*named* domain class (`Parser`, `GraphTraversal`) with a public, unit-tested
-API. That is domain modeling, not complexity remediation — it exits this
-rubric entirely and is not subject to the Tier 3 gate. The gate exists to
-ban single-use `_XxxRunner` facades, not real abstractions. To qualify for
-the exit, the class MUST have cohesive entity state, more than one public
-behavior, and its own dedicated test suite. A single-use private class with
-a constructor and one `run()` method is a runner no matter what it is
-renamed to (`_ScanEngine`, `_BatchProcessor`) and remains subject to the
-gate.
+_named_ domain class (`Parser`, `GraphTraversal`) with a public, unit-tested
+API. That is domain modeling, not complexity remediation — it exits this rubric
+entirely and is not subject to the Tier 3 gate. The gate exists to ban
+single-use `_XxxRunner` facades, not real abstractions. To qualify for the exit,
+the class MUST have cohesive entity state, more than one public behavior, and
+its own dedicated test suite. A single-use private class with a constructor and
+one `run()` method is a runner no matter what it is renamed to (`_ScanEngine`,
+`_BatchProcessor`) and remains subject to the gate.
 
 ---
 
 ### Pattern D: Fast-Fail Type Matching & Silent Data Swallowing
 
-When refactoring loops and type checks to reduce branching, **never** replace explicit type casts with pattern matching that silently drops data.
+When refactoring loops and type checks to reduce branching, **never** replace
+explicit type casts with pattern matching that silently drops data.
 
 **Flawed Structure (Silent Failure):**
+
 ```dart
 for (final raw in rawTasks) {
   // SILENTLY DROPS malformed data if raw is not a Map
@@ -342,6 +363,7 @@ for (final raw in rawTasks) {
 ```
 
 **Correct Structure (Fast-Fail Preservation):**
+
 ```dart
 for (final raw in rawTasks) {
   if (raw is! Map<String, dynamic>) {
@@ -356,11 +378,10 @@ for (final raw in rawTasks) {
 
 ### Pattern E: Loop-Body Extraction with Signal Returns
 
-When a loop body must be extracted but contains `break`/`continue` targeting
-the loop, never smuggle the control flow through boolean flags
-(`shouldBreak` soup) — that raises cognitive load and hides termination
-conditions. Return an explicit signal and keep the loop keywords at the loop
-site:
+When a loop body must be extracted but contains `break`/`continue` targeting the
+loop, never smuggle the control flow through boolean flags (`shouldBreak` soup)
+— that raises cognitive load and hides termination conditions. Return an
+explicit signal and keep the loop keywords at the loop site:
 
 ```dart
 enum _ScanAction { proceed, skip, halt }
@@ -387,10 +408,10 @@ for (final entry in entries) {
 
 Use a sealed class instead of an enum when the signal must carry a payload.
 Asynchronous classification works identically:
-`switch (await _classify(entry, seen))`. The exhaustive `switch` keeps
-every termination path visible at the loop site. Prefer extracting the
-*entire loop* when `data_flow` shows it forms a natural seam; use Pattern E
-when the loop body alone is the hotspot.
+`switch (await _classify(entry, seen))`. The exhaustive `switch` keeps every
+termination path visible at the loop site. Prefer extracting the _entire loop_
+when `data_flow` shows it forms a natural seam; use Pattern E when the loop body
+alone is the hotspot.
 
 ---
 
@@ -398,10 +419,10 @@ when the loop body alone is the hotspot.
 
 Run these verification commands before committing refactored code:
 
-1. **Complexity Audit**: Run `dart run cognitive_complexity@^0.2.4
-   --fail-threshold 15 <refactored files>` scoped to the files you touched.
-   Pre-existing breaches elsewhere in the project do not invalidate the
-   refactor.
+1. **Complexity Audit**: Run
+   `dart run cognitive_complexity@^0.2.4 --fail-threshold 15 <refactored files>`
+   scoped to the files you touched. Pre-existing breaches elsewhere in the
+   project do not invalidate the refactor.
 2. **Code Presentation**: Run `dart format .` to maintain uniform syntactic
    styling.
 3. **Static Analysis**: Run `dart analyze` to ensure zero static warnings, lint
@@ -416,15 +437,17 @@ Run these verification commands before committing refactored code:
 When staging refactored code and preparing a commit message or Pull Request:
 
 ### 1. User Confirmation Gate & Headless Defaults
-* **Interactive Sessions**: Before writing the PR description or commit body,
+
+- **Interactive Sessions**: Before writing the PR description or commit body,
   explicitly prompt the user in chat or via the harness confirmation tool (e.g.
   `ask_question`) whether to include a **Tool Provenance & Complexity Delta
   block**.
-* **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
+- **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
   subagents, automated eval suites like `evalin`, or headless CI), default to
   including the block automatically without blocking on user confirmation.
 
 ### 2. Standardized Provenance Block Format
+
 When confirmed (or running headlessly), append the following markdown block to
 the PR description or commit body so reviewers understand where the changes
 originated, see the quantified readability improvements, and can rerun the audit
@@ -433,28 +456,36 @@ locally:
 ````markdown
 ### 🤖 Tool Provenance & Complexity Delta
 
-This refactoring was guided by [`cognitive_complexity`](https://pub.dev/packages/cognitive_complexity) (`v{version}`).
+This refactoring was guided by
+[`cognitive_complexity`](https://pub.dev/packages/cognitive_complexity)
+(`v{version}`).
 
 <!-- mdformat off(prevent table wrapping) -->
-| Target Declaration | Pre-Score | Post-Score | Operational Ceiling |
-| :--- | :---: | :---: | :---: |
-| `{declaration_name}` (`{file_path}`) | `{pre_score}` | `{post_score}` | `<={threshold}` |
+
+| Target Declaration                   |   Pre-Score   |   Post-Score   | Operational Ceiling |
+| :----------------------------------- | :-----------: | :------------: | :-----------------: |
+| `{declaration_name}` (`{file_path}`) | `{pre_score}` | `{post_score}` |   `<={threshold}`   |
+
 <!-- mdformat on -->
 
 To reproduce or re-evaluate cognitive complexity scores:
+
 ```bash
 {exact_command_line}
 ```
 
 <!-- If statement data-flow analysis was used during decomposition: -->
+
 ```bash
 dart run cognitive_complexity:data_flow@^0.2.4 {file}:{start_line}-{end_line}
 ```
 ````
 
 ### 3. Version Resolution
+
 Determine the package version dynamically:
-* Check `pubspec.lock` in the workspace or run
+
+- Check `pubspec.lock` in the workspace or run
   `dart run cognitive_complexity@ --version`.
-* If invoked with a specific version constraint (e.g.
+- If invoked with a specific version constraint (e.g.
   `cognitive_complexity@0.2.3`), use that exact version.

--- a/skills/dart-dedupe/SKILL.md
+++ b/skills/dart-dedupe/SKILL.md
@@ -61,7 +61,7 @@ detect:
 Run the official package CLI directly:
 
 ```bash
-dart run dedupe [options] [target_path]
+dart run dedupe@^0.1.0 [options] [target_path]
 ```
 
 ### Execution Modes
@@ -69,13 +69,13 @@ dart run dedupe [options] [target_path]
 #### Mode 1: Full Repository / Directory Scan
 ```bash
 # Markdown summary with clickable file links
-dart run dedupe
+dart run dedupe@^0.1.0
 
 # Machine-readable JSON output for agent pipelines
-dart run dedupe --format=json
+dart run dedupe@^0.1.0 --format=json
 
 # Write JSON report to file alongside human stdout
-dart run dedupe --json-output=report.json
+dart run dedupe@^0.1.0 --json-output=report.json
 ```
 
 #### Mode 2: PR / Git Diff Delta Scan (`--git-diff`)
@@ -83,13 +83,13 @@ Focus strictly on code modified in a branch or PR:
 
 ```bash
 # In Git checkouts:
-dart run dedupe --git-diff=origin/main
+dart run dedupe@^0.1.0 --git-diff=origin/main
 
 # Filter report strictly to clusters intersecting modified lines:
-dart run dedupe --git-diff=origin/main --only-changed
+dart run dedupe@^0.1.0 --git-diff=origin/main --only-changed
 
 # Fail CI if diff duplication exceeds 5%:
-dart run dedupe --git-diff=origin/main --fail-threshold=5
+dart run dedupe@^0.1.0 --git-diff=origin/main --fail-threshold=5
 ```
 
 ### Common CLI Options Reference

--- a/skills/dart-dedupe/SKILL.md
+++ b/skills/dart-dedupe/SKILL.md
@@ -22,39 +22,43 @@ key_features:
 High-performance structural code duplication and clone detection engine and
 refactoring protocol for Dart and Flutter repositories using `pkg:dedupe`.
 
---------------------------------------------------------------------------------
+---
 
 ## 1. When to Use This Skill
 
-Use this skill when auditing codebase redundancy, identifying copy-paste
-blocks, preventing duplication regressions in pull requests, or evaluating
-shared utility and abstraction candidates across Dart packages.
+Use this skill when auditing codebase redundancy, identifying copy-paste blocks,
+preventing duplication regressions in pull requests, or evaluating shared
+utility and abstraction candidates across Dart packages.
 
 Unlike basic lexical diffs, `dedupe` tokenizes and analyzes Dart source code to
 detect:
-* **Identical Clones**: Exact token-for-token copies across files.
-* **Structural Clones**: Clones matching after normalizing string literals and
+
+- **Identical Clones**: Exact token-for-token copies across files.
+- **Structural Clones**: Clones matching after normalizing string literals and
   numeric constants (`--ignore-literals`).
-* **Parameterized Clones**: Clones matching after normalizing variable and type
+- **Parameterized Clones**: Clones matching after normalizing variable and type
   identifiers (`--ignore-identifiers`).
-* **Gapped / Near-Miss Clones**: Type-3 clones matching with internal statement
-  insertions, deletions, or edits via MinHash & LSH shingling (`--bucket=gapped`).
+- **Gapped / Near-Miss Clones**: Type-3 clones matching with internal statement
+  insertions, deletions, or edits via MinHash & LSH shingling
+  (`--bucket=gapped`).
 
 ### Trigger Indicators
-* **Copy-pasted utilities**: Identical or nearly identical helper functions
+
+- **Copy-pasted utilities**: Identical or nearly identical helper functions
   duplicated across multiple files or classes.
-* **Redundant serialization / parsing**: Repeated manual JSON decoders, record
+- **Redundant serialization / parsing**: Repeated manual JSON decoders, record
   mappers, or data transformation pipelines.
-* **PR / CL Duplication Regressions**: Catching newly introduced duplicate
-  code before merging pull requests.
+- **PR / CL Duplication Regressions**: Catching newly introduced duplicate code
+  before merging pull requests.
 
 ### When NOT to Use
-* **Single-File Private Variable Lints**: Use standard `dart analyze` for simple
-  unused variables or parameters.
-* **Code Formatting**: Use `dart format`.
-* **Non-Dart Projects**: Tool operates strictly on Dart syntax.
 
---------------------------------------------------------------------------------
+- **Single-File Private Variable Lints**: Use standard `dart analyze` for simple
+  unused variables or parameters.
+- **Code Formatting**: Use `dart format`.
+- **Non-Dart Projects**: Tool operates strictly on Dart syntax.
+
+---
 
 ## 2. Automated Execution & Scope Resolution
 
@@ -67,6 +71,7 @@ dart run dedupe@^0.1.0 [options] [target_path]
 ### Execution Modes
 
 #### Mode 1: Full Repository / Directory Scan
+
 ```bash
 # Markdown summary with clickable file links
 dart run dedupe@^0.1.0
@@ -79,6 +84,7 @@ dart run dedupe@^0.1.0 --json-output=report.json
 ```
 
 #### Mode 2: PR / Git Diff Delta Scan (`--git-diff`)
+
 Focus strictly on code modified in a branch or PR:
 
 ```bash
@@ -96,31 +102,31 @@ dart run dedupe@^0.1.0 --git-diff=origin/main --fail-threshold=5
 
 <!-- mdformat off(prevent table wrapping) -->
 
-| Option / Flag | Purpose | Default |
-| :--- | :--- | :--- |
-| `-k, --min-tokens` | Minimum token count for a reported duplicate block. | `40` |
-| `-l, --min-lines` | Minimum line count for a reported duplicate block. | `4` |
-| `--[no-]ignore-comments` | Ignore comments when comparing tokens. | `true` |
-| `--[no-]ignore-literals` | Normalize literals to detect structural clones. | `true` |
-| `--[no-]ignore-identifiers` | Normalize identifiers to detect parameterized clones. | `false` |
-| `--category` | Filter clusters (`all`, `logic`, `data`, `boilerplate`). | `all` |
-| `--bucket` | Filter clusters (`all`, `identical`, `structural`, `parameterized`, `gapped`). | `all` |
-| `--top` | Limit number of top clusters to display (`0` for all). | `0` |
-| `-f, --fail-threshold` | Maximum allowed duplication percentage before failing. | None |
-| `-d, --git-diff` | Git reference to compare against (e.g. `origin/main`). | None |
-| `--only-changed` | Only report clusters intersecting modified lines. | `false` |
-| `--exclude` | Comma-separated glob patterns of files to exclude. | Standard exclusions |
-| `--include` | Comma-separated glob patterns of files to include. | `**/*.dart` |
-| `--[no-]cache` | Enable on-disk caching of AST candidates & token sequences. | `true` |
-| `--cache-dir` | Custom directory for cache (defaults to `.dart_tool/dedupe`). | None |
-| `--[no-]files` | Include per-file duplication metrics table in report. | `true` |
-| `--[no-]clusters` | Include duplicate clusters list in report. | `true` |
-| `--format` | Output format (`markdown`, `json`, `github`, `text`). | `markdown` |
-| `--json-output` | File path to write machine-readable JSON report. | None |
+| Option / Flag               | Purpose                                                                        | Default             |
+| :-------------------------- | :----------------------------------------------------------------------------- | :------------------ |
+| `-k, --min-tokens`          | Minimum token count for a reported duplicate block.                            | `40`                |
+| `-l, --min-lines`           | Minimum line count for a reported duplicate block.                             | `4`                 |
+| `--[no-]ignore-comments`    | Ignore comments when comparing tokens.                                         | `true`              |
+| `--[no-]ignore-literals`    | Normalize literals to detect structural clones.                                | `true`              |
+| `--[no-]ignore-identifiers` | Normalize identifiers to detect parameterized clones.                          | `false`             |
+| `--category`                | Filter clusters (`all`, `logic`, `data`, `boilerplate`).                       | `all`               |
+| `--bucket`                  | Filter clusters (`all`, `identical`, `structural`, `parameterized`, `gapped`). | `all`               |
+| `--top`                     | Limit number of top clusters to display (`0` for all).                         | `0`                 |
+| `-f, --fail-threshold`      | Maximum allowed duplication percentage before failing.                         | None                |
+| `-d, --git-diff`            | Git reference to compare against (e.g. `origin/main`).                         | None                |
+| `--only-changed`            | Only report clusters intersecting modified lines.                              | `false`             |
+| `--exclude`                 | Comma-separated glob patterns of files to exclude.                             | Standard exclusions |
+| `--include`                 | Comma-separated glob patterns of files to include.                             | `**/*.dart`         |
+| `--[no-]cache`              | Enable on-disk caching of AST candidates & token sequences.                    | `true`              |
+| `--cache-dir`               | Custom directory for cache (defaults to `.dart_tool/dedupe`).                  | None                |
+| `--[no-]files`              | Include per-file duplication metrics table in report.                          | `true`              |
+| `--[no-]clusters`           | Include duplicate clusters list in report.                                     | `true`              |
+| `--format`                  | Output format (`markdown`, `json`, `github`, `text`).                          | `markdown`          |
+| `--json-output`             | File path to write machine-readable JSON report.                               | None                |
 
 <!-- mdformat on -->
 
---------------------------------------------------------------------------------
+---
 
 ## 3. The "Actionable vs. Necessary" Architectural Gate
 
@@ -128,28 +134,31 @@ dart run dedupe@^0.1.0 --git-diff=origin/main --fail-threshold=5
 Evaluate each candidate cluster before modifying code:
 
 ### ✅ Actionable Duplication (Refactor & Extract)
-* **Copy-pasted helpers or decoders:** Identical algorithms, database record
+
+- **Copy-pasted helpers or decoders:** Identical algorithms, database record
   parsers, or conversion utilities scattered across multiple classes or files.
-* **Shared contract declarations:** Common `typedef` contracts, data models, or
+- **Shared contract declarations:** Common `typedef` contracts, data models, or
   record shapes duplicated across platform stubs (extract to a shared library).
-* **Repetitive CLI orchestration:** Copy-pasted external process invocations or
+- **Repetitive CLI orchestration:** Copy-pasted external process invocations or
   JSON decoding blocks where schema updates would risk drift.
-* **Code generator scaffolding:** Repetitive string builders or verbose AST
+- **Code generator scaffolding:** Repetitive string builders or verbose AST
   instantiations that can be cleanly condensed into parameterized emitters.
 
 ### 🛑 Necessary Duplication (Reject Refactoring & Preserve)
-* **Type-unsafe polymorphic AST targets:** When similar-looking classes (such as
+
+- **Type-unsafe polymorphic AST targets:** When similar-looking classes (such as
   AST statement variants) do not share a common type interface. Using `dynamic`
   sacrifices compile-time type safety for negligible line reduction.
-* **Performance-critical specialized solver loops:** Symmetric horizontal vs.
+- **Performance-critical specialized solver loops:** Symmetric horizontal vs.
   vertical grid traversals where unifying orthogonal strides into a single
   abstraction would require allocating closures or virtual calls in tight loops.
-* **Speculative wrapping of standalone entry points:** Abstracting trivial
+- **Speculative wrapping of standalone entry points:** Abstracting trivial
   4-to-6 line `try/catch` fallback formatting across unrelated standalone CLI
   entry points (`bin/<script>.dart`).
-* **DAMP Test Boilerplate:** Repetitive setup structures in table-driven unit tests.
+- **DAMP Test Boilerplate:** Repetitive setup structures in table-driven unit
+  tests.
 
---------------------------------------------------------------------------------
+---
 
 ## 4. The 2-Stage Triage & Confirmation Protocol
 
@@ -157,9 +166,11 @@ To prevent unwanted diff bloat and preserve codebase stability, adhere to this
 strict 2-stage workflow:
 
 ### Stage 1: Read-Only Audit & Reporting (Mandatory Stop)
+
 Run `dart run dedupe --format=markdown` (or `--format=json`).
 
 Output a ranked **Duplication Triage Report** containing:
+
 1. **Target Summary**: Files analyzed, total lines, duplication percentage, and
    estimated lines saved.
 2. **Top Duplicate Clusters**: Clickable file links, line ranges, token counts,
@@ -169,15 +180,17 @@ Output a ranked **Duplication Triage Report** containing:
    mark as "Necessary Duplication (Preserve)".
 
 ### Stage 2: Interactive User Confirmation Gate
+
 Pause execution and prompt the user (via interactive choice or chat) to select
 the desired remediation scope:
+
 1. **(Recommended) Refactor Top Actionable Cluster Only**: Target the single
    highest-impact duplicate helper or decoder.
 2. **Refactor All Actionable Clusters in Scope**: Sequentially extract all
    approved duplicate blocks.
 3. **Report-Only / Exit**: Acknowledge findings without code mutations.
 
---------------------------------------------------------------------------------
+---
 
 ## 5. Pre & Post Refactor Verification Protocol
 
@@ -195,41 +208,49 @@ graph TD
 ```
 
 1. **Verify Baseline:** Run `dart test` prior to modification. Ensure 100% pass.
-2. **Surgical Modification:** Extract shared functions or helper classes cleanly.
-3. **Verify Post-Refactor Health:** Run `dart analyze --fatal-infos` and `dart test`.
+2. **Surgical Modification:** Extract shared functions or helper classes
+   cleanly.
+3. **Verify Post-Refactor Health:** Run `dart analyze --fatal-infos` and
+   `dart test`.
 4. **Zero-Clone Confirmation:** Re-run `dart run dedupe` to confirm the target
    cluster was eliminated.
 5. **Local Staging:** Stage verified diffs locally (`git add .`).
 
---------------------------------------------------------------------------------
+---
 
 ## 6. Pull Request & Commit Provenance Protocol
 
 When staging deduplicated code and preparing a commit message or Pull Request:
 
 ### 1. User Confirmation Gate & Headless Defaults
-* **Interactive Sessions**: Before writing the PR description or commit body,
+
+- **Interactive Sessions**: Before writing the PR description or commit body,
   explicitly prompt the user in chat or via the harness confirmation tool (e.g.
   `ask_question`) whether to include a **Tool Provenance & Reproduction block**.
-* **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
+- **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
   subagents, automated eval suites like `evalin`, or headless CI), default to
   including the block automatically without blocking on user confirmation.
 
 ### 2. Standardized Provenance Block Format
+
 When confirmed (or running headlessly), append the following markdown block to
 the PR description or commit body:
 
 ````markdown
 ### 🤖 Tool Provenance & Reproduction
 
-Structural duplication analysis performed with [`dedupe`](https://pub.dev/packages/dedupe) (`v{version}`).
+Structural duplication analysis performed with
+[`dedupe`](https://pub.dev/packages/dedupe) (`v{version}`).
 
 To reproduce or re-run this duplication scan locally:
+
 ```bash
 {exact_command_line}
 ```
 ````
 
 ### 3. Version Resolution
+
 Determine the package version dynamically:
-* Check `pubspec.lock` in the workspace or run `dart run dedupe --version`.
+
+- Check `pubspec.lock` in the workspace or run `dart run dedupe --version`.

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -59,7 +59,7 @@ Execute the official package CLI directly in the terminal to retrieve reachabili
 findings deterministically:
 
 ```bash
-dart run undead@ [options] [target_path]
+dart run undead@^0.1.1 [options] [target_path]
 ```
 
 > [!NOTE]
@@ -67,7 +67,7 @@ dart run undead@ [options] [target_path]
 > `.dart_tool/package_config.json` to resolve `package:<name>/...` imports. If
 > packages are unresolved, pass `--pub-get` to automatically run `dart pub get`
 > or `flutter pub get`. If encountering `.dart_tool` atomic rename errors in
-> sandboxed environments, pass `--no-precompile` (e.g. `dart run --no-precompile undead@`).
+> sandboxed environments, pass `--no-precompile` (e.g. `dart run --no-precompile undead@^0.1.1`).
 
 ### Execution Modes
 
@@ -78,10 +78,10 @@ tests:
 
 ```bash
 # Markdown output for human review
-dart run undead@
+dart run undead@^0.1.1
 
 # Machine-readable JSON output for agent automation
-dart run undead@ --format=json
+dart run undead@^0.1.1 --format=json
 ```
 
 #### Mode 2: Closed Application (`--mode=closed-app`)
@@ -89,7 +89,7 @@ Traces execution strictly from executable entrypoints (`bin/**`, `lib/main.dart`
 `lib/main_*.dart`). Treats unreferenced public declarations as dead:
 
 ```bash
-dart run undead@ --mode=closed-app
+dart run undead@^0.1.1 --mode=closed-app
 ```
 
 #### Mode 3: Example Code Handling (`--example-mode`)

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Audits, triages, and safely remediates unreachable and dead declarations in
   Dart and Flutter codebases using deterministic reachability analysis
   (pkg:undead). Use when identifying unused top-level declarations, classes,
-  functions, or dead test fixtures in libraries or closed applications. Don't use
-  for single-file private variable lints (use standard analyzer lints), code
+  functions, or dead test fixtures in libraries or closed applications. Don't
+  use for single-file private variable lints (use standard analyzer lints), code
   formatting, or non-Dart/Flutter repositories.
 license: Apache-2.0
 key_features:
@@ -22,7 +22,7 @@ key_features:
 Deterministic reachability and dead/unused declaration analysis for Dart and
 Flutter packages using `pkg:undead`.
 
---------------------------------------------------------------------------------
+---
 
 ## 1. When to Use This Skill
 
@@ -36,42 +36,45 @@ reachability graph from designated entrypoint roots down to all internal
 declarations.
 
 ### Trigger Indicators
-* **Orphaned Internal Utilities**: Functions, classes, or mixins under `lib/src/`
-  unreachable from public API barrels or internal entrypoints.
-* **Dead Application Features**: Unreachable views, controllers, or services in
+
+- **Orphaned Internal Utilities**: Functions, classes, or mixins under
+  `lib/src/` unreachable from public API barrels or internal entrypoints.
+- **Dead Application Features**: Unreachable views, controllers, or services in
   standalone CLI tools or Flutter apps.
-* **Orphaned Test Fixtures**: Dead `Fake*` or `Mock*` fixtures left behind after
+- **Orphaned Test Fixtures**: Dead `Fake*` or `Mock*` fixtures left behind after
   features were refactored.
-* **Pre-Release API Pruning**: Verifying whether newly introduced experimental
+- **Pre-Release API Pruning**: Verifying whether newly introduced experimental
   helpers are actually wired up before public release.
 
 ### When NOT to Use
-* **Single-File Private Lints**: Rely on standard `dart analyze` for simple
-  local variable or private parameter lints.
-* **Code Formatting or Lint Rules**: Use standard `dart format` or `dart fix`.
-* **Non-Dart / Non-Flutter Projects**: Tool exclusively operates on Dart ASTs.
 
---------------------------------------------------------------------------------
+- **Single-File Private Lints**: Rely on standard `dart analyze` for simple
+  local variable or private parameter lints.
+- **Code Formatting or Lint Rules**: Use standard `dart format` or `dart fix`.
+- **Non-Dart / Non-Flutter Projects**: Tool exclusively operates on Dart ASTs.
+
+---
 
 ## 2. Automated Execution & Scope Resolution
 
-Execute the official package CLI directly in the terminal to retrieve reachability
-findings deterministically:
+Execute the official package CLI directly in the terminal to retrieve
+reachability findings deterministically:
 
 ```bash
 dart run undead@^0.1.1 [options] [target_path]
 ```
 
-> [!NOTE]
-> **Pre-Flight Package Resolution Gate**: `package:analyzer` requires
+> [!NOTE] **Pre-Flight Package Resolution Gate**: `package:analyzer` requires
 > `.dart_tool/package_config.json` to resolve `package:<name>/...` imports. If
 > packages are unresolved, pass `--pub-get` to automatically run `dart pub get`
 > or `flutter pub get`. If encountering `.dart_tool` atomic rename errors in
-> sandboxed environments, pass `--no-precompile` (e.g. `dart run --no-precompile undead@^0.1.1`).
+> sandboxed environments, pass `--no-precompile` (e.g.
+> `dart run --no-precompile undead@^0.1.1`).
 
 ### Execution Modes
 
 #### Mode 1: Library Package (Default / Open-World)
+
 Preserves all non-`src` `lib/**` exports as public API roots. Analyzes whether
 internal declarations (`lib/src/**`) are reachable from exported barrels or
 tests:
@@ -85,19 +88,23 @@ dart run undead@^0.1.1 --format=json
 ```
 
 #### Mode 2: Closed Application (`--mode=closed-app`)
-Traces execution strictly from executable entrypoints (`bin/**`, `lib/main.dart`,
-`lib/main_*.dart`). Treats unreferenced public declarations as dead:
+
+Traces execution strictly from executable entrypoints (`bin/**`,
+`lib/main.dart`, `lib/main_*.dart`). Treats unreferenced public declarations as
+dead:
 
 ```bash
 dart run undead@^0.1.1 --mode=closed-app
 ```
 
 #### Mode 3: Example Code Handling (`--example-mode`)
+
 Controls how code in `example/` is treated during reachability analysis:
-* `demonstration` (Default): `example/` code is treated as a consumer root;
+
+- `demonstration` (Default): `example/` code is treated as a consumer root;
   example files are never suggested for deletion.
-* `strict`: Analyzes reachability within `example/` itself.
-* `skip`: Ignores `example/` completely during analysis.
+- `strict`: Analyzes reachability within `example/` itself.
+- `skip`: Ignores `example/` completely during analysis.
 
 ```bash
 dart run undead@ --example-mode=demonstration
@@ -105,58 +112,64 @@ dart run undead@ --example-mode=demonstration
 
 ### Common CLI Options Reference
 
-| Option / Flag | Purpose | Default |
-| :--- | :--- | :--- |
-| `-m, --mode` | Analysis mode (`library` or `closed-app`). | `library` |
-| `-f, --format` | Output formatting (`markdown`, `json`, `github`). | `markdown` |
-| `--json-output=<path>` | Write JSON report to file while preserving stdout. | None |
-| `--example-mode` | Policy for `example/` (`demonstration`, `strict`, `skip`). | `demonstration` |
-| `--extra-roots=<dir1,dir2>` | Comma-separated list of additional root/test dirs. | `""` |
-| `--test-support-patterns` | Comma-separated wildcards for test fixtures. | `Fake*,Mock*` |
-| `--ignore-name-patterns` | Comma-separated wildcards for names to ignore. | `""` |
-| `--[no-]workspace-discovery` | Discover consumer roots from sibling packages in workspace. | `true` |
-| `--[no-]ignore-external-bindings` | Preserve unreferenced `@JS()` and FFI facades. | `false` |
-| `--[no-]suggest-private` | Identify top-level declarations that can be made library-private. | `false` |
-| `--pub-get` | Auto-run `dart pub get` / `flutter pub get` if needed. | `false` |
-| `--fail-on-undead` | Exit with non-zero code (1) on findings (useful for CI). | `false` |
+| Option / Flag                     | Purpose                                                           | Default         |
+| :-------------------------------- | :---------------------------------------------------------------- | :-------------- |
+| `-m, --mode`                      | Analysis mode (`library` or `closed-app`).                        | `library`       |
+| `-f, --format`                    | Output formatting (`markdown`, `json`, `github`).                 | `markdown`      |
+| `--json-output=<path>`            | Write JSON report to file while preserving stdout.                | None            |
+| `--example-mode`                  | Policy for `example/` (`demonstration`, `strict`, `skip`).        | `demonstration` |
+| `--extra-roots=<dir1,dir2>`       | Comma-separated list of additional root/test dirs.                | `""`            |
+| `--test-support-patterns`         | Comma-separated wildcards for test fixtures.                      | `Fake*,Mock*`   |
+| `--ignore-name-patterns`          | Comma-separated wildcards for names to ignore.                    | `""`            |
+| `--[no-]workspace-discovery`      | Discover consumer roots from sibling packages in workspace.       | `true`          |
+| `--[no-]ignore-external-bindings` | Preserve unreferenced `@JS()` and FFI facades.                    | `false`         |
+| `--[no-]suggest-private`          | Identify top-level declarations that can be made library-private. | `false`         |
+| `--pub-get`                       | Auto-run `dart pub get` / `flutter pub get` if needed.            | `false`         |
+| `--fail-on-undead`                | Exit with non-zero code (1) on findings (useful for CI).          | `false`         |
 
---------------------------------------------------------------------------------
+---
 
 ## 3. Critical Safety Guardrails & Deletion Invariants
 
-> [!CAUTION]
-> **Audit Before Deleting**: Never delete declarations autonomously without
-> reviewing safety invariants and verifying against the test suite.
+> [!CAUTION] **Audit Before Deleting**: Never delete declarations autonomously
+> without reviewing safety invariants and verifying against the test suite.
 
 ### Invariant 1: Sealed Class Hierarchy Protection
-Direct subtypes of live `sealed` classes (via `extends`, `implements`, `with`, or
-`enum`) must **NEVER** be deleted, even if unreferenced elsewhere. Deleting a
+
+Direct subtypes of live `sealed` classes (via `extends`, `implements`, `with`,
+or `enum`) must **NEVER** be deleted, even if unreferenced elsewhere. Deleting a
 sealed subtype breaks Dart 3 exhaustive pattern matching across all `switch`
 expressions.
 
 ### Invariant 2: Co-Invoked Test Hazard Protection
+
 When a test file invokes both live and dead declarations:
-* **Isolated Dead Tests**: Test blocks referencing *only* dead code can be safely
-  pruned alongside the dead target.
-* **Co-Invoked Test Hazard**: When a single test function or widget test exercises
-  both live and dead code, **do not delete the test**. Refactor the test body to
-  remove only the dead assertions.
+
+- **Isolated Dead Tests**: Test blocks referencing _only_ dead code can be
+  safely pruned alongside the dead target.
+- **Co-Invoked Test Hazard**: When a single test function or widget test
+  exercises both live and dead code, **do not delete the test**. Refactor the
+  test body to remove only the dead assertions.
 
 ### Invariant 3: Framework Entrypoints & Pragmas
+
 Ensure framework-specific roots are not falsely classified as dead:
-* **Build Runner**: Builder factories and generator entrypoints in `build.yaml`.
-* **VM Entrypoints**: Declarations annotated with `@pragma('vm:entry-point')`.
-* **JS Interop**: External JavaScript facades (`@JS()`). Pass
+
+- **Build Runner**: Builder factories and generator entrypoints in `build.yaml`.
+- **VM Entrypoints**: Declarations annotated with `@pragma('vm:entry-point')`.
+- **JS Interop**: External JavaScript facades (`@JS()`). Pass
   `--ignore-external-bindings` if pruning libraries with public interop headers.
 
 ### Invariant 4: Custom Suppression Syntax
-To suppress intentional dead code or API placeholders without deleting:
-* **Declaration Level**: `// undead:ignore` (placed directly above declaration).
-* **File Level**: `// undead:ignore_for_file` (placed at top of file).
-* *(Note: Never use `// ignore: ...` as the Dart analyzer treats unknown lint
-  codes as errors).*
 
---------------------------------------------------------------------------------
+To suppress intentional dead code or API placeholders without deleting:
+
+- **Declaration Level**: `// undead:ignore` (placed directly above declaration).
+- **File Level**: `// undead:ignore_for_file` (placed at top of file).
+- _(Note: Never use `// ignore: ...` as the Dart analyzer treats unknown lint
+  codes as errors)._
+
+---
 
 ## 4. The 2-Stage Triage & Confirmation Protocol
 
@@ -164,9 +177,11 @@ To prevent accidental deletions of public APIs or breaking downstream consumers,
 follow this strict 2-stage workflow:
 
 ### Stage 1: Read-Only Audit & Reporting (Mandatory Stop)
+
 Run `dart run undead@ --format=markdown` (or `--format=json`).
 
 Output a ranked **Dead Code Triage Report** containing:
+
 1. **Target Summary**: Package name, analysis mode (`library` vs `closed-app`),
    and total undead declarations detected.
 2. **Actionable Findings Table**: Clickable file link, line number, declaration
@@ -175,8 +190,10 @@ Output a ranked **Dead Code Triage Report** containing:
    hazards, or public exports.
 
 ### Stage 2: Interactive User Confirmation Gate
+
 Pause execution and prompt the user (via interactive choice or chat) to select
 the desired remediation scope:
+
 1. **(Recommended) Prune Internal Dead Code Only**: Delete unreferenced
    declarations in `lib/src/**` and isolated test files.
 2. **Prune Application Entrypoints**: Target dead features in a closed app
@@ -185,7 +202,7 @@ the desired remediation scope:
    placeholders.
 4. **Report-Only / Exit**: Acknowledge findings without code mutations.
 
---------------------------------------------------------------------------------
+---
 
 ## 5. Pre & Post Deletion Verification Protocol
 
@@ -201,33 +218,35 @@ graph TD
     E -->|Fail| G[Step 7: Rollback / Fix Hazard]
 ```
 
-1. **Pre-Flight Baseline**: Execute `dart test` to confirm the test suite is 100%
-   green before touching any code.
-2. **Surgical Deletion**: Remove the flagged declaration and any orphaned imports
-   associated with it.
+1. **Pre-Flight Baseline**: Execute `dart test` to confirm the test suite is
+   100% green before touching any code.
+2. **Surgical Deletion**: Remove the flagged declaration and any orphaned
+   imports associated with it.
 3. **Post-Flight Verification**:
-   * Run `dart analyze` to ensure zero compilation or unresolved reference
+   - Run `dart analyze` to ensure zero compilation or unresolved reference
      errors.
-   * Run `dart test` to confirm all remaining tests pass.
+   - Run `dart test` to confirm all remaining tests pass.
 4. **Clean Diff Staging**: Inspect modifications using `git diff --stat` (or
    isolate in a temporary feature branch/worktree) to ensure only intended
    declarations were removed.
 
---------------------------------------------------------------------------------
+---
 
 ## 6. Pull Request & Commit Provenance Protocol
 
 When staging pruned code and preparing a commit message or Pull Request:
 
 ### 1. User Confirmation Gate & Headless Defaults
-* **Interactive Sessions**: Before writing the PR description or commit body,
+
+- **Interactive Sessions**: Before writing the PR description or commit body,
   explicitly prompt the user in chat or via the harness confirmation tool (e.g.
   `ask_question`) whether to include a **Tool Provenance & Reproduction block**.
-* **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
+- **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
   subagents, automated eval suites like `evalin`, or headless CI), default to
   including the block automatically without blocking on user confirmation.
 
 ### 2. Standardized Provenance Block Format
+
 When confirmed (or running headlessly), append the following markdown block to
 the PR description or commit body so reviewers understand where the deletions
 originated and can rerun the reachability analysis locally:
@@ -235,16 +254,20 @@ originated and can rerun the reachability analysis locally:
 ````markdown
 ### 🤖 Tool Provenance & Reproduction
 
-Dead code detection and reachability analysis performed with [`undead`](https://pub.dev/packages/undead) (`v{version}`).
+Dead code detection and reachability analysis performed with
+[`undead`](https://pub.dev/packages/undead) (`v{version}`).
 
 To reproduce or re-run this reachability audit locally:
+
 ```bash
 {exact_command_line}
 ```
 ````
 
 ### 3. Version Resolution
+
 Determine the package version dynamically:
-* Check `pubspec.lock` in the workspace or run `dart run undead@ --version`.
-* If invoked with a specific version constraint (e.g. `undead@0.1.0`), use that
+
+- Check `pubspec.lock` in the workspace or run `dart run undead@ --version`.
+- If invoked with a specific version constraint (e.g. `undead@0.1.0`), use that
   exact version.


### PR DESCRIPTION
## Overview
Pins package version constraints in `analytica.dart` skills to current published versions on pub.dev and establishes a repository synchronization invariant in `AGENTS.md`.

## Changes
- Pin `skills/dart-cognitive-complexity/SKILL.md` to `cognitive_complexity@^0.2.4` and `data_flow@^0.2.4`.
- Pin `skills/dart-dedupe/SKILL.md` to `dedupe@^0.1.0`.
- Pin `skills/dart-undead/SKILL.md` to `undead@^0.1.1`.
- Add `Skill / Package Synchronization Invariant` in `AGENTS.md` requiring skills to only reference published package versions or compatible version ranges.