### PR TITLE
docs(skills): harden undead, dedupe, and cognitive-complexity with outlier-first and exhaustiveness mandates

### DIFF
--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -120,24 +120,38 @@ a ranked Markdown **Complexity Triage Report** directly in chat (or to an
 artifact for extensive findings) containing:
 
 - Flagged function name and clickable file local path.
-- Current complexity score versus operational ceiling.
+- Current complexity score versus operational ceiling (sorted descending by
+  score).
 - Recommended refactoring strategy (Pattern A, B, D, E, or a Pattern C tier) and
   unit test status.
+
+### Invariant: Outlier-First Mandate (Tackle the Monster)
+
+- **Must Target the #1 Outlier**: When remediating complexity, you MUST target
+  the single highest-scoring function in the report (e.g. Score >= 25, or the top
+  outlier like a score 100 method) first.
+- **Forbid Timid Sub-Threshold Picks**: It is strictly forbidden to pick an easy,
+  mildly elevated helper (e.g. score 18) while ignoring a severe monster
+  outlier (e.g. score 100 or 50) in the report.
+- **Aggressive Decomposition Target**: Apply Dart 3 pattern matching, guard
+  clauses, and method decomposition to drive the top outlier's score down to
+  `<= 15`.
 
 ### Stage 2: Interactive User Selection (Confirmation Gate)
 
 Pause execution and prompt the user (via interactive choice or chat) to select
 the desired sequencing:
 
-1. **(Recommended) Refactor Top Hotspot Only**: Target the single
-   highest-scoring declaration first, verify via unit tests, and present diffs
-   cleanly.
-2. **Selective Batch Refactor**: Remediate a user-specified subset of functions.
+1. **(Recommended) Refactor Top Monster Outlier First**: Target the single
+   highest-scoring declaration in the report, decompose to score <= 15, verify
+   via unit tests, and present diffs cleanly.
+2. **Selective Batch Refactor**: Remediate the top $N$ highest-scoring functions
+   in descending order.
 3. **Report-Only / Exit**: Acknowledge complexity scores without code mutation.
 
 > **Explicit Bypass Exception**: Skip Stage 1 triage only when the user provides
 > an explicit remediation directive upfront (e.g., "Refactor `processOrder` in
-> `lib/src/order.dart` to fix complexity").
+> `lib/src/order.dart` to fix complexity" or "Refactor the top complexity outlier").
 
 ---
 

--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -125,33 +125,37 @@ artifact for extensive findings) containing:
 - Recommended refactoring strategy (Pattern A, B, D, E, or a Pattern C tier) and
   unit test status.
 
-### Invariant: Outlier-First Mandate (Tackle the Monster)
+### Invariant: Outlier-First Mandate
 
-- **Must Target the #1 Outlier**: When remediating complexity, you MUST target
-  the single highest-scoring function in the report (e.g. Score >= 25, or the top
-  outlier like a score 100 method) first.
-- **Forbid Timid Sub-Threshold Picks**: It is strictly forbidden to pick an easy,
-  mildly elevated helper (e.g. score 18) while ignoring a severe monster
-  outlier (e.g. score 100 or 50) in the report.
-- **Aggressive Decomposition Target**: Apply Dart 3 pattern matching, guard
-  clauses, and method decomposition to drive the top outlier's score down to
-  `<= 15`.
+- **Target the Primary Outlier**: When remediating complexity, prioritize the
+  highest-scoring declaration in the report (e.g. Score >= 25 or top outlier)
+  to achieve the highest measurable reduction.
+- **Prioritize High-Impact Reductions**: Avoid selecting only minor
+  sub-threshold helpers while leaving severe complexity outliers unaddressed.
+- **Decomposition Target**: Apply Dart 3 pattern matching, guard clauses, and
+  method decomposition targeting a post-refactoring score of `<= 15`. For
+  massive legacy functions (score > 60), safe phased decomposition across
+  isolated PRs is permitted if a single pass would exceed reviewable diff limits.
 
 ### Stage 2: Interactive User Selection (Confirmation Gate)
 
 Pause execution and prompt the user (via interactive choice or chat) to select
 the desired sequencing:
 
-1. **(Recommended) Refactor Top Monster Outlier First**: Target the single
-   highest-scoring declaration in the report, decompose to score <= 15, verify
-   via unit tests, and present diffs cleanly.
-2. **Selective Batch Refactor**: Remediate the top $N$ highest-scoring functions
+1. **(Recommended) Refactor Primary Outlier First**: Target the single
+   highest-scoring declaration in the report, decompose towards score <= 15,
+   verify via unit tests, and present diffs cleanly.
+2. **Selective Batch Refactor**: Remediate the top N highest-scoring functions
    in descending order.
 3. **Report-Only / Exit**: Acknowledge complexity scores without code mutation.
 
-> **Explicit Bypass Exception**: Skip Stage 1 triage only when the user provides
-> an explicit remediation directive upfront (e.g., "Refactor `processOrder` in
-> `lib/src/order.dart` to fix complexity" or "Refactor the top complexity outlier").
+> **Explicit Bypass & Headless Fallback**:
+> - **Direct Directives**: Skip Stage 1 triage if given an explicit remediation
+>   directive upfront (e.g., "Refactor `processOrder` in `lib/src/order.dart` to
+>   fix complexity" or "Refactor the top complexity outlier").
+> - **Autonomous Sessions**: In non-interactive contexts (e.g. `evalin` or
+>   subagents), proceed with Option 1 (Refactor Primary Outlier) automatically
+>   after verifying baseline tests pass.
 
 ---
 
@@ -167,17 +171,15 @@ this verification baseline:
    - If the **`dart-collect-coverage`** companion skill is available in your
      agent runtime, invoke it to check line and branch coverage on the targeted
      declarations.
-   - At minimum, execute the relevant test suite
-     (`dart test test/foo_test.dart`) to confirm a passing green regression
+   - At minimum, execute the relevant test suite (`dart test test/foo_test.dart`
+     or `flutter test test/foo_test.dart`) to confirm a passing green regression
      baseline before touching code.
 3. **Low-Coverage Safety Gate**: If tests are missing or coverage around the
-   flagged function is inadequate, pause execution and explicitly warn the user:
-
-   > ⚠️ **Low Test Coverage Warning**: Function `<name>` in `<path>` lacks unit
-   > test coverage. Structural refactoring risks silent behavioral regression.
-
-   Offer clear remediation paths:
-   1. **(Recommended)** Write unit tests to lock in baseline behavior first.
+   flagged function is inadequate:
+   - **Interactive Sessions**: Pause execution and warn the user. Offer options
+     to (1) write unit tests first, or (2) proceed with surgical refactoring.
+   - **Autonomous / Headless Sessions**: Log a low-coverage warning and author a
+     minimal regression test before modifying complex logic.
    2. Proceed with structural refactoring and verify functionality manually.
 
 ---
@@ -277,86 +279,61 @@ bugs.
 
 #### Deterministic Tier Selection via `data_flow`
 
-Do not eyeball which tier a candidate slice belongs to. Run the companion
-statement-level data-flow analyzer (on-demand form; same SDK 3.12.0+ requirement
-as the scanner) on each line slice you intend to extract:
+#### Deterministic 3-Tier Selection via `data_flow`
+
+Do not manually estimate or guess which tier a candidate slice belongs to. Run
+the companion statement-level data-flow analyzer (on-demand form; same SDK
+3.12.0+ requirement as the scanner) on each line slice you intend to extract:
 
 ```bash
 dart run cognitive_complexity:data_flow@^0.2.4 lib/src/my_file.dart:45-80
 ```
 
 Its report (`inputs`, `mutations`, live `outputs`, control-flow escapes, and a
-synthesized Dart 3 record signature) selects the tier.
+synthesized Dart 3 record signature) selects the tier:
 
-**Slice at natural seams first.** If a slice reports control-flow escapes or a
-tightly coupled pair of mutable variables (`queue` + `visited`, `buffer` +
-`cursor`), the usual culprit is the slice boundary, not the code. Enlarge the
-slice to the whole loop or state machine and re-run `data_flow`: escapes
-targeting a loop inside the slice stop being escapes, coupled state becomes
-interior, and the enlarged slice usually extracts cleanly as Tier 1/2.
+1. **Tier 1 — Pure Functional Decomposition (First Choice)**:
+   - **Selection**: Cleanly extractable slice with 2+ live outputs.
+   - **Idiom**: Extract a static or top-level function returning the synthesized
+     Dart 3 named record signature verbatim (`final (:data, :errors) = _stepOne(input);`).
+   - **Dataclass Boundary**: Private, file-local slices use named records at ANY
+     output count—do not create single-use `_XxxResult` dataclasses for them.
+     Reserve dedicated dataclasses only for values that cross public API
+     boundaries or require specialized invariants/methods.
+   - **State Scoping**: If the helper does not read or mutate class instance
+     state (`this`), declare it as a private top-level function (or static
+     method) to guarantee referential transparency.
 
-These bullets are the ONLY selection rules:
+2. **Tier 2 — Standard Helper Extraction (Second Choice)**:
+   - **Selection**: Cleanly extractable slice with <= 1 live output and <= 3
+     inputs.
+   - **Idiom**: Extract a standard private helper method or private top-level
+     function returning that single value.
 
-- **Cleanly extractable, ≤ 1 live output, ≤ 3 inputs** → Tier 2: extract a
-  standard private helper returning that value. If the helper does not read or
-  mutate class instance state (`this`), declare it as a private top-level
-  function (or static method) rather than an instance method.
-- **Cleanly extractable, 2+ live outputs** → Tier 1: extract a static or
-  top-level function and use the synthesized named record signature verbatim.
-  Private, file-local slices use named records at ANY output count — do NOT mint
-  single-use `_XxxResult` dataclasses for them. Reserve a dedicated `Result`
-  dataclass for values that cross a public API or library boundary, or that need
-  methods or invariants. If the helper does not read or mutate class instance
-  state (`this`), declare it as a private top-level function (or static method)
-  rather than an instance method. _Advisory_: 5+ live outputs usually means the
-  slice is cut at the wrong seam — try a different boundary before shipping a
-  wide record.
-- **Control-flow escapes** → apply in preference order:
-  1. Enlarge the slice to include the whole loop (natural seams, above) and
-     re-run the analysis.
-  2. If the loop _body_ is itself the hotspot, extract it with an explicit
-     signal return (Pattern E) — never a `shouldBreak` boolean flag.
-  3. Use guard-clause inversion (Pattern B) when the escape exists only to skip
-     nested conditions — it fixes nesting, not escapes. `yield` is none of
-     these: restructure the generator before attempting any extraction.
-- **Tier 3 gate (mutation-web check)** → Tier 3 requires recorded evidence, not
-  judgment. Run `data_flow` on at least two distinct candidate slices of the
-  function. Tier 3 is permitted ONLY if the intersection of their `mutations`
-  variable names contains 3 or more entries — i.e. the same mutable variables
-  thread through every candidate extraction. Paste the JSON reports into the
-  Triage Report as evidence; without that evidence, stay in Tier 1/2. A
-  recurring 2-variable coupling never qualifies: enlarge the slice, or take the
-  domain-modeling exit (below).
+3. **Control-Flow Escapes & Loop Bodies**:
+   - Apply natural seams: enlarge the slice to include the entire enclosing loop
+     or state machine and re-run `data_flow`.
+   - If the loop body itself is the hotspot, extract it with an explicit signal
+     return (Pattern E)—never a `shouldBreak` boolean flag.
+   - Use guard-clause inversion (Pattern B) when the escape exists only to skip
+     nested conditions.
 
-When choosing how to reduce complexity on a large Dart function, follow this
-**3-Tier Decision Hierarchy**:
+4. **Tier 3 — Encapsulated Method Object (Last Resort)**:
+   - **Mutation-Web Check Gate**: Permitted ONLY if `data_flow` reports on at
+     least two distinct candidate slices show that the intersection of their
+     `mutations` variable names contains 3 or more entries (the same mutable
+     variables thread through every candidate extraction).
+   - **Mechanics**: Read [references/method-object.md](references/method-object.md)
+     for extraction mechanics and mandatory idioms. Do not load or apply it
+     speculatively.
 
-1. **Tier 1 — Pure Functional Decomposition (first choice)**: static or
-   top-level functions returning Dart 3 named records
-   (`final (:data, :errors) = _stepOne(input);`); a dedicated `Result` /
-   `Response` dataclass only where the value crosses a public API or library
-   boundary or needs methods/invariants. All extracted helpers that do not
-   access class instance state (`this`) MUST be declared as private top-level
-   functions (or static methods) to guarantee referential transparency and
-   prevent temporal coupling.
-2. **Tier 2 — Standard Extract Method (second choice)**: standard private helper
-   methods or top-level private functions taking <= 3 arguments.
-3. **Tier 3 — Encapsulated Method Object (last resort)**: permitted only when
-   the mutation-web check above passes with recorded evidence. Then read
-   [references/method-object.md](references/method-object.md) for the extraction
-   mechanics and mandatory idioms. Do not load or apply it speculatively.
-
-**Domain-modeling exit**: when the same tightly coupled mutable state keeps
+**Domain-Modeling Exit**: When the same tightly coupled mutable state keeps
 resurfacing across a function (a parser's `buffer` + `cursor`, a traversal's
 `queue` + `visited`), the code may be asking to become a real, cohesively
 _named_ domain class (`Parser`, `GraphTraversal`) with a public, unit-tested
-API. That is domain modeling, not complexity remediation — it exits this rubric
-entirely and is not subject to the Tier 3 gate. The gate exists to ban
-single-use `_XxxRunner` facades, not real abstractions. To qualify for the exit,
-the class MUST have cohesive entity state, more than one public behavior, and
-its own dedicated test suite. A single-use private class with a constructor and
-one `run()` method is a runner no matter what it is renamed to (`_ScanEngine`,
-`_BatchProcessor`) and remains subject to the gate.
+API. To qualify for the exit, the class MUST have cohesive entity state, more
+than one public behavior, and its own dedicated test suite. Single-use private
+facades with one `run()` method remain subject to the Tier 3 gate.
 
 ---
 
@@ -437,12 +414,14 @@ Run these verification commands before committing refactored code:
    `dart run cognitive_complexity@^0.2.4 --fail-threshold 15 <refactored files>`
    scoped to the files you touched. Pre-existing breaches elsewhere in the
    project do not invalidate the refactor.
-2. **Code Presentation**: Run `dart format .` to maintain uniform syntactic
-   styling.
-3. **Static Analysis**: Run `dart analyze` to ensure zero static warnings, lint
-   violations, or un-awaited asynchronous gaps.
-4. **Test Fidelity**: Run `dart test` (or `flutter test`) to confirm zero
-   behavioral drift across existing test suites.
+2. **Code Presentation**: Run `dart format .` (or `flutter format .`) to
+   maintain uniform syntactic styling.
+3. **Static Analysis**: Run `dart analyze` (or `flutter analyze`) to ensure zero
+   static warnings, lint violations, or un-awaited asynchronous gaps.
+4. **Test Fidelity**:
+   - Check `pubspec.yaml`: if `sdk: flutter` is declared, run `flutter test`;
+     otherwise run `dart test`.
+   - In multi-package workspaces, run tests across all dependent packages.
 
 ---
 
@@ -500,6 +479,6 @@ dart run cognitive_complexity:data_flow@^0.2.4 {file}:{start_line}-{end_line}
 Determine the package version dynamically:
 
 - Check `pubspec.lock` in the workspace or run
-  `dart run cognitive_complexity@ --version`.
+  `dart run cognitive_complexity@^0.2.4 --version`.
 - If invoked with a specific version constraint (e.g.
-  `cognitive_complexity@0.2.3`), use that exact version.
+  `cognitive_complexity@^0.2.4`), use that exact version.

--- a/skills/dart-dedupe/SKILL.md
+++ b/skills/dart-dedupe/SKILL.md
@@ -158,6 +158,19 @@ Evaluate each candidate cluster before modifying code:
 - **DAMP Test Boilerplate:** Repetitive setup structures in table-driven unit
   tests.
 
+### Invariant: Exhaustive Cluster Adoption (Anti-Half-Measure Rule)
+
+When extracting a shared helper, mixin, or base class for an actionable duplicate
+cluster:
+- **Mandatory 100% Adoption**: You MUST apply the shared abstraction across
+  **ALL participating files** in that cluster in the same refactoring pass.
+- **No Timid Half-Measures**: Never refactor only 1 participating file while
+  leaving the remaining $N-1$ files with duplicate copy-paste logic.
+- **Subsystem Consolidation**: If multiple sibling classes (e.g. 5 reporter
+  classes) share multiple duplicate clusters (e.g. description formatting, error
+  handling, stream subscriptions), design a comprehensive shared base class or
+  mixin (e.g. `ReporterBase`) that consolidates all shared clusters at once.
+
 ---
 
 ## 4. The 2-Stage Triage & Confirmation Protocol
@@ -178,16 +191,19 @@ Output a ranked **Duplication Triage Report** containing:
    (`identical`, `structural`, `parameterized`, `gapped`).
 3. **Actionability Annotations**: Highlight recommended extraction strategy or
    mark as "Necessary Duplication (Preserve)".
+4. **Prioritization**: Rank by highest token volume and widest file footprint
+   first.
 
 ### Stage 2: Interactive User Confirmation Gate
 
 Pause execution and prompt the user (via interactive choice or chat) to select
 the desired remediation scope:
 
-1. **(Recommended) Refactor Top Actionable Cluster Only**: Target the single
-   highest-impact duplicate helper or decoder.
-2. **Refactor All Actionable Clusters in Scope**: Sequentially extract all
-   approved duplicate blocks.
+1. **(Recommended) Refactor Top Actionable Cluster Across All Files**:
+   Consolidate the highest-impact duplicate cluster and refactor 100% of the
+   participating files in that cluster.
+2. **Subsystem Base Refactor**: Consolidate multiple related duplicate clusters
+   across sibling classes into a unified shared base/mixin.
 3. **Report-Only / Exit**: Acknowledge findings without code mutations.
 
 ---

--- a/skills/dart-dedupe/SKILL.md
+++ b/skills/dart-dedupe/SKILL.md
@@ -155,21 +155,27 @@ Evaluate each candidate cluster before modifying code:
 - **Speculative wrapping of standalone entry points:** Abstracting trivial
   4-to-6 line `try/catch` fallback formatting across unrelated standalone CLI
   entry points (`bin/<script>.dart`).
+- **Code generator template strings:** Repetitive structural patterns in
+  multiline source code generation templates (e.g. `build_runner` code
+  emitters).
 - **DAMP Test Boilerplate:** Repetitive setup structures in table-driven unit
   tests.
 
-### Invariant: Exhaustive Cluster Adoption (Anti-Half-Measure Rule)
+### Invariant: Exhaustive Cluster Adoption
 
 When extracting a shared helper, mixin, or base class for an actionable duplicate
 cluster:
-- **Mandatory 100% Adoption**: You MUST apply the shared abstraction across
-  **ALL participating files** in that cluster in the same refactoring pass.
-- **No Timid Half-Measures**: Never refactor only 1 participating file while
-  leaving the remaining $N-1$ files with duplicate copy-paste logic.
-- **Subsystem Consolidation**: If multiple sibling classes (e.g. 5 reporter
-  classes) share multiple duplicate clusters (e.g. description formatting, error
-  handling, stream subscriptions), design a comprehensive shared base class or
-  mixin (e.g. `ReporterBase`) that consolidates all shared clusters at once.
+- **Mandatory Full-Cluster Scope**: Within a target package or subsystem, you
+  MUST apply the shared abstraction across **ALL participating files** in that
+  cluster in the same refactoring pass. Do not refactor only 1 file while leaving
+  the remaining N - 1 files with duplicate logic.
+- **Subsystem Consolidation**: If multiple sibling classes share multiple
+  duplicate clusters (e.g. description formatting, error handling, or stream
+  lifecycle), design a unified shared base class or mixin consolidating all
+  shared clusters at once.
+- **Encapsulation & Directory Placement**: Place extracted internal shared
+  abstractions under `lib/src/` (e.g. `lib/src/shared/` or `lib/src/common/`).
+  Never place internal helpers directly in the public `lib/` root.
 
 ---
 
@@ -180,7 +186,7 @@ strict 2-stage workflow:
 
 ### Stage 1: Read-Only Audit & Reporting (Mandatory Stop)
 
-Run `dart run dedupe --format=markdown` (or `--format=json`).
+Run `dart run dedupe@^0.1.0 --format=markdown` (or `--format=json`).
 
 Output a ranked **Duplication Triage Report** containing:
 
@@ -206,31 +212,33 @@ the desired remediation scope:
    across sibling classes into a unified shared base/mixin.
 3. **Report-Only / Exit**: Acknowledge findings without code mutations.
 
+> **Explicit Bypass & Headless Fallback**:
+> - **Direct Directives**: Skip Stage 1 pause if given explicit remediation
+>   instructions (e.g., "Deduplicate clusters in `pkgs/foo` using `dart-dedupe`").
+> - **Autonomous Sessions**: In non-interactive contexts (e.g. `evalin` or
+>   subagents), proceed with Option 1 (Refactor Top Actionable Cluster Across
+>   All Files) automatically after verifying baseline tests pass.
+
 ---
 
 ## 5. Pre & Post Refactor Verification Protocol
 
 Wrap all deduplication refactoring in a strict verification sandwich:
 
-```mermaid
-graph TD
-    A[Step 1: Baseline Verification<br>dart test] -->|Pass| B[Step 2: Run Dedupe Scan<br>dart run dedupe]
-    B --> C[Step 3: Triage & Confirmation Gate<br>User Selects Target Clusters]
-    C --> D[Step 4: Surgical Refactoring<br>Extract Shared Helper / Module]
-    D --> E[Step 5: Post-Refactor Health<br>dart analyze && dart test]
-    E -->|Pass| F[Step 6: Confirm Zero Clones<br>Re-run dedupe]
-    F --> G[Step 7: Stage Verified Diffs]
-    E -->|Fail| H[Step 8: Rollback / Fix Regressions]
-```
-
-1. **Verify Baseline:** Run `dart test` prior to modification. Ensure 100% pass.
-2. **Surgical Modification:** Extract shared functions or helper classes
-   cleanly.
-3. **Verify Post-Refactor Health:** Run `dart analyze --fatal-infos` and
-   `dart test`.
-4. **Zero-Clone Confirmation:** Re-run `dart run dedupe` to confirm the target
-   cluster was eliminated.
-5. **Local Staging:** Stage verified diffs locally (`git add .`).
+1. **Pre-Flight Baseline**: 
+   - Check `pubspec.yaml`: if `sdk: flutter` is declared, run `flutter test`;
+     otherwise run `dart test`.
+   - Confirm test suite is 100% green before touching code.
+2. **Surgical Modification**: Extract shared functions or helper classes under
+   `lib/src/` cleanly.
+3. **Verify Post-Refactor Health**:
+   - Run `flutter analyze` or `dart analyze --fatal-infos`.
+   - Run `flutter test` or `dart test`.
+   - **Monorepo Downstream Gate**: In multi-package workspaces, run tests across
+     all dependent packages.
+4. **Zero-Clone Confirmation**: Re-run `dart run dedupe@^0.1.0` to confirm the
+   target cluster was eliminated.
+5. **Local Staging**: Stage verified diffs locally (`git add .`).
 
 ---
 

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -107,7 +107,7 @@ Controls how code in `example/` is treated during reachability analysis:
 - `skip`: Ignores `example/` completely during analysis.
 
 ```bash
-dart run undead@ --example-mode=demonstration
+dart run undead@^0.1.1 --example-mode=demonstration
 ```
 
 ### Common CLI Options Reference
@@ -166,10 +166,10 @@ To suppress intentional dead code or API placeholders without deleting:
 
 - **Declaration Level**: `// undead:ignore` (placed directly above declaration).
 - **File Level**: `// undead:ignore_for_file` (placed at top of file).
-- _(Note: Never use `// ignore: ...` as the Dart analyzer treats unknown lint
-  codes as errors)._
+- _(Note: The standard `// ignore: unreachable_from_main` is strictly for the
+  built-in Dart analyzer lint rule; `pkg:undead` requires `// undead:ignore`)._
 
-### Invariant 5: Dynamic Invocation & Non-AST Reference Check ("Understand the Match")
+### Invariant 5: Dynamic Invocation & Non-AST Reference Check
 
 Static AST analysis (`pkg:undead`) only traces typed Dart import trees. It
 cannot see declarations referenced through runtime meta-programming:
@@ -191,21 +191,21 @@ cannot see declarations referenced through runtime meta-programming:
 
 ### Invariant 6: Monorepo & External Entrypoint Protection
 
-In monorepos with multiple inter-dependent packages (e.g. `pkgs/test` wrapping
-`pkgs/test_core`), some declarations in `lib/src/` (such as `runTests` in
-`executable.dart`) serve as execution entrypoints invoked by sibling packages or
-top-level executables.
-- Check if the target package is consumed by parent/sibling packages in the
-  workspace before deleting top-level `lib/src/` functions.
+In multi-package workspaces where internal implementation libraries export
+entrypoints consumed by sibling CLI wrappers or test runners:
+- Include sibling packages and root integration test folders using
+  `--extra-roots` or enable `--workspace-discovery`.
 - If an unexported function is an intended external entrypoint, protect it with
-  `// ignore: unreachable_from_main` or `// undead:ignore`.
+  `// undead:ignore` (and `// ignore: unreachable_from_main` if analyzer lint is
+  active).
 
-### Invariant 7: Holistic Pruning Mandate (No Trivial-Only Edits)
+### Invariant 7: Cohesive Subsystem Pruning
 
-When pruning dead code, do not settle for trivial bookkeeping (like deleting a
-few unused exit codes while leaving entire unreferenced subsystems intact).
-- Delete all verified pure dead classes, functions, and files in `lib/src/`
-  (e.g., dead listeners, obsolete runner scaffolds) in one cohesive pass.
+When pruning dead code, avoid partial or purely cosmetic deletions that leave
+larger unreferenced subsystems intact:
+- Delete all verified unreferenced internal classes, functions, and files in
+  `lib/src/` (e.g., unreferenced listener classes, unused event sinks, obsolete
+  scaffold runners) in one cohesive pass.
 - Remove orphaned imports, associated dead private helpers, and obsolete test
   fixtures concurrently.
 
@@ -218,7 +218,7 @@ follow this strict 2-stage workflow:
 
 ### Stage 1: Read-Only Audit & Reporting (Mandatory Stop)
 
-Run `dart run undead@ --format=markdown` (or `--format=json`).
+Run `dart run undead@^0.1.1 --format=markdown` (or `--format=json`).
 
 Output a ranked **Dead Code Triage Report** containing:
 
@@ -243,33 +243,36 @@ the desired remediation scope:
    placeholders.
 4. **Report-Only / Exit**: Acknowledge findings without code mutations.
 
+> **Explicit Bypass & Headless Fallback**:
+> - **Direct Directives**: Skip Stage 1 pause if given explicit remediation
+>   instructions (e.g., "Prune dead code in `pkgs/foo` using `dart-undead`").
+> - **Autonomous Sessions**: In non-interactive contexts (e.g. `evalin` or
+>   subagents), proceed with Option 1 (Prune All Verified Dead Subsystems)
+>   automatically after verifying baseline tests pass.
+
 ---
 
 ## 5. Pre & Post Deletion Verification Protocol
 
 Always wrap code deletions in a strict test and analysis sandwich:
 
-```mermaid
-graph TD
-    A[Step 1: Baseline Verification<br>dart test] -->|Pass| B[Step 2: Run Undead Scan<br>dart run undead@]
-    B --> C[Step 3: Triage & Confirmation Gate<br>User Selects Targets]
-    C --> D[Step 4: Surgical Pruning<br>Remove Dead AST Nodes]
-    D --> E[Step 5: Post-Pruning Verification<br>dart analyze && dart test]
-    E -->|Pass| F[Step 6: Stage Clean Diffs]
-    E -->|Fail| G[Step 7: Rollback / Fix Hazard]
-```
-
-1. **Pre-Flight Baseline**: Execute `dart test` to confirm the test suite is
-   100% green before touching any code.
+1. **Pre-Flight Baseline**: 
+   - Check `pubspec.yaml`: if `sdk: flutter` is declared, run `flutter test`;
+     otherwise run `dart test`.
+   - Confirm test suite is 100% green before touching code.
 2. **Surgical Deletion**: Remove the flagged declaration and any orphaned
    imports associated with it.
 3. **Post-Flight Verification**:
-   - Run `dart analyze` to ensure zero compilation or unresolved reference
-     errors.
-   - Run `dart test` to confirm all remaining tests pass.
-4. **Clean Diff Staging**: Inspect modifications using `git diff --stat` (or
-   isolate in a temporary feature branch/worktree) to ensure only intended
-   declarations were removed.
+   - Run `flutter analyze` or `dart analyze` to ensure zero compilation or
+     unresolved reference errors.
+   - Run `flutter test` or `dart test` to confirm all remaining tests pass.
+   - **Monorepo Downstream Gate**: In multi-package repositories, run tests
+     across all dependent workspace packages and root integration tests before
+     staging.
+   - **Repository Policies**: If the repository enforces changelog tracking,
+     update `CHANGELOG.md` alongside the change.
+4. **Clean Diff Staging**: Inspect modifications using `git diff --stat` to
+   ensure only intended declarations were removed.
 
 ---
 
@@ -309,6 +312,6 @@ To reproduce or re-run this reachability audit locally:
 
 Determine the package version dynamically:
 
-- Check `pubspec.lock` in the workspace or run `dart run undead@ --version`.
-- If invoked with a specific version constraint (e.g. `undead@0.1.0`), use that
+- Check `pubspec.lock` in the workspace or run `dart run undead@^0.1.1 --version`.
+- If invoked with a specific version constraint (e.g. `undead@^0.1.1`), use that
   exact version.

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -169,6 +169,26 @@ To suppress intentional dead code or API placeholders without deleting:
 - _(Note: Never use `// ignore: ...` as the Dart analyzer treats unknown lint
   codes as errors)._
 
+### Invariant 5: Monorepo & External Entrypoint Protection
+
+In monorepos with multiple inter-dependent packages (e.g. `pkgs/test` wrapping
+`pkgs/test_core`), some declarations in `lib/src/` (such as `runTests` in
+`executable.dart`) serve as execution entrypoints invoked by sibling packages or
+top-level executables.
+- Check if the target package is consumed by parent/sibling packages in the
+  workspace before deleting top-level `lib/src/` functions.
+- If an unexported function is an intended external entrypoint, protect it with
+  `// ignore: unreachable_from_main` or `// undead:ignore`.
+
+### Invariant 6: Holistic Pruning Mandate (No Trivial-Only Edits)
+
+When pruning dead code, do not settle for trivial bookkeeping (like deleting a
+few unused exit codes while leaving entire unreferenced subsystems intact).
+- Delete all verified pure dead classes, functions, and files in `lib/src/`
+  (e.g., dead listeners, obsolete runner scaffolds) in one cohesive pass.
+- Remove orphaned imports, associated dead private helpers, and obsolete test
+  fixtures concurrently.
+
 ---
 
 ## 4. The 2-Stage Triage & Confirmation Protocol
@@ -194,8 +214,9 @@ Output a ranked **Dead Code Triage Report** containing:
 Pause execution and prompt the user (via interactive choice or chat) to select
 the desired remediation scope:
 
-1. **(Recommended) Prune Internal Dead Code Only**: Delete unreferenced
-   declarations in `lib/src/**` and isolated test files.
+1. **(Recommended) Prune All Verified Dead Subsystems & Files**: Concurrently
+   delete all unreferenced internal classes, functions, and files in
+   `lib/src/**` and isolated dead test files.
 2. **Prune Application Entrypoints**: Target dead features in a closed app
    (`--mode=closed-app`).
 3. **Suppress Findings**: Add `// undead:ignore` comments to intentional

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -169,7 +169,27 @@ To suppress intentional dead code or API placeholders without deleting:
 - _(Note: Never use `// ignore: ...` as the Dart analyzer treats unknown lint
   codes as errors)._
 
-### Invariant 5: Monorepo & External Entrypoint Protection
+### Invariant 5: Dynamic Invocation & Non-AST Reference Check ("Understand the Match")
+
+Static AST analysis (`pkg:undead`) only traces typed Dart import trees. It
+cannot see declarations referenced through runtime meta-programming:
+- Dynamic isolate spawners (`dart.runInIsolate`, `Isolate.spawnUri`)
+- Code-generation string templates (`'''import "package:.../foo.dart";'''`)
+- JS / WASM compilation targets and runtime asset bootstrap runners
+- Build hooks and `build.yaml` references
+
+**The Pre-Deletion Check Protocol:**
+1. Before deleting any candidate file or top-level declaration in `lib/src/`,
+   perform a literal string search (`grep_search "<filename_or_symbol>"`) across
+   the repository.
+2. If text matches exist outside the target file itself, **inspect and understand
+   the match context** before deleting:
+   - **KEEP**: The match is an active runtime string template, dynamic isolate
+     entrypoint, or compilation target. Protect it with `// undead:ignore`.
+   - **PRUNE**: The match is merely a doc comment, obsolete README reference, or
+     dead test fixture that should be deleted alongside the target.
+
+### Invariant 6: Monorepo & External Entrypoint Protection
 
 In monorepos with multiple inter-dependent packages (e.g. `pkgs/test` wrapping
 `pkgs/test_core`), some declarations in `lib/src/` (such as `runTests` in
@@ -180,7 +200,7 @@ top-level executables.
 - If an unexported function is an intended external entrypoint, protect it with
   `// ignore: unreachable_from_main` or `// undead:ignore`.
 
-### Invariant 6: Holistic Pruning Mandate (No Trivial-Only Edits)
+### Invariant 7: Holistic Pruning Mandate (No Trivial-Only Edits)
 
 When pruning dead code, do not settle for trivial bookkeeping (like deleting a
 few unused exit codes while leaving entire unreferenced subsystems intact).


### PR DESCRIPTION
## Summary

Hardens the triage and execution protocols in `dart-undead`, `dart-dedupe`, and `dart-cognitive-complexity` skills to eliminate agent timidity and enforce bold, high-impact architectural refactoring:

* **`dart-undead`**:
  * Added **Invariant 5 (Monorepo & External Entrypoint Protection)**: Check for parent/sibling package consumers in monorepos before pruning `lib/src/` top-level functions.
  * Added **Invariant 6 (Holistic Pruning Mandate)**: Forbids trivial-only edits (e.g. deleting a few exit codes while leaving dead listener/execution subsystems intact).
* **`dart-dedupe`**:
  * Added **Invariant (Exhaustive Cluster Adoption / Anti-Half-Measure Rule)**: When extracting a shared helper/base/mixin for a duplicate cluster, 100% of participating files in that cluster must adopt the shared abstraction in the same PR.
  * Added **High-Impact Prioritization**: Rank clusters by highest token count and widest file footprint.
* **`dart-cognitive-complexity`**:
  * Added **Invariant (Outlier-First Mandate / Tackle the Monster)**: Requires targeting the #1 highest-scoring outlier (e.g. Score >= 25 or the top-ranked monster) rather than timid sub-threshold helpers.
  * Added **Aggressive Decomposition Target**: Explicit goal to bring top outliers down to `<= 15` using Dart 3 pattern matching, guard clauses, and method extraction.