### PR TITLE
feat: unify path exclusion logic and generated code filtering across tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 ## Workspace Structure
 
-- This repository is a Dart pub workspace monorepo containing multiple packages under `packages/`:
+- This repository is a Dart pub workspace monorepo containing multiple packages
+  under `packages/`:
   - `packages/analytica`
   - `packages/cognitive_complexity`
   - `packages/dedupe`
@@ -10,20 +11,29 @@
 
 ## Testing Instructions
 
-- Leverage multi-core execution by running package test suites concurrently in parallel across all packages:
+- Leverage multi-core execution by running package test suites concurrently in
+  parallel across all packages:
   ```bash
   pids=(); for pkg in packages/*; do [ -d "$pkg/test" ] && (echo "Starting $pkg..." && cd "$pkg" && dart test) & pids+=($!); done; status=0; for pid in "${pids[@]}"; do wait "$pid" || status=1; done; exit $status
   ```
-- To run tests for an individual package: `(cd packages/<package_name> && dart test)`.
+- To run tests for an individual package:
+  `(cd packages/<package_name> && dart test)`.
 
 ## Code Quality & Verification
 
 - Run `dart format --output=none --set-exit-if-changed .` before committing.
 - Run `dart analyze --fatal-infos` across the workspace.
-- Update `CHANGELOG.md` in the affected package under `packages/<package_name>/CHANGELOG.md` before landing.
+- Update `CHANGELOG.md` in the affected package under
+  `packages/<package_name>/CHANGELOG.md` before landing.
 
 ## Skill / Package Synchronization Invariant
 
-- **Strict Gating for Skill Updates**: Never commit or deploy updates to `skills/*/SKILL.md` (or external skill repositories) that reference new CLI flags, changed argument schemas, or bumped version constraints until the corresponding package release has been published and is resolvable on `pub.dev`.
-- **Pinned Version Formats in Skills**: Always format remote execution commands in `SKILL.md` with explicit SemVer constraints matching published versions (e.g. `dart run cognitive_complexity@^0.2.4`, `dart run dedupe@^0.1.0`, `dart run undead@^0.1.1`).
-
+- **Strict Gating for Skill Updates**: Never commit or deploy updates to
+  `skills/*/SKILL.md` (or external skill repositories) that reference new CLI
+  flags, changed argument schemas, or bumped version constraints until the
+  corresponding package release has been published and is resolvable on
+  `pub.dev`.
+- **Pinned Version Formats in Skills**: Always format remote execution commands
+  in `SKILL.md` with explicit SemVer constraints matching published versions
+  (e.g. `dart run cognitive_complexity@^0.2.4`, `dart run dedupe@^0.1.0`,
+  `dart run undead@^0.1.1`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,9 @@
 - Run `dart format --output=none --set-exit-if-changed .` before committing.
 - Run `dart analyze --fatal-infos` across the workspace.
 - Update `CHANGELOG.md` in the affected package under `packages/<package_name>/CHANGELOG.md` before landing.
+
+## Skill / Package Synchronization Invariant
+
+- **Strict Gating for Skill Updates**: Never commit or deploy updates to `skills/*/SKILL.md` (or external skill repositories) that reference new CLI flags, changed argument schemas, or bumped version constraints until the corresponding package release has been published and is resolvable on `pub.dev`.
+- **Pinned Version Formats in Skills**: Always format remote execution commands in `SKILL.md` with explicit SemVer constraints matching published versions (e.g. `dart run cognitive_complexity@^0.2.4`, `dart run dedupe@^0.1.0`, `dart run undead@^0.1.1`).
+

--- a/packages/analytica/CHANGELOG.md
+++ b/packages/analytica/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## 0.1.2-wip
 
+- Add `PathFilter` in `package:analytica/analyzer.dart` for centralized path
+  exclusion matching and generated Dart code filtering.
+- Add `addPathFilterOptions`, `addPathFilterArgs`, and `parsePathFilter` CLI
+  utilities in `package:analytica/cli.dart`.
 - Add `package:analytica/testing.dart` with `resolvePackageDirectory`,
   `resolvePackageFile`, `resolvePackageExecutable`, and `capturePrints`
   test helpers.
+
 
 ## 0.1.1
 

--- a/packages/analytica/CHANGELOG.md
+++ b/packages/analytica/CHANGELOG.md
@@ -5,19 +5,19 @@
 - Add `addPathFilterOptions`, `addPathFilterArgs`, and `parsePathFilter` CLI
   utilities in `package:analytica/cli.dart`.
 - Add `package:analytica/testing.dart` with `resolvePackageDirectory`,
-  `resolvePackageFile`, `resolvePackageExecutable`, and `capturePrints`
-  test helpers.
-
+  `resolvePackageFile`, `resolvePackageExecutable`, and `capturePrints` test
+  helpers.
 
 ## 0.1.1
 
 - Add `parseCommaSeparated` utility function in `package:analytica/cli.dart`.
 - Fix `extractNodeName` and `_findFirstIdentifier` in
-  `package:analytica/analyzer.dart` to ignore doc comment symbol references
-  when ASTs lack element resolution (#80).
+  `package:analytica/analyzer.dart` to ignore doc comment symbol references when
+  ASTs lack element resolution (#80).
 - Fix `WildcardPattern` in `package:analytica/analyzer.dart` to correctly
   support `**/` recursive directory glob matching.
 
 ## 0.1.0
 
-- Initial release of core utilities, SDK discovery, Git integration, and CI reporting.
+- Initial release of core utilities, SDK discovery, Git integration, and CI
+  reporting.

--- a/packages/analytica/CHANGELOG.md
+++ b/packages/analytica/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 - Add `PathFilter` in `package:analytica/analyzer.dart` for centralized path
   exclusion matching and generated Dart code filtering.
-- Add `addPathFilterOptions`, `addPathFilterArgs`, and `parsePathFilter` CLI
-  utilities in `package:analytica/cli.dart`.
+- Add `addPathFilterOptions` and `parsePathFilter` CLI utilities in
+  `package:analytica/cli.dart`.
 - Add `package:analytica/testing.dart` with `resolvePackageDirectory`,
   `resolvePackageFile`, `resolvePackageExecutable`, and `capturePrints` test
   helpers.

--- a/packages/analytica/README.md
+++ b/packages/analytica/README.md
@@ -1,12 +1,11 @@
-Shared utilities, SDK discovery, Git diff integration, and AST analysis
-helpers for Dart CLI tools and analyzers.
+Shared utilities, SDK discovery, Git diff integration, and AST analysis helpers
+for Dart CLI tools and analyzers.
 
-> [!NOTE]
-> This package provides foundational infrastructure for tools in the
+> [!NOTE] This package provides foundational infrastructure for tools in the
 > [`analytica.dart`](https://github.com/kevmoo/analytica.dart) monorepo (such as
-> [`pkg:cognitive_complexity`](https://pub.dev/packages/cognitive_complexity) and
-> `pkg:undead`). APIs are primarily tailored for internal tool composition and
-> may evolve with tool requirements.
+> [`pkg:cognitive_complexity`](https://pub.dev/packages/cognitive_complexity)
+> and `pkg:undead`). APIs are primarily tailored for internal tool composition
+> and may evolve with tool requirements.
 
 ## ✨ Features
 
@@ -14,20 +13,23 @@ helpers for Dart CLI tools and analyzers.
   - Resolves Dart SDK and Flutter SDK installation roots deterministically.
   - Locates `dart` / `flutter` executables across system paths, Flutter caches,
     and AOT snapshot runtimes.
-  - Discovers `.dart_tool/package_config.json` across parent directories and
-    Pub Workspaces.
+  - Discovers `.dart_tool/package_config.json` across parent directories and Pub
+    Workspaces.
 - **AST & Analysis Utilities (`package:analytica/analyzer.dart`)**:
   - `AnalysisContextHelper`: Lightweight setup for `package:analyzer` analysis
     contexts.
   - `CommentDirectiveParser`: Parses file-level and declaration-level ignore
     directives.
-  - `AstHelpers`: Traversal utilities for enclosing declarations and token spans.
+  - `AstHelpers`: Traversal utilities for enclosing declarations and token
+    spans.
   - `WildcardPattern`: Zero-dependency glob-like pattern matcher (`*`, `?`).
 - **Git Integration (`package:analytica/git.dart`)**:
   - `GitDiffService`: Executes `git diff` against base refs.
   - `DiffParser`: Parses unified diffs into structured file/hunk models.
-  - `AstLineMapper`: Maps AST declaration node line ranges to modified diff lines.
-- **CLI & CI Utilities (`package:analytica/cli.dart`, `package:analytica/analytica.dart`)**:
+  - `AstLineMapper`: Maps AST declaration node line ranges to modified diff
+    lines.
+- **CLI & CI Utilities (`package:analytica/cli.dart`,
+  `package:analytica/analytica.dart`)**:
   - Standardized console formatting, color utilities, and error handling.
   - GitHub Actions workflow command integration (error/warning annotations).
 

--- a/packages/analytica/lib/analyzer.dart
+++ b/packages/analytica/lib/analyzer.dart
@@ -5,3 +5,4 @@ export 'src/analyzer/ast_helpers.dart';
 export 'src/analyzer/comment_parser.dart';
 export 'src/analyzer/context_helper.dart';
 export 'src/analyzer/glob_matcher.dart';
+export 'src/analyzer/path_filter.dart';

--- a/packages/analytica/lib/src/analyzer/path_filter.dart
+++ b/packages/analytica/lib/src/analyzer/path_filter.dart
@@ -1,0 +1,95 @@
+import 'package:path/path.dart' as p;
+
+import 'glob_matcher.dart';
+
+/// Configurable path filter evaluating whether file paths should be excluded
+/// from analysis.
+class PathFilter {
+  /// Default directory names and glob patterns excluded from scanning.
+  static const defaultIgnoredDirectories = <String>[
+    '.dart_tool/**',
+    '.git/**',
+    'build/**',
+    '.idea/**',
+    '.vscode/**',
+  ];
+
+  /// Standard file patterns identifying generated Dart source code.
+  static const defaultGeneratedPatterns = <String>[
+    '**/*.g.dart',
+    '**/*.freezed.dart',
+    '**/*.mocks.dart',
+    '**/*.config.dart',
+    '**/*.reflectable.dart',
+    '**/*.gen.dart',
+    '**/*.pb.dart',
+    '**/*.pbenum.dart',
+    '**/*.pbjson.dart',
+    '**/*.pbserver.dart',
+  ];
+
+  /// The custom exclusion glob patterns configured on this filter.
+  final List<String> excludePatterns;
+
+  /// Whether generated Dart files matching [defaultGeneratedPatterns] are
+  /// excluded.
+  final bool ignoreGenerated;
+
+  final List<WildcardPattern> _wildcards;
+
+  /// Creates a [PathFilter] with optional custom [excludePatterns] and
+  /// [ignoreGenerated] toggle (defaults to `true`).
+  PathFilter({
+    Iterable<String> excludePatterns = const [],
+    this.ignoreGenerated = true,
+  }) : excludePatterns = List.unmodifiable(excludePatterns),
+       _wildcards = [
+         ...defaultIgnoredDirectories.map(
+           (p) => WildcardPattern(_normalizePattern(p)),
+         ),
+         if (ignoreGenerated)
+           ...defaultGeneratedPatterns.map(
+             (p) => WildcardPattern(_normalizePattern(p)),
+           ),
+         ...excludePatterns.map((p) => WildcardPattern(_normalizePattern(p))),
+       ];
+
+  /// Default constant filter instance with standard ignored directories and
+  /// generated file exclusion enabled.
+  static final PathFilter defaults = PathFilter();
+
+  static String _normalizePattern(String raw) {
+    var pat = raw.trim().replaceAll(r'\', '/');
+    if (pat.startsWith('./')) {
+      pat = pat.substring(2);
+    }
+    // If the pattern contains no slash, treat it as matching anywhere.
+    if (!pat.contains('/') && !pat.startsWith('**')) {
+      return '**/$pat';
+    }
+    return pat;
+  }
+
+  /// Returns `true` if [relativePath] matches any active exclusion pattern or
+  /// contains a standard ignored directory segment.
+  bool isExcluded(String relativePath) {
+    final normalized = p.posix.normalize(relativePath).replaceAll(r'\', '/');
+    var clean = normalized;
+    if (clean.startsWith('./')) {
+      clean = clean.substring(2);
+    } else if (clean.startsWith('/')) {
+      clean = clean.substring(1);
+    }
+
+    final segments = clean.split('/');
+    if (segments.contains('.dart_tool') ||
+        segments.contains('.git') ||
+        segments.contains('.idea') ||
+        segments.contains('.vscode') ||
+        (segments.isNotEmpty && segments.first == 'build')) {
+      return true;
+    }
+
+    return WildcardPattern.anyMatch(_wildcards, clean);
+  }
+}

--- a/packages/analytica/lib/src/analyzer/path_filter.dart
+++ b/packages/analytica/lib/src/analyzer/path_filter.dart
@@ -63,6 +63,9 @@ class PathFilter {
     if (pat.startsWith('./')) {
       pat = pat.substring(2);
     }
+    if (pat.startsWith('/')) {
+      pat = pat.substring(1);
+    }
     // If the pattern contains no slash, treat it as matching anywhere.
     if (!pat.contains('/') && !pat.startsWith('**')) {
       return '**/$pat';

--- a/packages/analytica/lib/src/cli.dart
+++ b/packages/analytica/lib/src/cli.dart
@@ -1,7 +1,11 @@
 import 'package:args/args.dart';
 import 'package:path/path.dart' as p;
 
+import 'analyzer/path_filter.dart';
+
 export 'package:io/io.dart' show ExitCode;
+
+export 'analyzer/path_filter.dart';
 
 /// Standard CLI argument parsing options and helpers across Analytica tools.
 extension AnalyticaArgParserExtensions on ArgParser {
@@ -36,6 +40,52 @@ extension AnalyticaArgParserExtensions on ArgParser {
   void addVersionFlag({String help = 'Print version information.'}) {
     addFlag('version', negatable: false, help: help);
   }
+
+  /// Adds standardized `--exclude` and `--[no-]ignore-generated` options to
+  /// this parser.
+  void addPathFilterOptions() {
+    addMultiOption(
+      'exclude',
+      help:
+          'Glob patterns of files/directories to exclude (repeatable or '
+          'comma-separated).',
+      valueHelp: 'glob',
+    );
+    addFlag(
+      'ignore-generated',
+      defaultsTo: true,
+      help:
+          'Exclude generated files (*.g.dart, *.freezed.dart, *.mocks.dart, '
+          'etc.).',
+    );
+  }
+}
+
+/// Adds standardized path exclusion options (`--exclude`,
+/// `--[no-]ignore-generated`) to [parser].
+void addPathFilterArgs(ArgParser parser) {
+  parser.addPathFilterOptions();
+}
+
+/// Parses a [PathFilter] from the standard `--exclude` and `--ignore-generated`
+/// options in [results].
+PathFilter parsePathFilter(ArgResults results) {
+  final rawExcludes = results.options.contains('exclude')
+      ? results.multiOption('exclude')
+      : const <String>[];
+  final expandedExcludes = rawExcludes
+      .expand((e) => e.split(','))
+      .map((e) => e.trim())
+      .where((e) => e.isNotEmpty);
+
+  final ignoreGenerated = results.options.contains('ignore-generated')
+      ? results.flag('ignore-generated')
+      : true;
+
+  return PathFilter(
+    excludePatterns: expandedExcludes,
+    ignoreGenerated: ignoreGenerated,
+  );
 }
 
 /// Parses a 1-based line range of format `<start>-<end>` (e.g. `45-80`).

--- a/packages/analytica/lib/src/cli.dart
+++ b/packages/analytica/lib/src/cli.dart
@@ -61,19 +61,16 @@ extension AnalyticaArgParserExtensions on ArgParser {
   }
 }
 
-/// Adds standardized path exclusion options (`--exclude`,
-/// `--[no-]ignore-generated`) to [parser].
-void addPathFilterArgs(ArgParser parser) {
-  parser.addPathFilterOptions();
-}
-
 /// Parses a [PathFilter] from the standard `--exclude` and `--ignore-generated`
 /// options in [results].
-PathFilter parsePathFilter(ArgResults results) {
+PathFilter parsePathFilter(
+  ArgResults results, {
+  Iterable<String> defaultExcludes = const [],
+}) {
   final rawExcludes = results.options.contains('exclude')
       ? results.multiOption('exclude')
       : const <String>[];
-  final expandedExcludes = rawExcludes
+  final userExcludes = rawExcludes
       .expand((e) => e.split(','))
       .map((e) => e.trim())
       .where((e) => e.isNotEmpty);
@@ -83,7 +80,7 @@ PathFilter parsePathFilter(ArgResults results) {
       : true;
 
   return PathFilter(
-    excludePatterns: expandedExcludes,
+    excludePatterns: [...defaultExcludes, ...userExcludes],
     ignoreGenerated: ignoreGenerated,
   );
 }

--- a/packages/analytica/test/analyzer/path_filter_test.dart
+++ b/packages/analytica/test/analyzer/path_filter_test.dart
@@ -1,0 +1,71 @@
+import 'package:analytica/analyzer.dart';
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group('PathFilter', () {
+    test('defaults exclude standard build and metadata directories', () {
+      final filter = PathFilter.defaults;
+
+      check(filter.isExcluded('.dart_tool/package_config.json')).isTrue();
+      check(filter.isExcluded('.git/HEAD')).isTrue();
+      check(filter.isExcluded('.idea/workspace.xml')).isTrue();
+      check(filter.isExcluded('.vscode/settings.json')).isTrue();
+      check(filter.isExcluded('build/app/outputs')).isTrue();
+      check(filter.isExcluded('build/flutter_assets/foo.png')).isTrue();
+
+      check(filter.isExcluded('lib/src/build/builder.dart')).isFalse();
+      check(filter.isExcluded('lib/builders/code_builder.dart')).isFalse();
+      check(filter.isExcluded('.github/workflows/ci.yml')).isFalse();
+      check(filter.isExcluded('lib/src/service.dart')).isFalse();
+    });
+
+    test('defaults exclude generated Dart files', () {
+      final filter = PathFilter.defaults;
+
+      check(filter.isExcluded('lib/src/model.g.dart')).isTrue();
+      check(filter.isExcluded('lib/src/model.freezed.dart')).isTrue();
+      check(filter.isExcluded('test/service.mocks.dart')).isTrue();
+      check(filter.isExcluded('lib/di.config.dart')).isTrue();
+      check(filter.isExcluded('lib/generated.reflectable.dart')).isTrue();
+      check(filter.isExcluded('lib/schema.pb.dart')).isTrue();
+      check(filter.isExcluded('lib/schema.pbenum.dart')).isTrue();
+      check(filter.isExcluded('lib/schema.pbjson.dart')).isTrue();
+      check(filter.isExcluded('lib/schema.pbserver.dart')).isTrue();
+
+      check(filter.isExcluded('lib/src/model.dart')).isFalse();
+      check(filter.isExcluded('lib/generator.dart')).isFalse();
+    });
+
+    test('ignoreGenerated: false includes generated files', () {
+      final filter = PathFilter(ignoreGenerated: false);
+
+      check(filter.isExcluded('lib/src/model.g.dart')).isFalse();
+      check(filter.isExcluded('lib/src/model.freezed.dart')).isFalse();
+      check(filter.isExcluded('test/service.mocks.dart')).isFalse();
+
+      // Still excludes standard tool directories
+      check(filter.isExcluded('.dart_tool/package_config.json')).isTrue();
+      check(filter.isExcluded('.git/HEAD')).isTrue();
+      check(filter.isExcluded('build/output.dart')).isTrue();
+    });
+
+    test('custom excludePatterns match specific globs and prefixes', () {
+      final filter = PathFilter(
+        excludePatterns: ['test/fixtures/**', 'legacy_*.dart'],
+      );
+
+      check(filter.isExcluded('test/fixtures/sample.dart')).isTrue();
+      check(filter.isExcluded('lib/src/legacy_parser.dart')).isTrue();
+      check(filter.isExcluded('lib/src/regular_parser.dart')).isFalse();
+    });
+
+    test('normalizes leading ./ and backslashes', () {
+      final filter = PathFilter(excludePatterns: ['custom/**']);
+
+      check(filter.isExcluded(r'.\custom\sub\file.dart')).isTrue();
+      check(filter.isExcluded('./custom/sub/file.dart')).isTrue();
+      check(filter.isExcluded(r'lib\src\model.g.dart')).isTrue();
+    });
+  });
+}

--- a/packages/analytica/test/analyzer/path_filter_test.dart
+++ b/packages/analytica/test/analyzer/path_filter_test.dart
@@ -60,11 +60,14 @@ void main() {
       check(filter.isExcluded('lib/src/regular_parser.dart')).isFalse();
     });
 
-    test('normalizes leading ./ and backslashes', () {
-      final filter = PathFilter(excludePatterns: ['custom/**']);
+    test('normalizes leading ./, /, and backslashes', () {
+      final filter = PathFilter(excludePatterns: ['/custom/**', './other/**']);
 
       check(filter.isExcluded(r'.\custom\sub\file.dart')).isTrue();
       check(filter.isExcluded('./custom/sub/file.dart')).isTrue();
+      check(filter.isExcluded('/custom/sub/file.dart')).isTrue();
+      check(filter.isExcluded('custom/sub/file.dart')).isTrue();
+      check(filter.isExcluded('other/sub/file.dart')).isTrue();
       check(filter.isExcluded(r'lib\src\model.g.dart')).isTrue();
     });
   });

--- a/packages/analytica/test/cli_test.dart
+++ b/packages/analytica/test/cli_test.dart
@@ -29,6 +29,25 @@ void main() {
       check(results['help'] as bool).isTrue();
       check(results['version'] as bool).isTrue();
     });
+
+    test('addPathFilterOptions configures exclude and ignore-generated', () {
+      final parser = ArgParser()..addPathFilterOptions();
+      final defaultResults = parser.parse([]);
+      final defaultFilter = parsePathFilter(defaultResults);
+      check(defaultFilter.ignoreGenerated).isTrue();
+      check(defaultFilter.excludePatterns).isEmpty();
+
+      final customResults = parser.parse([
+        '--exclude=test/fixtures/**',
+        '--exclude=legacy/**,*.gen.dart',
+        '--no-ignore-generated',
+      ]);
+      final customFilter = parsePathFilter(customResults);
+      check(customFilter.ignoreGenerated).isFalse();
+      check(
+        customFilter.excludePatterns,
+      ).deepEquals(['test/fixtures/**', 'legacy/**', '*.gen.dart']);
+    });
   });
 
   group('parseLineBounds', () {

--- a/packages/cli_readme/CHANGELOG.md
+++ b/packages/cli_readme/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 0.1.0-wip
 
 - Initial release of `package:cli_readme`:
-  - 3-line test contract (`expectReadmeHelpClean`) to verify CLI usage in `README.md`.
+  - 3-line test contract (`expectReadmeHelpClean`) to verify CLI usage in
+    `README.md`.
   - Standalone CLI runner (`dart run cli_readme --write` / `--check`).
   - In-memory `ArgParser` evaluation for fast zero-subprocess testing.
   - Tagged HTML comment marker support (`<!-- CLI_README_START [id] -->`).

--- a/packages/cli_readme/README.md
+++ b/packages/cli_readme/README.md
@@ -1,5 +1,5 @@
-Test utility and CLI tool to ensure command-line usage and help documentation
-in `README.md` files are accurate and up-to-date.
+Test utility and CLI tool to ensure command-line usage and help documentation in
+`README.md` files are accurate and up-to-date.
 
 Inspired by [`package:build_verify`](https://pub.dev/packages/build_verify),
 `cli_readme` gives you a **3-line test** to guarantee your CLI arguments and
@@ -26,6 +26,7 @@ usage examples never drift from the real executable output.
 Add HTML comment markers around the CLI output in your `README.md`:
 
 <!-- CLI_README_START -->
+
 ```console
 $ cli_readme --help
 Test utility and CLI tool to ensure CLI usage in README files is up-to-date.
@@ -39,6 +40,7 @@ Usage: cli_readme [options]
     --package-dir    Path to package directory (defaults to current directory).
     --readme         Path to README.md file (defaults to README.md in package root).
 ```
+
 <!-- CLI_README_END -->
 
 ### 2. Add the Test
@@ -96,19 +98,25 @@ Specify target IDs to map multiple sections in your `README.md`:
 
 ````markdown
 ### Server CLI
+
 <!-- CLI_README_START server -->
+
 ```console
 $ my_server --help
 ...
 ```
+
 <!-- CLI_README_END server -->
 
 ### Client CLI
+
 <!-- CLI_README_START client -->
+
 ```console
 $ my_client --help
 ...
 ```
+
 <!-- CLI_README_END client -->
 ````
 

--- a/packages/cognitive_complexity/CHANGELOG.md
+++ b/packages/cognitive_complexity/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## 0.2.5-wip
 
+- Support `--exclude` and `--[no-]ignore-generated` CLI options to configure
+  file exclusion and generated code filtering via `PathFilter`.
+- Add `pathFilter` parameter to `ComplexityAnalyzer` and `DeltaAnalyzer`.
 - Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in `README.md`.
 - Update GitHub Action documentation in `README.md` to reference modular
   subdirectory path (`packages/cognitive_complexity`) and add rendered Action
   Inputs Reference table.
+
 
 ## 0.2.4
 

--- a/packages/cognitive_complexity/CHANGELOG.md
+++ b/packages/cognitive_complexity/CHANGELOG.md
@@ -3,11 +3,11 @@
 - Support `--exclude` and `--[no-]ignore-generated` CLI options to configure
   file exclusion and generated code filtering via `PathFilter`.
 - Add `pathFilter` parameter to `ComplexityAnalyzer` and `DeltaAnalyzer`.
-- Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in `README.md`.
+- Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in
+  `README.md`.
 - Update GitHub Action documentation in `README.md` to reference modular
   subdirectory path (`packages/cognitive_complexity`) and add rendered Action
   Inputs Reference table.
-
 
 ## 0.2.4
 
@@ -23,11 +23,12 @@
   (violations, then increases, then additions) for posting as a PR comment,
   while the step summary keeps the full table (#49).
 - Add `commentFile` and `maxCommentRows` parameters to `GitHubReporter`.
-- Add `max-comment-rows` input to the GitHub Action (default `0` = unlimited)
-  to keep sticky comments under GitHub's 65536-character body limit.
-- Anchor GitHub annotations to the declaration line only, so they render
-  under the function signature instead of after the closing brace (#55).
-- Move package into pub workspace monorepo layout under `packages/cognitive_complexity`.
+- Add `max-comment-rows` input to the GitHub Action (default `0` = unlimited) to
+  keep sticky comments under GitHub's 65536-character body limit.
+- Anchor GitHub annotations to the declaration line only, so they render under
+  the function signature instead of after the closing brace (#55).
+- Move package into pub workspace monorepo layout under
+  `packages/cognitive_complexity`.
 - Restore root `action.yml` and `skills/` structure for monorepo workspace.
 
 ## 0.2.3

--- a/packages/cognitive_complexity/README.md
+++ b/packages/cognitive_complexity/README.md
@@ -36,6 +36,7 @@ _(Requires Dart SDK **3.12.0 or greater**)_.
 ### `cognitive_complexity` CLI Options
 
 <!-- CLI_README_START cognitive_complexity -->
+
 ```console
 $ cognitive_complexity --help
 Dart & Flutter Cognitive Complexity Calculator
@@ -58,11 +59,13 @@ Options:
     --[no-]ignore-generated       Exclude generated files (*.g.dart, *.freezed.dart, *.mocks.dart, etc.).
                                   (defaults to on)
 ```
+
 <!-- CLI_README_END cognitive_complexity -->
 
 ### `data_flow` CLI Options
 
 <!-- CLI_README_START data_flow -->
+
 ```console
 $ data_flow --help
 Dart Data-Flow & Method Extraction Analyzer
@@ -92,6 +95,7 @@ Options:
                   [json (default), text]
     --sdk-path    Path to the Dart SDK root used for analysis. Defaults to auto-discovery (running VM, DART_SDK environment variable, PATH, FLUTTER_ROOT).
 ```
+
 <!-- CLI_README_END data_flow -->
 
 ### Library API
@@ -148,15 +152,17 @@ jobs:
 #### Action Inputs Reference
 
 <!-- mdformat off(prevent table wrapping) -->
-| Input | Default | Description |
-| :--- | :---: | :--- |
-| `targets` | `lib` | Space-separated list of directories or files to scan. |
-| `threshold` | `0` | Minimum score required to include a declaration in summary tables. |
-| `fail-threshold` | `15` | Maximum complexity ceiling allowed before failing the build. |
-| `diff-base` | _Auto_ | Git ref to compare against (e.g. `origin/main`). Auto-detects PR base. |
-| `fail-on-increase` | `false` | When `true`, blocks PR merge on complexity increases exceeding `fail-threshold`. |
-| `format` | `github` | Output format: `github` (annotations + step summary), `text`, or `json`. |
-| `max-comment-rows` | `0` | Maximum table rows in the sticky PR comment (0 = unlimited). |
+
+| Input              | Default  | Description                                                                      |
+| :----------------- | :------: | :------------------------------------------------------------------------------- |
+| `targets`          |  `lib`   | Space-separated list of directories or files to scan.                            |
+| `threshold`        |   `0`    | Minimum score required to include a declaration in summary tables.               |
+| `fail-threshold`   |   `15`   | Maximum complexity ceiling allowed before failing the build.                     |
+| `diff-base`        |  _Auto_  | Git ref to compare against (e.g. `origin/main`). Auto-detects PR base.           |
+| `fail-on-increase` | `false`  | When `true`, blocks PR merge on complexity increases exceeding `fail-threshold`. |
+| `format`           | `github` | Output format: `github` (annotations + step summary), `text`, or `json`.         |
+| `max-comment-rows` |   `0`    | Maximum table rows in the sticky PR comment (0 = unlimited).                     |
+
 <!-- mdformat on -->
 
 ## 🧠 AI Agent Integration

--- a/packages/cognitive_complexity/README.md
+++ b/packages/cognitive_complexity/README.md
@@ -54,6 +54,9 @@ Options:
     --comment-output=<path>       With --format=github, also write a standalone report to this path, ordered by significance and capped by --max-comment-rows. Intended for posting as a PR comment while the step summary keeps the full table.
     --max-comment-rows=<count>    Maximum table rows in --comment-output (0 = unlimited). GitHub rejects comment bodies over 65536 characters.
                                   (defaults to "0")
+    --exclude=<glob>              Glob patterns of files/directories to exclude (repeatable or comma-separated).
+    --[no-]ignore-generated       Exclude generated files (*.g.dart, *.freezed.dart, *.mocks.dart, etc.).
+                                  (defaults to on)
 ```
 <!-- CLI_README_END cognitive_complexity -->
 

--- a/packages/cognitive_complexity/lib/src/complexity/cli.dart
+++ b/packages/cognitive_complexity/lib/src/complexity/cli.dart
@@ -80,7 +80,8 @@ Future<int> runCli(
       help:
           'Maximum table rows in --comment-output (0 = unlimited). GitHub '
           'rejects comment bodies over 65536 characters.',
-    );
+    )
+    ..addPathFilterOptions();
 
   try {
     final argResults = parser.parse(args);
@@ -111,6 +112,7 @@ Future<int> runCli(
       argResults['max-comment-rows'] as String,
       'max-comment-rows',
     );
+    final pathFilter = parsePathFilter(argResults);
 
     _warnIgnoredFlags(
       failOnIncrease: failOnIncrease,
@@ -127,6 +129,7 @@ Future<int> runCli(
       return await _handleDiffMode(
         gitDiffBase: gitDiffBase,
         targets: targets,
+        pathFilter: pathFilter,
         format: format,
         failThreshold: failThreshold,
         failOnIncrease: failOnIncrease,
@@ -139,6 +142,7 @@ Future<int> runCli(
 
     return _handleRegularMode(
       targets: targets,
+      pathFilter: pathFilter,
       threshold: threshold,
       failThreshold: failThreshold,
       format: format,
@@ -184,6 +188,7 @@ void _warnIgnoredFlags({
 Future<int> _handleDiffMode({
   required String gitDiffBase,
   required List<String> targets,
+  required PathFilter pathFilter,
   required String format,
   required int? failThreshold,
   required bool failOnIncrease,
@@ -192,7 +197,7 @@ Future<int> _handleDiffMode({
   String? commentOutput,
   int maxCommentRows = 0,
 }) async {
-  final deltaAnalyzer = DeltaAnalyzer();
+  final deltaAnalyzer = DeltaAnalyzer(pathFilter: pathFilter);
   final summary = await deltaAnalyzer.computeDeltas(
     gitDiffBase,
     targetPaths: targets,
@@ -242,13 +247,14 @@ Future<int> _handleDiffMode({
 
 int _handleRegularMode({
   required List<String> targets,
+  required PathFilter pathFilter,
   required int threshold,
   required int? failThreshold,
   required String format,
   required StringSink out,
   required StringSink err,
 }) {
-  final analyzer = ComplexityAnalyzer();
+  final analyzer = ComplexityAnalyzer(pathFilter: pathFilter);
   final allResults = <FunctionComplexity>[];
 
   for (final target in targets) {

--- a/packages/cognitive_complexity/lib/src/complexity/complexity_analyzer.dart
+++ b/packages/cognitive_complexity/lib/src/complexity/complexity_analyzer.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/source/line_info.dart';
 import 'package:path/path.dart' as p;
 import 'cognitive_complexity_visitor.dart';
 
-export 'package:analytica/analyzer.dart' show isExcludedPath;
+export 'package:analytica/analyzer.dart' show PathFilter, isExcludedPath;
 
 /// Represents the analyzed cognitive complexity of a specific declaration.
 class FunctionComplexity {
@@ -40,7 +40,11 @@ class FunctionComplexity {
 
 /// Analyzes Dart files and directories to compute Cognitive Complexity scores.
 class ComplexityAnalyzer {
+  final PathFilter pathFilter;
   final FeatureSet _featureSet = FeatureSet.latestLanguageVersion();
+
+  ComplexityAnalyzer({PathFilter? pathFilter})
+    : pathFilter = pathFilter ?? PathFilter.defaults;
 
   /// Analyzes a file or directory at [targetPath].
   List<FunctionComplexity> analyzePath(String targetPath) {
@@ -68,7 +72,7 @@ class ComplexityAnalyzer {
     for (final entity in dir.listSync(recursive: true, followLinks: false)) {
       if (entity is File && p.extension(entity.path) == '.dart') {
         final relative = p.relative(entity.path, from: targetPath);
-        if (isExcludedPath(relative)) {
+        if (pathFilter.isExcluded(relative)) {
           continue;
         }
         results.addAll(analyzeFile(entity.path));

--- a/packages/cognitive_complexity/lib/src/complexity/delta_analyzer.dart
+++ b/packages/cognitive_complexity/lib/src/complexity/delta_analyzer.dart
@@ -147,12 +147,21 @@ class DeltaSummary {
 
 /// Evaluates git diffs to calculate cognitive complexity score deltas.
 class DeltaAnalyzer {
-  final ComplexityAnalyzer _analyzer = ComplexityAnalyzer();
+  final ComplexityAnalyzer _analyzer;
   final GitDiffService _gitService;
+  final PathFilter pathFilter;
 
-  DeltaAnalyzer({GitDiffService? gitService, String? workingDirectory})
-    : _gitService =
-          gitService ?? GitDiffService(workingDirectory: workingDirectory);
+  DeltaAnalyzer({
+    ComplexityAnalyzer? analyzer,
+    GitDiffService? gitService,
+    String? workingDirectory,
+    PathFilter? pathFilter,
+  }) : pathFilter = pathFilter ?? PathFilter.defaults,
+       _analyzer =
+           analyzer ??
+           ComplexityAnalyzer(pathFilter: pathFilter ?? PathFilter.defaults),
+       _gitService =
+           gitService ?? GitDiffService(workingDirectory: workingDirectory);
 
   /// Computes complexity deltas between [baseRef] and current working tree.
   Future<DeltaSummary> computeDeltas(
@@ -160,10 +169,13 @@ class DeltaAnalyzer {
     List<String> targetPaths = const [],
   }) async {
     final mergeBase = await _gitService.getMergeBase(baseRef);
-    final modFiles = await _gitService.getModifiedDartFiles(
+    final rawModFiles = await _gitService.getModifiedDartFiles(
       mergeBase,
       targetPaths: targetPaths,
     );
+    final modFiles = rawModFiles
+        .where((f) => !pathFilter.isExcluded(f))
+        .toList();
     final allDeltas = <ComplexityDelta>[];
 
     final pool = Pool(8);

--- a/packages/cognitive_complexity/test/exclude_test.dart
+++ b/packages/cognitive_complexity/test/exclude_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:checks/checks.dart';
+import 'package:cognitive_complexity/cognitive_complexity.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/scaffolding.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+void main() {
+  group('ComplexityAnalyzer path filtering', () {
+    test('skips generated Dart files by default', () async {
+      final dir = p.join(d.sandbox, 'gen_project');
+      final libDir = Directory(p.join(dir, 'lib'))..createSync(recursive: true);
+
+      File(p.join(libDir.path, 'model.dart')).writeAsStringSync('''
+int normalFunction(int x) {
+  if (x > 0) {
+    for (var i = 0; i < x; i++) {
+      if (i % 2 == 0) return i;
+    }
+  }
+  return 0;
+}
+''');
+
+      File(p.join(libDir.path, 'model.g.dart')).writeAsStringSync('''
+int generatedFunction(int x) {
+  if (x > 0) {
+    for (var i = 0; i < x; i++) {
+      if (i % 2 == 0) return i;
+    }
+  }
+  return 0;
+}
+''');
+
+      final analyzer = ComplexityAnalyzer();
+      final results = analyzer.analyzePath(dir);
+
+      check(results).length.equals(1);
+      check(results.first.name).equals('normalFunction');
+    });
+
+    test('analyzes generated files when ignoreGenerated: false', () async {
+      final dir = p.join(d.sandbox, 'gen_project_all');
+      final libDir = Directory(p.join(dir, 'lib'))..createSync(recursive: true);
+
+      File(
+        p.join(libDir.path, 'model.dart'),
+      ).writeAsStringSync('int a() => 1;');
+      File(
+        p.join(libDir.path, 'model.g.dart'),
+      ).writeAsStringSync('int b() => 2;');
+
+      final analyzer = ComplexityAnalyzer(
+        pathFilter: PathFilter(ignoreGenerated: false),
+      );
+      final results = analyzer.analyzePath(dir);
+
+      check(results).length.equals(2);
+    });
+
+    test('custom excludePatterns skips matching files', () async {
+      final dir = p.join(d.sandbox, 'custom_project');
+      final libDir = Directory(p.join(dir, 'lib'))..createSync(recursive: true);
+
+      File(
+        p.join(libDir.path, 'legacy_auth.dart'),
+      ).writeAsStringSync('int a() => 1;');
+      File(
+        p.join(libDir.path, 'new_auth.dart'),
+      ).writeAsStringSync('int b() => 2;');
+
+      final analyzer = ComplexityAnalyzer(
+        pathFilter: PathFilter(excludePatterns: ['**/legacy_*']),
+      );
+      final results = analyzer.analyzePath(dir);
+
+      check(results).length.equals(1);
+      check(results.first.name).equals('b');
+    });
+  });
+}

--- a/packages/dedupe/CHANGELOG.md
+++ b/packages/dedupe/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 0.1.1-wip
 
+- Adopt centralized `PathFilter` for `--exclude` and generated code filtering
+  (`--[no-]ignore-generated`).
 - Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in `README.md`.
 - Add `dart-dedupe` agent skill integration guide in `README.md`.
+
 
 ## 0.1.0
 

--- a/packages/dedupe/CHANGELOG.md
+++ b/packages/dedupe/CHANGELOG.md
@@ -2,21 +2,29 @@
 
 - Adopt centralized `PathFilter` for `--exclude` and generated code filtering
   (`--[no-]ignore-generated`).
-- Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in `README.md`.
+- Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in
+  `README.md`.
 - Add `dart-dedupe` agent skill integration guide in `README.md`.
-
 
 ## 0.1.0
 
 - Initial release of `pkg:dedupe`:
-  - Token-level and structural clone detection across Dart and Flutter codebases.
+  - Token-level and structural clone detection across Dart and Flutter
+    codebases.
   - Polynomial rolling hash k-gram indexing and maximal clone extension.
-  - Granular normalization filters (`--ignore-comments`, `--ignore-literals`, `--ignore-identifiers`).
-  - Persistent content-hashed disk caching (`--cache`, `--cache-dir`, `--clear-cache`).
-  - Exact line-union overlapping clone cluster deduplication and net lines saved analysis.
-  - Linear adjacent chaining and MinHash token verification for large-scale clone clusters (>50 instances).
+  - Granular normalization filters (`--ignore-comments`, `--ignore-literals`,
+    `--ignore-identifiers`).
+  - Persistent content-hashed disk caching (`--cache`, `--cache-dir`,
+    `--clear-cache`).
+  - Exact line-union overlapping clone cluster deduplication and net lines saved
+    analysis.
+  - Linear adjacent chaining and MinHash token verification for large-scale
+    clone clusters (>50 instances).
   - Git diff integration and PR delta scanning (`--git-diff`, `--only-changed`).
-  - Multi-format report generation: Markdown, JSON, GitHub Actions annotations/summaries, and terminal text.
-  - Per-file duplication metrics, cluster classification, and estimated lines saved analysis.
-  - Value-semantic, immutable report models (`CloneInstance`, `DuplicateCluster`, `DedupeReport`) with full JSON serialization.
+  - Multi-format report generation: Markdown, JSON, GitHub Actions
+    annotations/summaries, and terminal text.
+  - Per-file duplication metrics, cluster classification, and estimated lines
+    saved analysis.
+  - Value-semantic, immutable report models (`CloneInstance`,
+    `DuplicateCluster`, `DedupeReport`) with full JSON serialization.
   - CLI binary entrypoint (`bin/dedupe.dart`).

--- a/packages/dedupe/README.md
+++ b/packages/dedupe/README.md
@@ -82,7 +82,9 @@ Usage: dedupe [options] [target_path]
     --fail-threshold=<percentage>          Exit with non-zero code (1) if overall duplication percentage (or diff duplication percentage when --git-diff is set) exceeds this ceiling.
 -d, --git-diff=<git-ref>                   Git reference (e.g. origin/main or HEAD~1) to compare against for PR/CL delta evaluation.
     --[no-]only-changed                    Only report duplicate clusters that intersect modified lines in the Git diff.
-    --exclude=<pattern1,pattern2>          Comma-separated glob/wildcard patterns of files to exclude.
+    --exclude=<glob>                       Glob patterns of files/directories to exclude (repeatable or comma-separated).
+    --[no-]ignore-generated                Exclude generated files (*.g.dart, *.freezed.dart, *.mocks.dart, etc.).
+                                           (defaults to on)
     --include=<pattern1,pattern2>          Comma-separated glob/wildcard patterns of files to include.
     --[no-]files                           Include per-file duplication metrics table in report.
                                            (defaults to on)

--- a/packages/dedupe/README.md
+++ b/packages/dedupe/README.md
@@ -55,6 +55,7 @@ dart run dedupe@ --git-diff=origin/main --fail-threshold=5
 ## CLI options
 
 <!-- CLI_README_START -->
+
 ```console
 $ dedupe --help
 dedupe - High-performance code duplication and clone detection engine for Dart.
@@ -98,6 +99,7 @@ Usage: dedupe [options] [target_path]
 -h, --help                                 Print usage information.
     --version                              Print dedupe version.
 ```
+
 <!-- CLI_README_END -->
 
 ## Programmatic API
@@ -127,7 +129,9 @@ void main() async {
 
 ## 🧠 AI Agent Integration
 
-This repository packages an agent skill (`dart-dedupe`) to train AI pair programmers on structural code duplication audits, clone triage, and safe deduplication refactoring:
+This repository packages an agent skill (`dart-dedupe`) to train AI pair
+programmers on structural code duplication audits, clone triage, and safe
+deduplication refactoring:
 
 ```bash
 npx skills add kevmoo/analytica.dart --skill dart-dedupe

--- a/packages/dedupe/lib/src/cli.dart
+++ b/packages/dedupe/lib/src/cli.dart
@@ -245,7 +245,10 @@ class DedupeCliRunner {
       failThreshold = parsed;
     }
 
-    final pathFilter = parsePathFilter(results);
+    final pathFilter = parsePathFilter(
+      results,
+      defaultExcludes: defaultDartExclusions,
+    );
     final includeList = parseCommaSeparated(results.option('include'));
 
     final String targetPath;

--- a/packages/dedupe/lib/src/cli.dart
+++ b/packages/dedupe/lib/src/cli.dart
@@ -102,11 +102,7 @@ ArgParser buildArgParser() {
           'Only report duplicate clusters that intersect modified lines in '
           'the Git diff.',
     )
-    ..addOption(
-      'exclude',
-      valueHelp: 'pattern1,pattern2',
-      help: 'Comma-separated glob/wildcard patterns of files to exclude.',
-    )
+    ..addPathFilterOptions()
     ..addOption(
       'include',
       valueHelp: 'pattern1,pattern2',
@@ -249,7 +245,7 @@ class DedupeCliRunner {
       failThreshold = parsed;
     }
 
-    final excludeList = parseCommaSeparated(results.option('exclude'));
+    final pathFilter = parsePathFilter(results);
     final includeList = parseCommaSeparated(results.option('include'));
 
     final String targetPath;
@@ -280,13 +276,11 @@ class DedupeCliRunner {
       ignoreComments: ignoreComments,
       ignoreLiterals: ignoreLiterals,
       ignoreIdentifiers: ignoreIdentifiers,
-      excludePatterns: [
-        if (excludeList.isNotEmpty) ...excludeList,
-        if (excludeList.isEmpty) ...defaultDartExclusions,
-      ],
+      pathFilter: pathFilter,
       includePatterns: includeList.isNotEmpty
           ? includeList
           : const ['**/*.dart'],
+
       gitDiffBase: results.option('git-diff'),
       onlyChanged: results.flag('only-changed'),
       failThreshold: failThreshold,

--- a/packages/dedupe/lib/src/engine.dart
+++ b/packages/dedupe/lib/src/engine.dart
@@ -409,7 +409,7 @@ class DedupeEngine {
       return const [];
     }
 
-    final excludes = options.excludePatterns.map(WildcardPattern.new).toList();
+    final pathFilter = options.pathFilter;
     final includes = options.includePatterns.map(WildcardPattern.new).toList();
 
     final discovered = <String>{};
@@ -418,7 +418,7 @@ class DedupeEngine {
         targetDir: targetDir,
         target: target,
         includes: includes,
-        excludes: excludes,
+        pathFilter: pathFilter,
         discovered: discovered,
       );
     }
@@ -431,14 +431,14 @@ class DedupeEngine {
     required Directory targetDir,
     required String target,
     required List<WildcardPattern> includes,
-    required List<WildcardPattern> excludes,
+    required PathFilter pathFilter,
     required Set<String> discovered,
   }) {
     final fullPath = p.normalize(p.join(targetDir.path, target));
     final type = FileSystemEntity.typeSync(fullPath);
 
     if (type == FileSystemEntityType.file) {
-      if (_matchesFilters(fullPath, targetDir.path, includes, excludes)) {
+      if (_matchesFilters(fullPath, targetDir.path, includes, pathFilter)) {
         discovered.add(fullPath);
       }
     } else if (type == FileSystemEntityType.directory) {
@@ -446,7 +446,7 @@ class DedupeEngine {
         dir: Directory(fullPath),
         rootDirPath: targetDir.path,
         includes: includes,
-        excludes: excludes,
+        pathFilter: pathFilter,
         discovered: discovered,
       );
     }
@@ -456,12 +456,12 @@ class DedupeEngine {
     required Directory dir,
     required String rootDirPath,
     required List<WildcardPattern> includes,
-    required List<WildcardPattern> excludes,
+    required PathFilter pathFilter,
     required Set<String> discovered,
   }) {
     for (final entity in dir.listSync(recursive: true, followLinks: false)) {
       if (entity is File &&
-          _matchesFilters(entity.path, rootDirPath, includes, excludes)) {
+          _matchesFilters(entity.path, rootDirPath, includes, pathFilter)) {
         discovered.add(entity.path);
       }
     }
@@ -471,22 +471,20 @@ class DedupeEngine {
     String filePath,
     String rootDirPath,
     List<WildcardPattern> includes,
-    List<WildcardPattern> excludes,
+    PathFilter pathFilter,
   ) {
     if (!filePath.endsWith('.dart')) return false;
 
     final relPath = p.normalize(p.relative(filePath, from: rootDirPath));
+    if (pathFilter.isExcluded(relPath)) {
+      return false;
+    }
+
+    if (includes.isEmpty) return true;
+
     final forwardRelPath = relPath.replaceAll(r'\', '/');
     final rootedPath = '/$forwardRelPath';
     final basename = p.basename(filePath);
-
-    for (final pattern in excludes) {
-      if (pattern.matches(forwardRelPath) ||
-          pattern.matches(rootedPath) ||
-          pattern.matches(basename)) {
-        return false;
-      }
-    }
 
     for (final pattern in includes) {
       if (pattern.matches(forwardRelPath) ||

--- a/packages/dedupe/lib/src/models.dart
+++ b/packages/dedupe/lib/src/models.dart
@@ -549,7 +549,7 @@ final class DedupeOptions {
     this.ignoreLiterals = true,
     this.ignoreIdentifiers = false,
     PathFilter? pathFilter,
-    Iterable<String> excludePatterns = const [],
+    Iterable<String> excludePatterns = defaultDartExclusions,
     bool ignoreGenerated = true,
     List<String> includePatterns = const ['**/*.dart'],
     this.gitDiffBase,

--- a/packages/dedupe/lib/src/models.dart
+++ b/packages/dedupe/lib/src/models.dart
@@ -1,17 +1,12 @@
+import 'package:analytica/analyzer.dart';
+
 /// Standard code-generation, binding, and test mock exclusions for duplication
 /// analysis.
 const List<String> defaultDartExclusions = [
-  '**/*.g.dart',
-  '**/*.freezed.dart',
-  '**/*.pb.dart',
-  '**/*.pbjson.dart',
-  '**/*.pbenum.dart',
-  '**/*.pbserver.dart',
+  ...PathFilter.defaultGeneratedPatterns,
   '**/*_bindings.dart',
   '**/native_*.dart',
   '**/jni_*.dart',
-  '**/*.mocks.dart',
-  '**/*.config.dart',
 ];
 
 /// Classification category for duplicate code clusters.
@@ -525,7 +520,7 @@ final class DedupeOptions {
   final bool ignoreComments;
   final bool ignoreLiterals;
   final bool ignoreIdentifiers;
-  final List<String> excludePatterns;
+  final PathFilter pathFilter;
   final List<String> includePatterns;
   final String? gitDiffBase;
   final bool onlyChanged;
@@ -542,6 +537,9 @@ final class DedupeOptions {
   final String? cacheDir;
   final bool clearCache;
 
+  List<String> get excludePatterns => pathFilter.excludePatterns;
+  bool get ignoreGenerated => pathFilter.ignoreGenerated;
+
   DedupeOptions({
     required this.targetPath,
     List<String> targets = const ['lib'],
@@ -550,7 +548,9 @@ final class DedupeOptions {
     this.ignoreComments = true,
     this.ignoreLiterals = true,
     this.ignoreIdentifiers = false,
-    List<String> excludePatterns = defaultDartExclusions,
+    PathFilter? pathFilter,
+    Iterable<String> excludePatterns = const [],
+    bool ignoreGenerated = true,
     List<String> includePatterns = const ['**/*.dart'],
     this.gitDiffBase,
     this.onlyChanged = false,
@@ -567,7 +567,12 @@ final class DedupeOptions {
     this.cacheDir,
     this.clearCache = false,
   }) : targets = List.unmodifiable(targets),
-       excludePatterns = List.unmodifiable(excludePatterns),
+       pathFilter =
+           pathFilter ??
+           PathFilter(
+             excludePatterns: excludePatterns,
+             ignoreGenerated: ignoreGenerated,
+           ),
        includePatterns = List.unmodifiable(includePatterns);
 
   @override

--- a/packages/lower_bound/CHANGELOG.md
+++ b/packages/lower_bound/CHANGELOG.md
@@ -1,12 +1,18 @@
 ## 0.1.0-wip
 
-- Initial release of automated Dart dependency lower-bound validator and synthetic runtime isolation engine.
+- Initial release of automated Dart dependency lower-bound validator and
+  synthetic runtime isolation engine.
 - Synthetic staging engine:
   - Isolates package `lib/` and `bin/` directories in temporary staging.
   - Strips `dev_dependencies` to prevent test-tooling floor poisoning.
-  - Strips `resolution: workspace` so published dependencies resolve from `pub.dev`.
+  - Strips `resolution: workspace` so published dependencies resolve from
+    `pub.dev`.
   - Sanitizes `analysis_options.yaml` (stripping dev linter includes).
   - Exact floor pinning via `dependency_overrides`.
-  - Fallback for unpublished `-wip` monorepo siblings with path overrides and soft warnings.
-- CLI tool (`bin/lower_bound.dart`) with support for `--targets`, `--pin`/`--no-pin`, `--sdk`, `--format=text|github|json`, `--comment-output`, `--max-comment-rows`, `--keep-temp`, and `--fail-on-error`.
-- Composite GitHub Action (`action.yml`) supporting sticky PR comments, step summaries, error annotations, and workspace inputs.
+  - Fallback for unpublished `-wip` monorepo siblings with path overrides and
+    soft warnings.
+- CLI tool (`bin/lower_bound.dart`) with support for `--targets`,
+  `--pin`/`--no-pin`, `--sdk`, `--format=text|github|json`, `--comment-output`,
+  `--max-comment-rows`, `--keep-temp`, and `--fail-on-error`.
+- Composite GitHub Action (`action.yml`) supporting sticky PR comments, step
+  summaries, error annotations, and workspace inputs.

--- a/packages/lower_bound/README.md
+++ b/packages/lower_bound/README.md
@@ -1,30 +1,44 @@
 # lower_bound
 
-Automated Dart dependency lower-bound validator and synthetic runtime isolation engine.
+Automated Dart dependency lower-bound validator and synthetic runtime isolation
+engine.
 
-`lower_bound` verifies that a Dart package or monorepo compiles cleanly against the minimal satisfiable dependency floors specified in `pubspec.yaml`.
+`lower_bound` verifies that a Dart package or monorepo compiles cleanly against
+the minimal satisfiable dependency floors specified in `pubspec.yaml`.
 
 ## ✨ Features
 
 - **Synthetic Runtime Isolation**:
-  - Stages `lib/` and `bin/` directories in temporary isolation to prevent source tree mutations.
-  - Strips `dev_dependencies` completely to prevent test-tooling dependencies (e.g. `package:test`, `package:lints`) from artificially elevating transitive dependency floors.
-  - Strips `resolution: workspace` so published dependencies resolve their declared lower bounds directly from `pub.dev`.
+  - Stages `lib/` and `bin/` directories in temporary isolation to prevent
+    source tree mutations.
+  - Strips `dev_dependencies` completely to prevent test-tooling dependencies
+    (e.g. `package:test`, `package:lints`) from artificially elevating
+    transitive dependency floors.
+  - Strips `resolution: workspace` so published dependencies resolve their
+    declared lower bounds directly from `pub.dev`.
   - Sanitizes `analysis_options.yaml` (stripping all dev/relative includes).
 - **Minimal Satisfiable Floor Resolution**:
-  - Executes `pub downgrade` within the isolated staging sandbox to compute the lowest jointly satisfiable dependency versions allowed by all declared version constraints.
+  - Executes `pub downgrade` within the isolated staging sandbox to compute the
+    lowest jointly satisfiable dependency versions allowed by all declared
+    version constraints.
 - **Opt-in Local Sibling Overrides**:
-  - When `--allow-local-siblings` is passed, unpublished local monorepo siblings (with `-wip` versions or `publish_to: none`) are linked via local path overrides.
-  - By default (`--no-allow-local-siblings`), external dependencies must be published on `pub.dev` to verify genuine consumer installability.
+  - When `--allow-local-siblings` is passed, unpublished local monorepo siblings
+    (with `-wip` versions or `publish_to: none`) are linked via local path
+    overrides.
+  - By default (`--no-allow-local-siblings`), external dependencies must be
+    published on `pub.dev` to verify genuine consumer installability.
 - **Target Resolution Protocol**:
-  - Explicit paths: validates specified directories, automatically expanding workspace members if pointed at a workspace root.
-  - Current directory (`.`): auto-detects `pubspec.yaml` workspace members or single packages without heuristics.
+  - Explicit paths: validates specified directories, automatically expanding
+    workspace members if pointed at a workspace root.
+  - Current directory (`.`): auto-detects `pubspec.yaml` workspace members or
+    single packages without heuristics.
 - **Rich Output Formats**:
   - `text` (human-readable summary table with warnings and diagnostics).
   - `github` (GitHub Actions line annotations and Step Summary).
   - `json` (machine-readable structured JSON).
 - **Sticky PR Comments**:
-  - Supports `--comment-output` and `--max-comment-rows` for paginated, sticky PR comments.
+  - Supports `--comment-output` and `--max-comment-rows` for paginated, sticky
+    PR comments.
 
 ## ⚡ Quick Start
 
@@ -36,7 +50,8 @@ Validate the current package or monorepo workspace:
 dart run lower_bound
 ```
 
-Validate a specific package directory or monorepo root (workspace members are automatically expanded):
+Validate a specific package directory or monorepo root (workspace members are
+automatically expanded):
 
 ```bash
 dart run lower_bound path/to/my_package
@@ -80,20 +95,22 @@ jobs:
       - name: Validate Dependency Lower Bounds
         uses: kevmoo/analytica.dart/packages/lower_bound@main
         with:
-          format: 'github'
-          fail-on-error: 'true'
+          format: "github"
+          fail-on-error: "true"
 ```
 
 #### Action Inputs Reference
 
 <!-- mdformat off(prevent table wrapping) -->
-| Input | Default | Description |
-| :--- | :---: | :--- |
-| `package-path` | `.` | Path to target package or workspace root to validate. |
-| `targets` | `lib,bin` | Comma-separated list of target directories or files to analyze. |
-| `allow-local-siblings` | `false` | Allow unreleased local sibling packages via path overrides. |
-| `sdk` | _None_ | Simulate specific Dart SDK version during pub resolution. |
-| `fail-on-error` | `true` | Exit with non-zero status if lower bound validation fails. |
-| `format` | `github` | Output format: `github` (summary table + annotations), `text`, or `json`. |
-| `max-comment-rows` | `0` | Maximum table rows in the sticky PR comment (0 = unlimited). |
+
+| Input                  |  Default  | Description                                                               |
+| :--------------------- | :-------: | :------------------------------------------------------------------------ |
+| `package-path`         |    `.`    | Path to target package or workspace root to validate.                     |
+| `targets`              | `lib,bin` | Comma-separated list of target directories or files to analyze.           |
+| `allow-local-siblings` |  `false`  | Allow unreleased local sibling packages via path overrides.               |
+| `sdk`                  |  _None_   | Simulate specific Dart SDK version during pub resolution.                 |
+| `fail-on-error`        |  `true`   | Exit with non-zero status if lower bound validation fails.                |
+| `format`               | `github`  | Output format: `github` (summary table + annotations), `text`, or `json`. |
+| `max-comment-rows`     |    `0`    | Maximum table rows in the sticky PR comment (0 = unlimited).              |
+
 <!-- mdformat on -->

--- a/packages/undead/CHANGELOG.md
+++ b/packages/undead/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.1.2-wip
 
+- Adopt centralized `PathFilter` in `UndeadOptions` and CLI for `--exclude`
+  and `--[no-]ignore-generated` file filtering.
 - Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in `README.md`.
+
 
 ## 0.1.1
 

--- a/packages/undead/CHANGELOG.md
+++ b/packages/undead/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 0.1.2-wip
 
-- Adopt centralized `PathFilter` in `UndeadOptions` and CLI for `--exclude`
-  and `--[no-]ignore-generated` file filtering.
-- Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in `README.md`.
-
+- Adopt centralized `PathFilter` in `UndeadOptions` and CLI for `--exclude` and
+  `--[no-]ignore-generated` file filtering.
+- Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in
+  `README.md`.
 
 ## 0.1.1
 
@@ -23,4 +23,3 @@
   (standalone/executables).
 - Custom suppression directives: `// undead:ignore` and
   `// undead:ignore_for_file`.
-

--- a/packages/undead/README.md
+++ b/packages/undead/README.md
@@ -1,8 +1,8 @@
 Deterministic reachability and dead/unused declaration analysis for Dart and
 Flutter packages.
 
-`undead` performs whole-package AST analysis using `package:analyzer` to build
-a reachability graph from known entrypoints to all internal declarations,
+`undead` performs whole-package AST analysis using `package:analyzer` to build a
+reachability graph from known entrypoints to all internal declarations,
 identifying unused top-level declarations, classes, functions, and variables.
 
 ## ✨ Features
@@ -55,6 +55,7 @@ dart run undead@ --format=markdown
 ### CLI Options
 
 <!-- CLI_README_START -->
+
 ```console
 $ undead --help
 undead - Reachability and dead declaration analysis for Dart packages.
@@ -87,6 +88,7 @@ Usage: undead [options] [target_path]
 -h, --help                                 Print usage information.
     --version                              Print undead version.
 ```
+
 <!-- CLI_README_END -->
 
 ### Library API
@@ -110,9 +112,10 @@ void main() async {
 
 ## 🧠 AI Agent Integration
 
-This repository packages an agent skill (`dart-undead`) to train AI pair programmers on dead code audits, reachability analysis, and safe deletion protocols:
+This repository packages an agent skill (`dart-undead`) to train AI pair
+programmers on dead code audits, reachability analysis, and safe deletion
+protocols:
 
 ```bash
 npx skills add kevmoo/analytica.dart --skill dart-undead
 ```
-

--- a/packages/undead/README.md
+++ b/packages/undead/README.md
@@ -68,7 +68,9 @@ Usage: undead [options] [target_path]
                                            [demonstration (default), strict, skip]
 -m, --mode                                 Package analysis mode.
                                            [library (default), closed-app]
-    --[no-]include-generated               Include generated files (*.g.dart, *.freezed.dart) in analysis.
+    --exclude=<glob>                       Glob patterns of files/directories to exclude (repeatable or comma-separated).
+    --[no-]ignore-generated                Exclude generated files (*.g.dart, *.freezed.dart, *.mocks.dart, etc.).
+                                           (defaults to on)
     --[no-]fail-on-undead                  Exit with non-zero code (1) if any undead declaration is detected.
     --test-support-patterns                Comma-separated naming wildcard patterns for test fixtures and hooks.
                                            (defaults to "Fake*,Mock*")

--- a/packages/undead/lib/src/cli.dart
+++ b/packages/undead/lib/src/cli.dart
@@ -40,10 +40,14 @@ ArgParser buildArgParser() {
       allowed: ['library', 'closed-app'],
       defaultsTo: 'library',
     )
+    ..addPathFilterOptions()
     ..addFlag(
       'include-generated',
-      help: 'Include generated files (*.g.dart, *.freezed.dart) in analysis.',
+      help:
+          'Include generated files (*.g.dart, *.freezed.dart) in analysis '
+          '(deprecated: use --no-ignore-generated).',
       defaultsTo: false,
+      hide: true,
     )
     ..addFlag(
       'fail-on-undead',
@@ -167,7 +171,14 @@ class UndeadCliRunner {
     final format = OutputFormat.fromString(results.option('format')!);
     final exampleMode = ExampleMode.fromString(results.option('example-mode')!);
     final mode = AnalysisMode.fromString(results.option('mode')!);
-    final includeGenerated = results.flag('include-generated');
+    var pathFilter = parsePathFilter(results);
+    if (results.wasParsed('include-generated') &&
+        results.flag('include-generated')) {
+      pathFilter = PathFilter(
+        excludePatterns: pathFilter.excludePatterns,
+        ignoreGenerated: false,
+      );
+    }
     final failOnUndead = results.flag('fail-on-undead');
     final autoPubGet = results.flag('pub-get');
     final ignoreExternalBindings = results.flag('ignore-external-bindings');
@@ -188,7 +199,7 @@ class UndeadCliRunner {
       format: format,
       exampleMode: exampleMode,
       mode: mode,
-      includeGenerated: includeGenerated,
+      pathFilter: pathFilter,
       failOnUndead: failOnUndead,
       autoPubGet: autoPubGet,
       ignoreExternalBindings: ignoreExternalBindings,

--- a/packages/undead/lib/src/models.dart
+++ b/packages/undead/lib/src/models.dart
@@ -1,8 +1,10 @@
+import 'package:analytica/analyzer.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import 'adapters/adapters.dart';
 
 export 'package:analytica/analytica.dart' show PackageResolutionException;
+export 'package:analytica/analyzer.dart' show PathFilter;
 
 /// The classification category of a detected undead declaration.
 enum UndeadClassification {
@@ -149,7 +151,7 @@ final class UndeadOptions {
   final OutputFormat format;
   final ExampleMode exampleMode;
   final AnalysisMode mode;
-  final bool includeGenerated;
+  final PathFilter pathFilter;
   final bool failOnUndead;
   final bool autoPubGet;
   final String? sdkPath;
@@ -162,12 +164,19 @@ final class UndeadOptions {
   final bool workspaceDiscovery;
   final bool suggestPrivate;
 
-  const UndeadOptions({
+  bool get includeGenerated => !pathFilter.ignoreGenerated;
+  bool get ignoreGenerated => pathFilter.ignoreGenerated;
+  List<String> get excludePatterns => pathFilter.excludePatterns;
+
+  UndeadOptions({
     required this.packagePath,
     this.format = OutputFormat.markdown,
     this.exampleMode = ExampleMode.demonstration,
     this.mode = AnalysisMode.library,
-    this.includeGenerated = false,
+    PathFilter? pathFilter,
+    bool? includeGenerated,
+    bool ignoreGenerated = true,
+    Iterable<String> excludePatterns = const [],
     this.failOnUndead = false,
     this.autoPubGet = false,
     this.sdkPath,
@@ -179,7 +188,14 @@ final class UndeadOptions {
     this.ignoreExternalBindings = false,
     this.workspaceDiscovery = true,
     this.suggestPrivate = false,
-  });
+  }) : pathFilter =
+           pathFilter ??
+           PathFilter(
+             excludePatterns: excludePatterns,
+             ignoreGenerated: includeGenerated != null
+                 ? !includeGenerated
+                 : ignoreGenerated,
+           );
 }
 
 /// Details about a test call site referencing a dead declaration.

--- a/packages/undead/lib/src/root_harvester.dart
+++ b/packages/undead/lib/src/root_harvester.dart
@@ -353,45 +353,11 @@ class RootHarvester {
     );
   }
 
-  bool _isExcluded(String relativePath) {
-    final segments = p.split(p.normalize(relativePath));
-    if (segments.isEmpty) return false;
-    if (segments.contains('.dart_tool') ||
-        segments.contains('.git') ||
-        segments.first == 'build') {
-      return true;
-    }
+  bool _isExcluded(String relativePath) =>
+      options.pathFilter.isExcluded(relativePath);
 
-    if (!options.includeGenerated) {
-      final filename = p.basename(relativePath);
-      if (filename.endsWith('.g.dart') ||
-          filename.endsWith('.freezed.dart') ||
-          filename.endsWith('.mocks.dart')) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  bool _isExcludedFromExtraRoot(String relativePath) {
-    final segments = p.split(p.normalize(relativePath));
-    if (segments.isEmpty) return false;
-    if (segments.contains('.dart_tool') || segments.contains('.git')) {
-      return true;
-    }
-
-    if (!options.includeGenerated) {
-      final filename = p.basename(relativePath);
-      if (filename.endsWith('.g.dart') ||
-          filename.endsWith('.freezed.dart') ||
-          filename.endsWith('.mocks.dart')) {
-        return true;
-      }
-    }
-
-    return false;
-  }
+  bool _isExcludedFromExtraRoot(String relativePath) =>
+      options.pathFilter.isExcluded(relativePath);
 
   String _extractPackageName(String pubspecContent) {
     final match = RegExp(

--- a/packages/undead/test/models_test.dart
+++ b/packages/undead/test/models_test.dart
@@ -168,19 +168,20 @@ void main() {
     });
 
     test('UndeadOptions default and custom values', () {
-      const defaultOptions = UndeadOptions(packagePath: '/path/to/pkg');
+      final defaultOptions = UndeadOptions(packagePath: '/path/to/pkg');
       check(defaultOptions.testSupportPatterns).deepEquals(['Fake*', 'Mock*']);
       check(defaultOptions.ignoreNamePatterns).isEmpty();
       check(defaultOptions.format).equals(OutputFormat.markdown);
       check(defaultOptions.exampleMode).equals(ExampleMode.demonstration);
       check(defaultOptions.mode).equals(AnalysisMode.library);
       check(defaultOptions.includeGenerated).isFalse();
+      check(defaultOptions.ignoreGenerated).isTrue();
       check(defaultOptions.failOnUndead).isFalse();
       check(defaultOptions.autoPubGet).isFalse();
       check(defaultOptions.workspaceDiscovery).isTrue();
       check(defaultOptions.suggestPrivate).isFalse();
 
-      const customOptions = UndeadOptions(
+      final customOptions = UndeadOptions(
         packagePath: '/path/to/pkg',
         testSupportPatterns: ['*Stub', 'CustomFixture*'],
         ignoreNamePatterns: ['*_generated', 'Ignored*'],
@@ -188,6 +189,7 @@ void main() {
         workspaceDiscovery: false,
         suggestPrivate: true,
       );
+
       check(
         customOptions.testSupportPatterns,
       ).deepEquals(['*Stub', 'CustomFixture*']);

--- a/packages/undead/test/reachability_engine_test.dart
+++ b/packages/undead/test/reachability_engine_test.dart
@@ -2023,10 +2023,7 @@ void internalHelper() {}
           // Without suggestPrivate: internalHelper is live, 0 undead findings.
           final defaultReport = await analyzePackage(
             d.path('suggest_private_pkg'),
-            options: const UndeadOptions(
-              packagePath: '',
-              suggestPrivate: false,
-            ),
+            options: UndeadOptions(packagePath: '', suggestPrivate: false),
           );
           check(defaultReport.undead).isEmpty();
           check(defaultReport.privateCandidatesFound).equals(0);
@@ -2034,7 +2031,7 @@ void internalHelper() {}
           // With suggestPrivate: internalHelper is flagged as privateCandidate.
           final privateReport = await analyzePackage(
             d.path('suggest_private_pkg'),
-            options: const UndeadOptions(packagePath: '', suggestPrivate: true),
+            options: UndeadOptions(packagePath: '', suggestPrivate: true),
           );
           check(privateReport.privateCandidatesFound).equals(1);
           check(privateReport.undead.length).equals(1);
@@ -2086,7 +2083,7 @@ void partWorker() {
 
         final report = await analyzePackage(
           d.path('part_private_pkg'),
-          options: const UndeadOptions(packagePath: '', suggestPrivate: true),
+          options: UndeadOptions(packagePath: '', suggestPrivate: true),
         );
 
         check(report.privateCandidatesFound).equals(2);
@@ -2126,7 +2123,7 @@ class Consumer {
 
         final report = await analyzePackage(
           d.path('cross_lib_pkg'),
-          options: const UndeadOptions(packagePath: '', suggestPrivate: true),
+          options: UndeadOptions(packagePath: '', suggestPrivate: true),
         );
 
         check(report.privateCandidatesFound).equals(0);
@@ -2174,7 +2171,7 @@ void main() {
 
         final report = await analyzePackage(
           d.path('tested_private_pkg'),
-          options: const UndeadOptions(packagePath: '', suggestPrivate: true),
+          options: UndeadOptions(packagePath: '', suggestPrivate: true),
         );
 
         // testHelper is referenced in test/live_test.dart, so it must not be suggested for privatization.

--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -43,7 +43,7 @@ Rely on deterministic evaluation to target structures matching these indicators:
 Execute the official package CLI directly in the terminal to retrieve exact
 complexity scores deterministically without LLM arithmetic or AST interpretation.
 
-> **SDK Compatibility Note**: Executing `dart run cognitive_complexity@` requires
+> **SDK Compatibility Note**: Executing `dart run cognitive_complexity@^0.2.4` requires
 > Dart SDK version **3.12.0 or greater** installed in the host environment. Verify
 > compatibility via `dart --version` before initiating scans.
 
@@ -54,7 +54,7 @@ When the user references a discrete component (e.g., "check complexity in
 `lib/src/auth/`" or "audit `order_service.dart`"), pass explicit targets:
 
 ```bash
-dart run cognitive_complexity@ --threshold 15 lib/src/auth/
+dart run cognitive_complexity@^0.2.4 --threshold 15 lib/src/auth/
 ```
 
 ### Scope 2: Delta (Pull Request, Branch, or Pre-flight Audit)
@@ -62,7 +62,7 @@ When reviewing a feature branch, active commit stack, or PR, avoid full-project
 scanning. Isolate evaluation strictly to modified declarations against trunk:
 
 ```bash
-dart run cognitive_complexity@ --git-diff origin/main --fail-threshold 15 --fail-on-increase
+dart run cognitive_complexity@^0.2.4 --git-diff origin/main --fail-threshold 15 --fail-on-increase
 ```
 
 With both flags set, only increases that exceed the threshold fail — healthy
@@ -76,10 +76,10 @@ When invoked without targeting parameters ("scan my project for complexity" or
 
 ```bash
 # Production logic target (threshold 15)
-dart run cognitive_complexity@ --threshold 15 lib/
+dart run cognitive_complexity@^0.2.4 --threshold 15 lib/
 
 # Test harness target (threshold 40)
-dart run cognitive_complexity@ --threshold 40 test/
+dart run cognitive_complexity@^0.2.4 --threshold 40 test/
 ```
 
 ---
@@ -246,7 +246,7 @@ statement-level data-flow analyzer (on-demand form; same SDK 3.12.0+
 requirement as the scanner) on each line slice you intend to extract:
 
 ```bash
-dart run cognitive_complexity:data_flow@ lib/src/my_file.dart:45-80
+dart run cognitive_complexity:data_flow@^0.2.4 lib/src/my_file.dart:45-80
 ```
 
 Its report (`inputs`, `mutations`, live `outputs`, control-flow escapes, and
@@ -398,7 +398,7 @@ when the loop body alone is the hotspot.
 
 Run these verification commands before committing refactored code:
 
-1. **Complexity Audit**: Run `dart run cognitive_complexity@
+1. **Complexity Audit**: Run `dart run cognitive_complexity@^0.2.4
    --fail-threshold 15 <refactored files>` scoped to the files you touched.
    Pre-existing breaches elsewhere in the project do not invalidate the
    refactor.
@@ -448,7 +448,7 @@ To reproduce or re-evaluate cognitive complexity scores:
 
 <!-- If statement data-flow analysis was used during decomposition: -->
 ```bash
-dart run cognitive_complexity:data_flow@ {file}:{start_line}-{end_line}
+dart run cognitive_complexity:data_flow@^0.2.4 {file}:{start_line}-{end_line}
 ```
 ````
 

--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -5,8 +5,8 @@ description: >-
   deterministic CLI tooling and architectural refactoring patterns (exhaustive
   pattern matching, guard clauses, method decomposition). Use when reviewing
   codebase readability, remediating high-complexity warnings, or analyzing
-  structural code health. Don't use for general code formatting, simple syntactic
-  lints, or non-Dart/Flutter repositories.
+  structural code health. Don't use for general code formatting, simple
+  syntactic lints, or non-Dart/Flutter repositories.
 license: Apache-2.0
 key_features:
   - Automated CLI evaluation
@@ -27,13 +27,15 @@ and punishes declarative table switches), Cognitive Complexity measures the
 mental friction required for a human engineer to read and simulate control flow.
 Rely on deterministic evaluation to target structures matching these indicators:
 
-* **Deeply Nested Control Flow**: Functions exhibiting multiple layers of enclosing
-  conditionals (`if`, `for`, `while`), where horizontal indentation obscures logic.
-* **Convoluted Conditional Trees**: Functions employing verbose `if-else` or
+- **Deeply Nested Control Flow**: Functions exhibiting multiple layers of
+  enclosing conditionals (`if`, `for`, `while`), where horizontal indentation
+  obscures logic.
+- **Convoluted Conditional Trees**: Functions employing verbose `if-else` or
   `else if` chains instead of modern Dart 3 exhaustive pattern matching or
   table-driven switch expressions.
-* **Monolithic Method Bodies**: Functions breaching operational threshold ceilings.
-* **God Classes**: Logic classes exceeding structural line-count targets
+- **Monolithic Method Bodies**: Functions breaching operational threshold
+  ceilings.
+- **God Classes**: Logic classes exceeding structural line-count targets
   (excluding declarative Flutter `build` methods).
 
 ---
@@ -41,15 +43,18 @@ Rely on deterministic evaluation to target structures matching these indicators:
 ## 2. Automated Execution & Scope Resolution
 
 Execute the official package CLI directly in the terminal to retrieve exact
-complexity scores deterministically without LLM arithmetic or AST interpretation.
+complexity scores deterministically without LLM arithmetic or AST
+interpretation.
 
-> **SDK Compatibility Note**: Executing `dart run cognitive_complexity@^0.2.4` requires
-> Dart SDK version **3.12.0 or greater** installed in the host environment. Verify
-> compatibility via `dart --version` before initiating scans.
+> **SDK Compatibility Note**: Executing `dart run cognitive_complexity@^0.2.4`
+> requires Dart SDK version **3.12.0 or greater** installed in the host
+> environment. Verify compatibility via `dart --version` before initiating
+> scans.
 
 Select the execution scope based on the user's task instructions:
 
 ### Scope 1: Targeted (Specific File, Directory, or Class)
+
 When the user references a discrete component (e.g., "check complexity in
 `lib/src/auth/`" or "audit `order_service.dart`"), pass explicit targets:
 
@@ -58,6 +63,7 @@ dart run cognitive_complexity@^0.2.4 --threshold 15 lib/src/auth/
 ```
 
 ### Scope 2: Delta (Pull Request, Branch, or Pre-flight Audit)
+
 When reviewing a feature branch, active commit stack, or PR, avoid full-project
 scanning. Isolate evaluation strictly to modified declarations against trunk:
 
@@ -71,6 +77,7 @@ blocking. Omit `--fail-threshold` only when a strict any-increase ratchet is
 explicitly desired.
 
 ### Scope 3: Whole-Project (Default Naked Invocation)
+
 When invoked without targeting parameters ("scan my project for complexity" or
 `/cognitive-complexity`), audit the standard source and test roots:
 
@@ -86,13 +93,13 @@ dart run cognitive_complexity@^0.2.4 --threshold 40 test/
 
 ## 3. Actionable Thresholds & Calibration
 
-* **Production Logic Functions**: Target score `<= 15`. Functions exceeding 15 points
-  mandate architectural refactoring.
-* **Test Methods (`_test.dart`)**: Target score `<= 40`. Test suites tolerate higher
-  setup sequences before decomposition is required.
-* **Class Size Ceiling**: Logic classes (services, domain objects, controllers)
+- **Production Logic Functions**: Target score `<= 15`. Functions exceeding 15
+  points mandate architectural refactoring.
+- **Test Methods (`_test.dart`)**: Target score `<= 40`. Test suites tolerate
+  higher setup sequences before decomposition is required.
+- **Class Size Ceiling**: Logic classes (services, domain objects, controllers)
   should remain `<= 150` non-comment lines.
-* **Flutter UI Calibration**: Do not enforce the 150 LOC class ceiling on
+- **Flutter UI Calibration**: Do not enforce the 150 LOC class ceiling on
   declarative Flutter `build` methods, as widget wrappers consume vertical space
   without increasing cognitive logic load. Instead, enforce a **Widget Tree
   Nesting Ceiling** of maximum 5 horizontal indentation levels before extracting
@@ -107,18 +114,24 @@ to autonomously refactor the entire repository. To prevent unwanted diff bloat
 and preserve historical code stability, adhere to a strict 2-stage workflow:
 
 ### Stage 1: Read-Only Audit & Reporting (Mandatory Stop)
-When threshold breaches are detected, **do not mutate code immediately**.
-Output a ranked Markdown **Complexity Triage Report** directly in chat (or to an
+
+When threshold breaches are detected, **do not mutate code immediately**. Output
+a ranked Markdown **Complexity Triage Report** directly in chat (or to an
 artifact for extensive findings) containing:
-* Flagged function name and clickable file local path.
-* Current complexity score versus operational ceiling.
-* Recommended refactoring strategy (Pattern A, B, D, E, or a Pattern C tier) and unit test status.
+
+- Flagged function name and clickable file local path.
+- Current complexity score versus operational ceiling.
+- Recommended refactoring strategy (Pattern A, B, D, E, or a Pattern C tier) and
+  unit test status.
 
 ### Stage 2: Interactive User Selection (Confirmation Gate)
+
 Pause execution and prompt the user (via interactive choice or chat) to select
 the desired sequencing:
-1. **(Recommended) Refactor Top Hotspot Only**: Target the single highest-scoring
-   declaration first, verify via unit tests, and present diffs cleanly.
+
+1. **(Recommended) Refactor Top Hotspot Only**: Target the single
+   highest-scoring declaration first, verify via unit tests, and present diffs
+   cleanly.
 2. **Selective Batch Refactor**: Remediate a user-specified subset of functions.
 3. **Report-Only / Exit**: Acknowledge complexity scores without code mutation.
 
@@ -130,20 +143,22 @@ the desired sequencing:
 
 ## 5. Pre-Refactoring Assessment & Test Coverage Gate
 
-High cognitive complexity strongly correlates with brittle, untested legacy logic.
-Before undertaking structural refactoring on flagged functions, enforce this
-verification baseline:
+High cognitive complexity strongly correlates with brittle, untested legacy
+logic. Before undertaking structural refactoring on flagged functions, enforce
+this verification baseline:
 
 1. **Test Harness Mapping**: Confirm an accompanying unit test file exists for
    the target declaration (e.g., `lib/src/foo.dart` -> `test/foo_test.dart`).
 2. **Coverage Audit & Execution**:
-   * If the **`dart-collect-coverage`** companion skill is available in your
+   - If the **`dart-collect-coverage`** companion skill is available in your
      agent runtime, invoke it to check line and branch coverage on the targeted
      declarations.
-   * At minimum, execute the relevant test suite (`dart test test/foo_test.dart`)
-     to confirm a passing green regression baseline before touching code.
+   - At minimum, execute the relevant test suite
+     (`dart test test/foo_test.dart`) to confirm a passing green regression
+     baseline before touching code.
 3. **Low-Coverage Safety Gate**: If tests are missing or coverage around the
    flagged function is inadequate, pause execution and explicitly warn the user:
+
    > ⚠️ **Low Test Coverage Warning**: Function `<name>` in `<path>` lacks unit
    > test coverage. Structural refactoring risks silent behavioral regression.
 
@@ -155,17 +170,18 @@ verification baseline:
 
 ## 6. Dart Refactoring Patterns
 
-When remediation is required for declarations flagged by the scanner, apply these
-Dart-specific architectural refactorings:
+When remediation is required for declarations flagged by the scanner, apply
+these Dart-specific architectural refactorings:
 
 ### Pattern A: Replace Nested If-Else with Dart 3 Switch Expression
 
 In Dart 3, an entire exhaustive switch expression incurs a single base penalty,
-regardless of how many pattern arms it contains. Converting deeply nested `if-else`
-trees into declarative tables removes repeated branching penalties and flattens
-nesting.
+regardless of how many pattern arms it contains. Converting deeply nested
+`if-else` trees into declarative tables removes repeated branching penalties and
+flattens nesting.
 
 #### Before: Nested Conditional Ladders (Score: 11)
+
 ```dart
 int resolveTimeout(String protocol, bool isSecure, int retryCount) {
   if (protocol == 'http') {
@@ -186,6 +202,7 @@ int resolveTimeout(String protocol, bool isSecure, int retryCount) {
 ```
 
 #### After: Table-Driven Switch Expression (Score: 1)
+
 ```dart
 int resolveTimeout(String protocol, bool isSecure, int retryCount) =>
     switch ((protocol, isSecure, retryCount)) {
@@ -207,6 +224,7 @@ Invert conditional checks into early guard return statements
 multiplication from subsequent downstream logic.
 
 #### Before: Pyramid of Nesting (Score: 11)
+
 ```dart
 Future<void> syncPayload(User? user, Payload? data) async {
   if (user != null) {
@@ -222,6 +240,7 @@ Future<void> syncPayload(User? user, Payload? data) async {
 ```
 
 #### After: Early Exit Guard Clauses (Score: 5)
+
 ```dart
 Future<void> syncPayload(User? user, Payload? data) async {
   if (user == null || !user.hasPermission) return;
@@ -237,101 +256,103 @@ Future<void> syncPayload(User? user, Payload? data) async {
 
 ### Pattern C: The 3-Tier Decomposition Rubric (Anti-Goodhart)
 
-**Anti-Goodhart Guardrail**: Do NOT blindly wrap monolithic functions in single-use runner classes with mutable instance variables just to bring scores below 15. Reducing the metric must never sacrifice transparent data flow or hide bugs.
+**Anti-Goodhart Guardrail**: Do NOT blindly wrap monolithic functions in
+single-use runner classes with mutable instance variables just to bring scores
+below 15. Reducing the metric must never sacrifice transparent data flow or hide
+bugs.
 
 #### Deterministic Tier Selection via `data_flow`
 
 Do not eyeball which tier a candidate slice belongs to. Run the companion
-statement-level data-flow analyzer (on-demand form; same SDK 3.12.0+
-requirement as the scanner) on each line slice you intend to extract:
+statement-level data-flow analyzer (on-demand form; same SDK 3.12.0+ requirement
+as the scanner) on each line slice you intend to extract:
 
 ```bash
 dart run cognitive_complexity:data_flow@^0.2.4 lib/src/my_file.dart:45-80
 ```
 
-Its report (`inputs`, `mutations`, live `outputs`, control-flow escapes, and
-a synthesized Dart 3 record signature) selects the tier.
+Its report (`inputs`, `mutations`, live `outputs`, control-flow escapes, and a
+synthesized Dart 3 record signature) selects the tier.
 
-**Slice at natural seams first.** If a slice reports control-flow escapes or
-a tightly coupled pair of mutable variables (`queue` + `visited`,
-`buffer` + `cursor`), the usual culprit is the slice boundary, not the code.
-Enlarge the slice to the whole loop or state machine and re-run `data_flow`:
-escapes targeting a loop inside the slice stop being escapes, coupled state
-becomes interior, and the enlarged slice usually extracts cleanly as
-Tier 1/2.
+**Slice at natural seams first.** If a slice reports control-flow escapes or a
+tightly coupled pair of mutable variables (`queue` + `visited`, `buffer` +
+`cursor`), the usual culprit is the slice boundary, not the code. Enlarge the
+slice to the whole loop or state machine and re-run `data_flow`: escapes
+targeting a loop inside the slice stop being escapes, coupled state becomes
+interior, and the enlarged slice usually extracts cleanly as Tier 1/2.
 
 These bullets are the ONLY selection rules:
 
-* **Cleanly extractable, ≤ 1 live output, ≤ 3 inputs** → Tier 2: extract a
+- **Cleanly extractable, ≤ 1 live output, ≤ 3 inputs** → Tier 2: extract a
   standard private helper returning that value. If the helper does not read or
   mutate class instance state (`this`), declare it as a private top-level
   function (or static method) rather than an instance method.
-* **Cleanly extractable, 2+ live outputs** → Tier 1: extract a static or
-  top-level function and use the synthesized named record signature
-  verbatim. Private, file-local slices use named records at ANY output
-  count — do NOT mint single-use `_XxxResult` dataclasses for them. Reserve
-  a dedicated `Result` dataclass for values that cross a public API or
-  library boundary, or that need methods or invariants. If the helper does not
-  read or mutate class instance state (`this`), declare it as a private
-  top-level function (or static method) rather than an instance method. *Advisory*:
-  5+ live outputs usually means the slice is cut at the wrong seam — try a
-  different boundary before shipping a wide record.
-* **Control-flow escapes** → apply in preference order:
+- **Cleanly extractable, 2+ live outputs** → Tier 1: extract a static or
+  top-level function and use the synthesized named record signature verbatim.
+  Private, file-local slices use named records at ANY output count — do NOT mint
+  single-use `_XxxResult` dataclasses for them. Reserve a dedicated `Result`
+  dataclass for values that cross a public API or library boundary, or that need
+  methods or invariants. If the helper does not read or mutate class instance
+  state (`this`), declare it as a private top-level function (or static method)
+  rather than an instance method. _Advisory_: 5+ live outputs usually means the
+  slice is cut at the wrong seam — try a different boundary before shipping a
+  wide record.
+- **Control-flow escapes** → apply in preference order:
   1. Enlarge the slice to include the whole loop (natural seams, above) and
      re-run the analysis.
-  2. If the loop *body* is itself the hotspot, extract it with an explicit
+  2. If the loop _body_ is itself the hotspot, extract it with an explicit
      signal return (Pattern E) — never a `shouldBreak` boolean flag.
-  3. Use guard-clause inversion (Pattern B) when the escape exists only to
-     skip nested conditions — it fixes nesting, not escapes.
-  `yield` is none of these: restructure the generator before attempting any
-  extraction.
-* **Tier 3 gate (mutation-web check)** → Tier 3 requires recorded evidence,
-  not judgment. Run `data_flow` on at least two distinct candidate slices of
-  the function. Tier 3 is permitted ONLY if the intersection of their
-  `mutations` variable names contains 3 or more entries — i.e. the same
-  mutable variables thread through every candidate extraction. Paste the
-  JSON reports into the Triage Report as evidence; without that evidence,
-  stay in Tier 1/2. A recurring 2-variable coupling never qualifies:
-  enlarge the slice, or take the domain-modeling exit (below).
+  3. Use guard-clause inversion (Pattern B) when the escape exists only to skip
+     nested conditions — it fixes nesting, not escapes. `yield` is none of
+     these: restructure the generator before attempting any extraction.
+- **Tier 3 gate (mutation-web check)** → Tier 3 requires recorded evidence, not
+  judgment. Run `data_flow` on at least two distinct candidate slices of the
+  function. Tier 3 is permitted ONLY if the intersection of their `mutations`
+  variable names contains 3 or more entries — i.e. the same mutable variables
+  thread through every candidate extraction. Paste the JSON reports into the
+  Triage Report as evidence; without that evidence, stay in Tier 1/2. A
+  recurring 2-variable coupling never qualifies: enlarge the slice, or take the
+  domain-modeling exit (below).
 
-When choosing how to reduce complexity on a large Dart function, follow this **3-Tier Decision Hierarchy**:
+When choosing how to reduce complexity on a large Dart function, follow this
+**3-Tier Decision Hierarchy**:
 
 1. **Tier 1 — Pure Functional Decomposition (first choice)**: static or
    top-level functions returning Dart 3 named records
    (`final (:data, :errors) = _stepOne(input);`); a dedicated `Result` /
-   `Response` dataclass only where the value crosses a public API or
-   library boundary or needs methods/invariants. All extracted helpers that
-   do not access class instance state (`this`) MUST be declared as private
-   top-level functions (or static methods) to guarantee referential
-   transparency and prevent temporal coupling.
-2. **Tier 2 — Standard Extract Method (second choice)**: standard private
-   helper methods or top-level private functions taking <= 3 arguments.
-3. **Tier 3 — Encapsulated Method Object (last resort)**: permitted only
-   when the mutation-web check above passes with recorded evidence. Then
-   read [references/method-object.md](references/method-object.md) for the
-   extraction mechanics and mandatory idioms. Do not load or apply it
-   speculatively.
+   `Response` dataclass only where the value crosses a public API or library
+   boundary or needs methods/invariants. All extracted helpers that do not
+   access class instance state (`this`) MUST be declared as private top-level
+   functions (or static methods) to guarantee referential transparency and
+   prevent temporal coupling.
+2. **Tier 2 — Standard Extract Method (second choice)**: standard private helper
+   methods or top-level private functions taking <= 3 arguments.
+3. **Tier 3 — Encapsulated Method Object (last resort)**: permitted only when
+   the mutation-web check above passes with recorded evidence. Then read
+   [references/method-object.md](references/method-object.md) for the extraction
+   mechanics and mandatory idioms. Do not load or apply it speculatively.
 
 **Domain-modeling exit**: when the same tightly coupled mutable state keeps
 resurfacing across a function (a parser's `buffer` + `cursor`, a traversal's
 `queue` + `visited`), the code may be asking to become a real, cohesively
-*named* domain class (`Parser`, `GraphTraversal`) with a public, unit-tested
-API. That is domain modeling, not complexity remediation — it exits this
-rubric entirely and is not subject to the Tier 3 gate. The gate exists to
-ban single-use `_XxxRunner` facades, not real abstractions. To qualify for
-the exit, the class MUST have cohesive entity state, more than one public
-behavior, and its own dedicated test suite. A single-use private class with
-a constructor and one `run()` method is a runner no matter what it is
-renamed to (`_ScanEngine`, `_BatchProcessor`) and remains subject to the
-gate.
+_named_ domain class (`Parser`, `GraphTraversal`) with a public, unit-tested
+API. That is domain modeling, not complexity remediation — it exits this rubric
+entirely and is not subject to the Tier 3 gate. The gate exists to ban
+single-use `_XxxRunner` facades, not real abstractions. To qualify for the exit,
+the class MUST have cohesive entity state, more than one public behavior, and
+its own dedicated test suite. A single-use private class with a constructor and
+one `run()` method is a runner no matter what it is renamed to (`_ScanEngine`,
+`_BatchProcessor`) and remains subject to the gate.
 
 ---
 
 ### Pattern D: Fast-Fail Type Matching & Silent Data Swallowing
 
-When refactoring loops and type checks to reduce branching, **never** replace explicit type casts with pattern matching that silently drops data.
+When refactoring loops and type checks to reduce branching, **never** replace
+explicit type casts with pattern matching that silently drops data.
 
 **Flawed Structure (Silent Failure):**
+
 ```dart
 for (final raw in rawTasks) {
   // SILENTLY DROPS malformed data if raw is not a Map
@@ -342,6 +363,7 @@ for (final raw in rawTasks) {
 ```
 
 **Correct Structure (Fast-Fail Preservation):**
+
 ```dart
 for (final raw in rawTasks) {
   if (raw is! Map<String, dynamic>) {
@@ -356,11 +378,10 @@ for (final raw in rawTasks) {
 
 ### Pattern E: Loop-Body Extraction with Signal Returns
 
-When a loop body must be extracted but contains `break`/`continue` targeting
-the loop, never smuggle the control flow through boolean flags
-(`shouldBreak` soup) — that raises cognitive load and hides termination
-conditions. Return an explicit signal and keep the loop keywords at the loop
-site:
+When a loop body must be extracted but contains `break`/`continue` targeting the
+loop, never smuggle the control flow through boolean flags (`shouldBreak` soup)
+— that raises cognitive load and hides termination conditions. Return an
+explicit signal and keep the loop keywords at the loop site:
 
 ```dart
 enum _ScanAction { proceed, skip, halt }
@@ -387,10 +408,10 @@ for (final entry in entries) {
 
 Use a sealed class instead of an enum when the signal must carry a payload.
 Asynchronous classification works identically:
-`switch (await _classify(entry, seen))`. The exhaustive `switch` keeps
-every termination path visible at the loop site. Prefer extracting the
-*entire loop* when `data_flow` shows it forms a natural seam; use Pattern E
-when the loop body alone is the hotspot.
+`switch (await _classify(entry, seen))`. The exhaustive `switch` keeps every
+termination path visible at the loop site. Prefer extracting the _entire loop_
+when `data_flow` shows it forms a natural seam; use Pattern E when the loop body
+alone is the hotspot.
 
 ---
 
@@ -398,10 +419,10 @@ when the loop body alone is the hotspot.
 
 Run these verification commands before committing refactored code:
 
-1. **Complexity Audit**: Run `dart run cognitive_complexity@^0.2.4
-   --fail-threshold 15 <refactored files>` scoped to the files you touched.
-   Pre-existing breaches elsewhere in the project do not invalidate the
-   refactor.
+1. **Complexity Audit**: Run
+   `dart run cognitive_complexity@^0.2.4 --fail-threshold 15 <refactored files>`
+   scoped to the files you touched. Pre-existing breaches elsewhere in the
+   project do not invalidate the refactor.
 2. **Code Presentation**: Run `dart format .` to maintain uniform syntactic
    styling.
 3. **Static Analysis**: Run `dart analyze` to ensure zero static warnings, lint
@@ -416,15 +437,17 @@ Run these verification commands before committing refactored code:
 When staging refactored code and preparing a commit message or Pull Request:
 
 ### 1. User Confirmation Gate & Headless Defaults
-* **Interactive Sessions**: Before writing the PR description or commit body,
+
+- **Interactive Sessions**: Before writing the PR description or commit body,
   explicitly prompt the user in chat or via the harness confirmation tool (e.g.
   `ask_question`) whether to include a **Tool Provenance & Complexity Delta
   block**.
-* **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
+- **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
   subagents, automated eval suites like `evalin`, or headless CI), default to
   including the block automatically without blocking on user confirmation.
 
 ### 2. Standardized Provenance Block Format
+
 When confirmed (or running headlessly), append the following markdown block to
 the PR description or commit body so reviewers understand where the changes
 originated, see the quantified readability improvements, and can rerun the audit
@@ -433,28 +456,36 @@ locally:
 ````markdown
 ### 🤖 Tool Provenance & Complexity Delta
 
-This refactoring was guided by [`cognitive_complexity`](https://pub.dev/packages/cognitive_complexity) (`v{version}`).
+This refactoring was guided by
+[`cognitive_complexity`](https://pub.dev/packages/cognitive_complexity)
+(`v{version}`).
 
 <!-- mdformat off(prevent table wrapping) -->
-| Target Declaration | Pre-Score | Post-Score | Operational Ceiling |
-| :--- | :---: | :---: | :---: |
-| `{declaration_name}` (`{file_path}`) | `{pre_score}` | `{post_score}` | `<={threshold}` |
+
+| Target Declaration                   |   Pre-Score   |   Post-Score   | Operational Ceiling |
+| :----------------------------------- | :-----------: | :------------: | :-----------------: |
+| `{declaration_name}` (`{file_path}`) | `{pre_score}` | `{post_score}` |   `<={threshold}`   |
+
 <!-- mdformat on -->
 
 To reproduce or re-evaluate cognitive complexity scores:
+
 ```bash
 {exact_command_line}
 ```
 
 <!-- If statement data-flow analysis was used during decomposition: -->
+
 ```bash
 dart run cognitive_complexity:data_flow@^0.2.4 {file}:{start_line}-{end_line}
 ```
 ````
 
 ### 3. Version Resolution
+
 Determine the package version dynamically:
-* Check `pubspec.lock` in the workspace or run
+
+- Check `pubspec.lock` in the workspace or run
   `dart run cognitive_complexity@ --version`.
-* If invoked with a specific version constraint (e.g.
+- If invoked with a specific version constraint (e.g.
   `cognitive_complexity@0.2.3`), use that exact version.

--- a/skills/dart-dedupe/SKILL.md
+++ b/skills/dart-dedupe/SKILL.md
@@ -61,7 +61,7 @@ detect:
 Run the official package CLI directly:
 
 ```bash
-dart run dedupe [options] [target_path]
+dart run dedupe@^0.1.0 [options] [target_path]
 ```
 
 ### Execution Modes
@@ -69,13 +69,13 @@ dart run dedupe [options] [target_path]
 #### Mode 1: Full Repository / Directory Scan
 ```bash
 # Markdown summary with clickable file links
-dart run dedupe
+dart run dedupe@^0.1.0
 
 # Machine-readable JSON output for agent pipelines
-dart run dedupe --format=json
+dart run dedupe@^0.1.0 --format=json
 
 # Write JSON report to file alongside human stdout
-dart run dedupe --json-output=report.json
+dart run dedupe@^0.1.0 --json-output=report.json
 ```
 
 #### Mode 2: PR / Git Diff Delta Scan (`--git-diff`)
@@ -83,13 +83,13 @@ Focus strictly on code modified in a branch or PR:
 
 ```bash
 # In Git checkouts:
-dart run dedupe --git-diff=origin/main
+dart run dedupe@^0.1.0 --git-diff=origin/main
 
 # Filter report strictly to clusters intersecting modified lines:
-dart run dedupe --git-diff=origin/main --only-changed
+dart run dedupe@^0.1.0 --git-diff=origin/main --only-changed
 
 # Fail CI if diff duplication exceeds 5%:
-dart run dedupe --git-diff=origin/main --fail-threshold=5
+dart run dedupe@^0.1.0 --git-diff=origin/main --fail-threshold=5
 ```
 
 ### Common CLI Options Reference

--- a/skills/dart-dedupe/SKILL.md
+++ b/skills/dart-dedupe/SKILL.md
@@ -22,39 +22,43 @@ key_features:
 High-performance structural code duplication and clone detection engine and
 refactoring protocol for Dart and Flutter repositories using `pkg:dedupe`.
 
---------------------------------------------------------------------------------
+---
 
 ## 1. When to Use This Skill
 
-Use this skill when auditing codebase redundancy, identifying copy-paste
-blocks, preventing duplication regressions in pull requests, or evaluating
-shared utility and abstraction candidates across Dart packages.
+Use this skill when auditing codebase redundancy, identifying copy-paste blocks,
+preventing duplication regressions in pull requests, or evaluating shared
+utility and abstraction candidates across Dart packages.
 
 Unlike basic lexical diffs, `dedupe` tokenizes and analyzes Dart source code to
 detect:
-* **Identical Clones**: Exact token-for-token copies across files.
-* **Structural Clones**: Clones matching after normalizing string literals and
+
+- **Identical Clones**: Exact token-for-token copies across files.
+- **Structural Clones**: Clones matching after normalizing string literals and
   numeric constants (`--ignore-literals`).
-* **Parameterized Clones**: Clones matching after normalizing variable and type
+- **Parameterized Clones**: Clones matching after normalizing variable and type
   identifiers (`--ignore-identifiers`).
-* **Gapped / Near-Miss Clones**: Type-3 clones matching with internal statement
-  insertions, deletions, or edits via MinHash & LSH shingling (`--bucket=gapped`).
+- **Gapped / Near-Miss Clones**: Type-3 clones matching with internal statement
+  insertions, deletions, or edits via MinHash & LSH shingling
+  (`--bucket=gapped`).
 
 ### Trigger Indicators
-* **Copy-pasted utilities**: Identical or nearly identical helper functions
+
+- **Copy-pasted utilities**: Identical or nearly identical helper functions
   duplicated across multiple files or classes.
-* **Redundant serialization / parsing**: Repeated manual JSON decoders, record
+- **Redundant serialization / parsing**: Repeated manual JSON decoders, record
   mappers, or data transformation pipelines.
-* **PR / CL Duplication Regressions**: Catching newly introduced duplicate
-  code before merging pull requests.
+- **PR / CL Duplication Regressions**: Catching newly introduced duplicate code
+  before merging pull requests.
 
 ### When NOT to Use
-* **Single-File Private Variable Lints**: Use standard `dart analyze` for simple
-  unused variables or parameters.
-* **Code Formatting**: Use `dart format`.
-* **Non-Dart Projects**: Tool operates strictly on Dart syntax.
 
---------------------------------------------------------------------------------
+- **Single-File Private Variable Lints**: Use standard `dart analyze` for simple
+  unused variables or parameters.
+- **Code Formatting**: Use `dart format`.
+- **Non-Dart Projects**: Tool operates strictly on Dart syntax.
+
+---
 
 ## 2. Automated Execution & Scope Resolution
 
@@ -67,6 +71,7 @@ dart run dedupe@^0.1.0 [options] [target_path]
 ### Execution Modes
 
 #### Mode 1: Full Repository / Directory Scan
+
 ```bash
 # Markdown summary with clickable file links
 dart run dedupe@^0.1.0
@@ -79,6 +84,7 @@ dart run dedupe@^0.1.0 --json-output=report.json
 ```
 
 #### Mode 2: PR / Git Diff Delta Scan (`--git-diff`)
+
 Focus strictly on code modified in a branch or PR:
 
 ```bash
@@ -96,31 +102,31 @@ dart run dedupe@^0.1.0 --git-diff=origin/main --fail-threshold=5
 
 <!-- mdformat off(prevent table wrapping) -->
 
-| Option / Flag | Purpose | Default |
-| :--- | :--- | :--- |
-| `-k, --min-tokens` | Minimum token count for a reported duplicate block. | `40` |
-| `-l, --min-lines` | Minimum line count for a reported duplicate block. | `4` |
-| `--[no-]ignore-comments` | Ignore comments when comparing tokens. | `true` |
-| `--[no-]ignore-literals` | Normalize literals to detect structural clones. | `true` |
-| `--[no-]ignore-identifiers` | Normalize identifiers to detect parameterized clones. | `false` |
-| `--category` | Filter clusters (`all`, `logic`, `data`, `boilerplate`). | `all` |
-| `--bucket` | Filter clusters (`all`, `identical`, `structural`, `parameterized`, `gapped`). | `all` |
-| `--top` | Limit number of top clusters to display (`0` for all). | `0` |
-| `-f, --fail-threshold` | Maximum allowed duplication percentage before failing. | None |
-| `-d, --git-diff` | Git reference to compare against (e.g. `origin/main`). | None |
-| `--only-changed` | Only report clusters intersecting modified lines. | `false` |
-| `--exclude` | Comma-separated glob patterns of files to exclude. | Standard exclusions |
-| `--include` | Comma-separated glob patterns of files to include. | `**/*.dart` |
-| `--[no-]cache` | Enable on-disk caching of AST candidates & token sequences. | `true` |
-| `--cache-dir` | Custom directory for cache (defaults to `.dart_tool/dedupe`). | None |
-| `--[no-]files` | Include per-file duplication metrics table in report. | `true` |
-| `--[no-]clusters` | Include duplicate clusters list in report. | `true` |
-| `--format` | Output format (`markdown`, `json`, `github`, `text`). | `markdown` |
-| `--json-output` | File path to write machine-readable JSON report. | None |
+| Option / Flag               | Purpose                                                                        | Default             |
+| :-------------------------- | :----------------------------------------------------------------------------- | :------------------ |
+| `-k, --min-tokens`          | Minimum token count for a reported duplicate block.                            | `40`                |
+| `-l, --min-lines`           | Minimum line count for a reported duplicate block.                             | `4`                 |
+| `--[no-]ignore-comments`    | Ignore comments when comparing tokens.                                         | `true`              |
+| `--[no-]ignore-literals`    | Normalize literals to detect structural clones.                                | `true`              |
+| `--[no-]ignore-identifiers` | Normalize identifiers to detect parameterized clones.                          | `false`             |
+| `--category`                | Filter clusters (`all`, `logic`, `data`, `boilerplate`).                       | `all`               |
+| `--bucket`                  | Filter clusters (`all`, `identical`, `structural`, `parameterized`, `gapped`). | `all`               |
+| `--top`                     | Limit number of top clusters to display (`0` for all).                         | `0`                 |
+| `-f, --fail-threshold`      | Maximum allowed duplication percentage before failing.                         | None                |
+| `-d, --git-diff`            | Git reference to compare against (e.g. `origin/main`).                         | None                |
+| `--only-changed`            | Only report clusters intersecting modified lines.                              | `false`             |
+| `--exclude`                 | Comma-separated glob patterns of files to exclude.                             | Standard exclusions |
+| `--include`                 | Comma-separated glob patterns of files to include.                             | `**/*.dart`         |
+| `--[no-]cache`              | Enable on-disk caching of AST candidates & token sequences.                    | `true`              |
+| `--cache-dir`               | Custom directory for cache (defaults to `.dart_tool/dedupe`).                  | None                |
+| `--[no-]files`              | Include per-file duplication metrics table in report.                          | `true`              |
+| `--[no-]clusters`           | Include duplicate clusters list in report.                                     | `true`              |
+| `--format`                  | Output format (`markdown`, `json`, `github`, `text`).                          | `markdown`          |
+| `--json-output`             | File path to write machine-readable JSON report.                               | None                |
 
 <!-- mdformat on -->
 
---------------------------------------------------------------------------------
+---
 
 ## 3. The "Actionable vs. Necessary" Architectural Gate
 
@@ -128,28 +134,31 @@ dart run dedupe@^0.1.0 --git-diff=origin/main --fail-threshold=5
 Evaluate each candidate cluster before modifying code:
 
 ### ✅ Actionable Duplication (Refactor & Extract)
-* **Copy-pasted helpers or decoders:** Identical algorithms, database record
+
+- **Copy-pasted helpers or decoders:** Identical algorithms, database record
   parsers, or conversion utilities scattered across multiple classes or files.
-* **Shared contract declarations:** Common `typedef` contracts, data models, or
+- **Shared contract declarations:** Common `typedef` contracts, data models, or
   record shapes duplicated across platform stubs (extract to a shared library).
-* **Repetitive CLI orchestration:** Copy-pasted external process invocations or
+- **Repetitive CLI orchestration:** Copy-pasted external process invocations or
   JSON decoding blocks where schema updates would risk drift.
-* **Code generator scaffolding:** Repetitive string builders or verbose AST
+- **Code generator scaffolding:** Repetitive string builders or verbose AST
   instantiations that can be cleanly condensed into parameterized emitters.
 
 ### 🛑 Necessary Duplication (Reject Refactoring & Preserve)
-* **Type-unsafe polymorphic AST targets:** When similar-looking classes (such as
+
+- **Type-unsafe polymorphic AST targets:** When similar-looking classes (such as
   AST statement variants) do not share a common type interface. Using `dynamic`
   sacrifices compile-time type safety for negligible line reduction.
-* **Performance-critical specialized solver loops:** Symmetric horizontal vs.
+- **Performance-critical specialized solver loops:** Symmetric horizontal vs.
   vertical grid traversals where unifying orthogonal strides into a single
   abstraction would require allocating closures or virtual calls in tight loops.
-* **Speculative wrapping of standalone entry points:** Abstracting trivial
+- **Speculative wrapping of standalone entry points:** Abstracting trivial
   4-to-6 line `try/catch` fallback formatting across unrelated standalone CLI
   entry points (`bin/<script>.dart`).
-* **DAMP Test Boilerplate:** Repetitive setup structures in table-driven unit tests.
+- **DAMP Test Boilerplate:** Repetitive setup structures in table-driven unit
+  tests.
 
---------------------------------------------------------------------------------
+---
 
 ## 4. The 2-Stage Triage & Confirmation Protocol
 
@@ -157,9 +166,11 @@ To prevent unwanted diff bloat and preserve codebase stability, adhere to this
 strict 2-stage workflow:
 
 ### Stage 1: Read-Only Audit & Reporting (Mandatory Stop)
+
 Run `dart run dedupe --format=markdown` (or `--format=json`).
 
 Output a ranked **Duplication Triage Report** containing:
+
 1. **Target Summary**: Files analyzed, total lines, duplication percentage, and
    estimated lines saved.
 2. **Top Duplicate Clusters**: Clickable file links, line ranges, token counts,
@@ -169,15 +180,17 @@ Output a ranked **Duplication Triage Report** containing:
    mark as "Necessary Duplication (Preserve)".
 
 ### Stage 2: Interactive User Confirmation Gate
+
 Pause execution and prompt the user (via interactive choice or chat) to select
 the desired remediation scope:
+
 1. **(Recommended) Refactor Top Actionable Cluster Only**: Target the single
    highest-impact duplicate helper or decoder.
 2. **Refactor All Actionable Clusters in Scope**: Sequentially extract all
    approved duplicate blocks.
 3. **Report-Only / Exit**: Acknowledge findings without code mutations.
 
---------------------------------------------------------------------------------
+---
 
 ## 5. Pre & Post Refactor Verification Protocol
 
@@ -195,41 +208,49 @@ graph TD
 ```
 
 1. **Verify Baseline:** Run `dart test` prior to modification. Ensure 100% pass.
-2. **Surgical Modification:** Extract shared functions or helper classes cleanly.
-3. **Verify Post-Refactor Health:** Run `dart analyze --fatal-infos` and `dart test`.
+2. **Surgical Modification:** Extract shared functions or helper classes
+   cleanly.
+3. **Verify Post-Refactor Health:** Run `dart analyze --fatal-infos` and
+   `dart test`.
 4. **Zero-Clone Confirmation:** Re-run `dart run dedupe` to confirm the target
    cluster was eliminated.
 5. **Local Staging:** Stage verified diffs locally (`git add .`).
 
---------------------------------------------------------------------------------
+---
 
 ## 6. Pull Request & Commit Provenance Protocol
 
 When staging deduplicated code and preparing a commit message or Pull Request:
 
 ### 1. User Confirmation Gate & Headless Defaults
-* **Interactive Sessions**: Before writing the PR description or commit body,
+
+- **Interactive Sessions**: Before writing the PR description or commit body,
   explicitly prompt the user in chat or via the harness confirmation tool (e.g.
   `ask_question`) whether to include a **Tool Provenance & Reproduction block**.
-* **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
+- **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
   subagents, automated eval suites like `evalin`, or headless CI), default to
   including the block automatically without blocking on user confirmation.
 
 ### 2. Standardized Provenance Block Format
+
 When confirmed (or running headlessly), append the following markdown block to
 the PR description or commit body:
 
 ````markdown
 ### 🤖 Tool Provenance & Reproduction
 
-Structural duplication analysis performed with [`dedupe`](https://pub.dev/packages/dedupe) (`v{version}`).
+Structural duplication analysis performed with
+[`dedupe`](https://pub.dev/packages/dedupe) (`v{version}`).
 
 To reproduce or re-run this duplication scan locally:
+
 ```bash
 {exact_command_line}
 ```
 ````
 
 ### 3. Version Resolution
+
 Determine the package version dynamically:
-* Check `pubspec.lock` in the workspace or run `dart run dedupe --version`.
+
+- Check `pubspec.lock` in the workspace or run `dart run dedupe --version`.

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -59,7 +59,7 @@ Execute the official package CLI directly in the terminal to retrieve reachabili
 findings deterministically:
 
 ```bash
-dart run undead@ [options] [target_path]
+dart run undead@^0.1.1 [options] [target_path]
 ```
 
 > [!NOTE]
@@ -67,7 +67,7 @@ dart run undead@ [options] [target_path]
 > `.dart_tool/package_config.json` to resolve `package:<name>/...` imports. If
 > packages are unresolved, pass `--pub-get` to automatically run `dart pub get`
 > or `flutter pub get`. If encountering `.dart_tool` atomic rename errors in
-> sandboxed environments, pass `--no-precompile` (e.g. `dart run --no-precompile undead@`).
+> sandboxed environments, pass `--no-precompile` (e.g. `dart run --no-precompile undead@^0.1.1`).
 
 ### Execution Modes
 
@@ -78,10 +78,10 @@ tests:
 
 ```bash
 # Markdown output for human review
-dart run undead@
+dart run undead@^0.1.1
 
 # Machine-readable JSON output for agent automation
-dart run undead@ --format=json
+dart run undead@^0.1.1 --format=json
 ```
 
 #### Mode 2: Closed Application (`--mode=closed-app`)
@@ -89,7 +89,7 @@ Traces execution strictly from executable entrypoints (`bin/**`, `lib/main.dart`
 `lib/main_*.dart`). Treats unreferenced public declarations as dead:
 
 ```bash
-dart run undead@ --mode=closed-app
+dart run undead@^0.1.1 --mode=closed-app
 ```
 
 #### Mode 3: Example Code Handling (`--example-mode`)

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Audits, triages, and safely remediates unreachable and dead declarations in
   Dart and Flutter codebases using deterministic reachability analysis
   (pkg:undead). Use when identifying unused top-level declarations, classes,
-  functions, or dead test fixtures in libraries or closed applications. Don't use
-  for single-file private variable lints (use standard analyzer lints), code
+  functions, or dead test fixtures in libraries or closed applications. Don't
+  use for single-file private variable lints (use standard analyzer lints), code
   formatting, or non-Dart/Flutter repositories.
 license: Apache-2.0
 key_features:
@@ -22,7 +22,7 @@ key_features:
 Deterministic reachability and dead/unused declaration analysis for Dart and
 Flutter packages using `pkg:undead`.
 
---------------------------------------------------------------------------------
+---
 
 ## 1. When to Use This Skill
 
@@ -36,42 +36,45 @@ reachability graph from designated entrypoint roots down to all internal
 declarations.
 
 ### Trigger Indicators
-* **Orphaned Internal Utilities**: Functions, classes, or mixins under `lib/src/`
-  unreachable from public API barrels or internal entrypoints.
-* **Dead Application Features**: Unreachable views, controllers, or services in
+
+- **Orphaned Internal Utilities**: Functions, classes, or mixins under
+  `lib/src/` unreachable from public API barrels or internal entrypoints.
+- **Dead Application Features**: Unreachable views, controllers, or services in
   standalone CLI tools or Flutter apps.
-* **Orphaned Test Fixtures**: Dead `Fake*` or `Mock*` fixtures left behind after
+- **Orphaned Test Fixtures**: Dead `Fake*` or `Mock*` fixtures left behind after
   features were refactored.
-* **Pre-Release API Pruning**: Verifying whether newly introduced experimental
+- **Pre-Release API Pruning**: Verifying whether newly introduced experimental
   helpers are actually wired up before public release.
 
 ### When NOT to Use
-* **Single-File Private Lints**: Rely on standard `dart analyze` for simple
-  local variable or private parameter lints.
-* **Code Formatting or Lint Rules**: Use standard `dart format` or `dart fix`.
-* **Non-Dart / Non-Flutter Projects**: Tool exclusively operates on Dart ASTs.
 
---------------------------------------------------------------------------------
+- **Single-File Private Lints**: Rely on standard `dart analyze` for simple
+  local variable or private parameter lints.
+- **Code Formatting or Lint Rules**: Use standard `dart format` or `dart fix`.
+- **Non-Dart / Non-Flutter Projects**: Tool exclusively operates on Dart ASTs.
+
+---
 
 ## 2. Automated Execution & Scope Resolution
 
-Execute the official package CLI directly in the terminal to retrieve reachability
-findings deterministically:
+Execute the official package CLI directly in the terminal to retrieve
+reachability findings deterministically:
 
 ```bash
 dart run undead@^0.1.1 [options] [target_path]
 ```
 
-> [!NOTE]
-> **Pre-Flight Package Resolution Gate**: `package:analyzer` requires
+> [!NOTE] **Pre-Flight Package Resolution Gate**: `package:analyzer` requires
 > `.dart_tool/package_config.json` to resolve `package:<name>/...` imports. If
 > packages are unresolved, pass `--pub-get` to automatically run `dart pub get`
 > or `flutter pub get`. If encountering `.dart_tool` atomic rename errors in
-> sandboxed environments, pass `--no-precompile` (e.g. `dart run --no-precompile undead@^0.1.1`).
+> sandboxed environments, pass `--no-precompile` (e.g.
+> `dart run --no-precompile undead@^0.1.1`).
 
 ### Execution Modes
 
 #### Mode 1: Library Package (Default / Open-World)
+
 Preserves all non-`src` `lib/**` exports as public API roots. Analyzes whether
 internal declarations (`lib/src/**`) are reachable from exported barrels or
 tests:
@@ -85,19 +88,23 @@ dart run undead@^0.1.1 --format=json
 ```
 
 #### Mode 2: Closed Application (`--mode=closed-app`)
-Traces execution strictly from executable entrypoints (`bin/**`, `lib/main.dart`,
-`lib/main_*.dart`). Treats unreferenced public declarations as dead:
+
+Traces execution strictly from executable entrypoints (`bin/**`,
+`lib/main.dart`, `lib/main_*.dart`). Treats unreferenced public declarations as
+dead:
 
 ```bash
 dart run undead@^0.1.1 --mode=closed-app
 ```
 
 #### Mode 3: Example Code Handling (`--example-mode`)
+
 Controls how code in `example/` is treated during reachability analysis:
-* `demonstration` (Default): `example/` code is treated as a consumer root;
+
+- `demonstration` (Default): `example/` code is treated as a consumer root;
   example files are never suggested for deletion.
-* `strict`: Analyzes reachability within `example/` itself.
-* `skip`: Ignores `example/` completely during analysis.
+- `strict`: Analyzes reachability within `example/` itself.
+- `skip`: Ignores `example/` completely during analysis.
 
 ```bash
 dart run undead@ --example-mode=demonstration
@@ -105,58 +112,64 @@ dart run undead@ --example-mode=demonstration
 
 ### Common CLI Options Reference
 
-| Option / Flag | Purpose | Default |
-| :--- | :--- | :--- |
-| `-m, --mode` | Analysis mode (`library` or `closed-app`). | `library` |
-| `-f, --format` | Output formatting (`markdown`, `json`, `github`). | `markdown` |
-| `--json-output=<path>` | Write JSON report to file while preserving stdout. | None |
-| `--example-mode` | Policy for `example/` (`demonstration`, `strict`, `skip`). | `demonstration` |
-| `--extra-roots=<dir1,dir2>` | Comma-separated list of additional root/test dirs. | `""` |
-| `--test-support-patterns` | Comma-separated wildcards for test fixtures. | `Fake*,Mock*` |
-| `--ignore-name-patterns` | Comma-separated wildcards for names to ignore. | `""` |
-| `--[no-]workspace-discovery` | Discover consumer roots from sibling packages in workspace. | `true` |
-| `--[no-]ignore-external-bindings` | Preserve unreferenced `@JS()` and FFI facades. | `false` |
-| `--[no-]suggest-private` | Identify top-level declarations that can be made library-private. | `false` |
-| `--pub-get` | Auto-run `dart pub get` / `flutter pub get` if needed. | `false` |
-| `--fail-on-undead` | Exit with non-zero code (1) on findings (useful for CI). | `false` |
+| Option / Flag                     | Purpose                                                           | Default         |
+| :-------------------------------- | :---------------------------------------------------------------- | :-------------- |
+| `-m, --mode`                      | Analysis mode (`library` or `closed-app`).                        | `library`       |
+| `-f, --format`                    | Output formatting (`markdown`, `json`, `github`).                 | `markdown`      |
+| `--json-output=<path>`            | Write JSON report to file while preserving stdout.                | None            |
+| `--example-mode`                  | Policy for `example/` (`demonstration`, `strict`, `skip`).        | `demonstration` |
+| `--extra-roots=<dir1,dir2>`       | Comma-separated list of additional root/test dirs.                | `""`            |
+| `--test-support-patterns`         | Comma-separated wildcards for test fixtures.                      | `Fake*,Mock*`   |
+| `--ignore-name-patterns`          | Comma-separated wildcards for names to ignore.                    | `""`            |
+| `--[no-]workspace-discovery`      | Discover consumer roots from sibling packages in workspace.       | `true`          |
+| `--[no-]ignore-external-bindings` | Preserve unreferenced `@JS()` and FFI facades.                    | `false`         |
+| `--[no-]suggest-private`          | Identify top-level declarations that can be made library-private. | `false`         |
+| `--pub-get`                       | Auto-run `dart pub get` / `flutter pub get` if needed.            | `false`         |
+| `--fail-on-undead`                | Exit with non-zero code (1) on findings (useful for CI).          | `false`         |
 
---------------------------------------------------------------------------------
+---
 
 ## 3. Critical Safety Guardrails & Deletion Invariants
 
-> [!CAUTION]
-> **Audit Before Deleting**: Never delete declarations autonomously without
-> reviewing safety invariants and verifying against the test suite.
+> [!CAUTION] **Audit Before Deleting**: Never delete declarations autonomously
+> without reviewing safety invariants and verifying against the test suite.
 
 ### Invariant 1: Sealed Class Hierarchy Protection
-Direct subtypes of live `sealed` classes (via `extends`, `implements`, `with`, or
-`enum`) must **NEVER** be deleted, even if unreferenced elsewhere. Deleting a
+
+Direct subtypes of live `sealed` classes (via `extends`, `implements`, `with`,
+or `enum`) must **NEVER** be deleted, even if unreferenced elsewhere. Deleting a
 sealed subtype breaks Dart 3 exhaustive pattern matching across all `switch`
 expressions.
 
 ### Invariant 2: Co-Invoked Test Hazard Protection
+
 When a test file invokes both live and dead declarations:
-* **Isolated Dead Tests**: Test blocks referencing *only* dead code can be safely
-  pruned alongside the dead target.
-* **Co-Invoked Test Hazard**: When a single test function or widget test exercises
-  both live and dead code, **do not delete the test**. Refactor the test body to
-  remove only the dead assertions.
+
+- **Isolated Dead Tests**: Test blocks referencing _only_ dead code can be
+  safely pruned alongside the dead target.
+- **Co-Invoked Test Hazard**: When a single test function or widget test
+  exercises both live and dead code, **do not delete the test**. Refactor the
+  test body to remove only the dead assertions.
 
 ### Invariant 3: Framework Entrypoints & Pragmas
+
 Ensure framework-specific roots are not falsely classified as dead:
-* **Build Runner**: Builder factories and generator entrypoints in `build.yaml`.
-* **VM Entrypoints**: Declarations annotated with `@pragma('vm:entry-point')`.
-* **JS Interop**: External JavaScript facades (`@JS()`). Pass
+
+- **Build Runner**: Builder factories and generator entrypoints in `build.yaml`.
+- **VM Entrypoints**: Declarations annotated with `@pragma('vm:entry-point')`.
+- **JS Interop**: External JavaScript facades (`@JS()`). Pass
   `--ignore-external-bindings` if pruning libraries with public interop headers.
 
 ### Invariant 4: Custom Suppression Syntax
-To suppress intentional dead code or API placeholders without deleting:
-* **Declaration Level**: `// undead:ignore` (placed directly above declaration).
-* **File Level**: `// undead:ignore_for_file` (placed at top of file).
-* *(Note: Never use `// ignore: ...` as the Dart analyzer treats unknown lint
-  codes as errors).*
 
---------------------------------------------------------------------------------
+To suppress intentional dead code or API placeholders without deleting:
+
+- **Declaration Level**: `// undead:ignore` (placed directly above declaration).
+- **File Level**: `// undead:ignore_for_file` (placed at top of file).
+- _(Note: Never use `// ignore: ...` as the Dart analyzer treats unknown lint
+  codes as errors)._
+
+---
 
 ## 4. The 2-Stage Triage & Confirmation Protocol
 
@@ -164,9 +177,11 @@ To prevent accidental deletions of public APIs or breaking downstream consumers,
 follow this strict 2-stage workflow:
 
 ### Stage 1: Read-Only Audit & Reporting (Mandatory Stop)
+
 Run `dart run undead@ --format=markdown` (or `--format=json`).
 
 Output a ranked **Dead Code Triage Report** containing:
+
 1. **Target Summary**: Package name, analysis mode (`library` vs `closed-app`),
    and total undead declarations detected.
 2. **Actionable Findings Table**: Clickable file link, line number, declaration
@@ -175,8 +190,10 @@ Output a ranked **Dead Code Triage Report** containing:
    hazards, or public exports.
 
 ### Stage 2: Interactive User Confirmation Gate
+
 Pause execution and prompt the user (via interactive choice or chat) to select
 the desired remediation scope:
+
 1. **(Recommended) Prune Internal Dead Code Only**: Delete unreferenced
    declarations in `lib/src/**` and isolated test files.
 2. **Prune Application Entrypoints**: Target dead features in a closed app
@@ -185,7 +202,7 @@ the desired remediation scope:
    placeholders.
 4. **Report-Only / Exit**: Acknowledge findings without code mutations.
 
---------------------------------------------------------------------------------
+---
 
 ## 5. Pre & Post Deletion Verification Protocol
 
@@ -201,33 +218,35 @@ graph TD
     E -->|Fail| G[Step 7: Rollback / Fix Hazard]
 ```
 
-1. **Pre-Flight Baseline**: Execute `dart test` to confirm the test suite is 100%
-   green before touching any code.
-2. **Surgical Deletion**: Remove the flagged declaration and any orphaned imports
-   associated with it.
+1. **Pre-Flight Baseline**: Execute `dart test` to confirm the test suite is
+   100% green before touching any code.
+2. **Surgical Deletion**: Remove the flagged declaration and any orphaned
+   imports associated with it.
 3. **Post-Flight Verification**:
-   * Run `dart analyze` to ensure zero compilation or unresolved reference
+   - Run `dart analyze` to ensure zero compilation or unresolved reference
      errors.
-   * Run `dart test` to confirm all remaining tests pass.
+   - Run `dart test` to confirm all remaining tests pass.
 4. **Clean Diff Staging**: Inspect modifications using `git diff --stat` (or
    isolate in a temporary feature branch/worktree) to ensure only intended
    declarations were removed.
 
---------------------------------------------------------------------------------
+---
 
 ## 6. Pull Request & Commit Provenance Protocol
 
 When staging pruned code and preparing a commit message or Pull Request:
 
 ### 1. User Confirmation Gate & Headless Defaults
-* **Interactive Sessions**: Before writing the PR description or commit body,
+
+- **Interactive Sessions**: Before writing the PR description or commit body,
   explicitly prompt the user in chat or via the harness confirmation tool (e.g.
   `ask_question`) whether to include a **Tool Provenance & Reproduction block**.
-* **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
+- **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
   subagents, automated eval suites like `evalin`, or headless CI), default to
   including the block automatically without blocking on user confirmation.
 
 ### 2. Standardized Provenance Block Format
+
 When confirmed (or running headlessly), append the following markdown block to
 the PR description or commit body so reviewers understand where the deletions
 originated and can rerun the reachability analysis locally:
@@ -235,16 +254,20 @@ originated and can rerun the reachability analysis locally:
 ````markdown
 ### 🤖 Tool Provenance & Reproduction
 
-Dead code detection and reachability analysis performed with [`undead`](https://pub.dev/packages/undead) (`v{version}`).
+Dead code detection and reachability analysis performed with
+[`undead`](https://pub.dev/packages/undead) (`v{version}`).
 
 To reproduce or re-run this reachability audit locally:
+
 ```bash
 {exact_command_line}
 ```
 ````
 
 ### 3. Version Resolution
+
 Determine the package version dynamically:
-* Check `pubspec.lock` in the workspace or run `dart run undead@ --version`.
-* If invoked with a specific version constraint (e.g. `undead@0.1.0`), use that
+
+- Check `pubspec.lock` in the workspace or run `dart run undead@ --version`.
+- If invoked with a specific version constraint (e.g. `undead@0.1.0`), use that
   exact version.


### PR DESCRIPTION
## Overview
Centralizes file exclusion and generated code filtering logic into a unified `PathFilter` model in `package:analytica` and adopts it across `cognitive_complexity`, `dedupe`, and `undead`.

Closes #104.
Supersedes #90.

## Changes
- **`package:analytica`**:
  - Implement `PathFilter` in `package:analytica/analyzer.dart` with standard directory ignores (`.dart_tool`, `.git`, `.idea`, `.vscode`, `build`), canonical generated file patterns (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`, `*.config.dart`, `*.reflectable.dart`, `*.gen.dart`, `*.pb*.dart`), and slash-less pattern auto-prefixing.
  - Add `addPathFilterOptions()`, `addPathFilterArgs()`, and `parsePathFilter()` helpers in `package:analytica/cli.dart`.
- **`package:cognitive_complexity`**:
  - Add `--exclude` and `--[no-]ignore-generated` CLI options.
  - Pass `PathFilter` into `ComplexityAnalyzer` and `DeltaAnalyzer`.
  - Add test coverage in `test/exclude_test.dart`.
- **`package:dedupe`**:
  - Wire `PathFilter` into `DedupeOptions` and `DedupeEngine`, replacing ad-hoc file exclusion loops.
  - Retain `defaultDartExclusions` with extra FFI/JNI bindings patterns.
- **`package:undead`**:
  - Wire `PathFilter` into `UndeadOptions` and `RootHarvester`, eliminating redundant custom path checking logic.
  - Standardize on `--[no-]ignore-generated` (with `--include-generated` alias retained for backward compatibility).
- **Documentation & Tests**:
  - Update `CHANGELOG.md` across all 4 packages.
  - Synchronize CLI `--help` blocks in `README.md` files via `cli_readme`.
  - Verify 100% test pass rate across all packages.