### PR TITLE
fix(cognitive_complexity): remove noisy workflow warning annotations

### DIFF
--- a/packages/cognitive_complexity/CHANGELOG.md
+++ b/packages/cognitive_complexity/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Support `--exclude` and `--[no-]ignore-generated` CLI options to configure
   file exclusion and generated code filtering via `PathFilter`.
 - Add `pathFilter` parameter to `ComplexityAnalyzer` and `DeltaAnalyzer`.
+- Remove noisy GitHub workflow `::warning` annotations on non-violating
+  complexity increases, keeping inline annotations reserved for violations (`::error`)
+  while full deltas remain tracked in step summaries and PR comment tables.
 - Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in
   `README.md`.
 - Update GitHub Action documentation in `README.md` to reference modular

--- a/packages/cognitive_complexity/lib/src/complexity/github_reporter.dart
+++ b/packages/cognitive_complexity/lib/src/complexity/github_reporter.dart
@@ -136,7 +136,7 @@ class GitHubReporter {
 
     // Annotations are emitted once for every changed declaration, independent
     // of how many rows each table renders. Capping the comment must not hide
-    // an inline warning from the Files-changed view.
+    // an inline error from the Files-changed view.
     for (final d in changed) {
       _emitDiagnostic(d, failThreshold, failOnIncrease);
     }
@@ -256,13 +256,6 @@ class GitHubReporter {
         '::error file=${d.filePath},line=${d.startLine},'
         'title=Cognitive Complexity Violation::'
         '${d.name} was $reason to score ${d.newScore}.',
-      );
-    } else if (d.status == DeltaStatus.increased) {
-      _stdoutSink.writeln(
-        '::warning file=${d.filePath},line=${d.startLine},'
-        'title=Cognitive Complexity Increased '
-        '(+${d.delta})::${d.name} increased from ${d.oldScore} to '
-        '${d.newScore} (+${d.delta} points).',
       );
     }
   }

--- a/packages/cognitive_complexity/test/comment_output_test.dart
+++ b/packages/cognitive_complexity/test/comment_output_test.dart
@@ -165,8 +165,7 @@ void main() {
       check(comment).not((c) => c.contains('most significant of'));
     });
 
-    test('annotates every changed declaration regardless of the '
-        'cap', () async {
+    test('annotates violations regardless of the cap', () async {
       final out = await runScanner([
         '--comment-output=$commentPath',
         '--max-comment-rows=1',
@@ -174,7 +173,7 @@ void main() {
 
       // Capping the comment must not hide inline Files-changed annotations.
       check('::error'.allMatches(out).length).equals(3);
-      check('::warning'.allMatches(out).length).equals(3);
+      check('::warning'.allMatches(out).length).equals(0);
     });
 
     test('writes no comment file when --comment-output is omitted', () async {

--- a/packages/cognitive_complexity/test/delta_analyzer_test.dart
+++ b/packages/cognitive_complexity/test/delta_analyzer_test.dart
@@ -115,34 +115,34 @@ void main() {
   });
 
   group('GitHubReporter Annotation Emissions', () {
-    test('Emits workflow warning annotations for increased complexity', () {
-      final outBuf = StringBuffer();
-      final reporter = GitHubReporter(stdoutSink: outBuf);
+    test(
+      'Does not emit workflow warning annotations for non-violating increases',
+      () {
+        final outBuf = StringBuffer();
+        final reporter = GitHubReporter(stdoutSink: outBuf);
 
-      const delta = ComplexityDelta(
-        filePath: 'lib/service.dart',
-        name: 'Service.execute',
-        startLine: 12,
-        endLine: 40,
-        oldScore: 5,
-        newScore: 10,
-        status: DeltaStatus.increased,
-      );
+        const delta = ComplexityDelta(
+          filePath: 'lib/service.dart',
+          name: 'Service.execute',
+          startLine: 12,
+          endLine: 40,
+          oldScore: 5,
+          newScore: 10,
+          status: DeltaStatus.increased,
+        );
 
-      const summary = DeltaSummary(
-        baseRef: 'main',
-        targetRef: 'HEAD',
-        filesAnalyzed: 1,
-        deltas: [delta],
-      );
+        const summary = DeltaSummary(
+          baseRef: 'main',
+          targetRef: 'HEAD',
+          filesAnalyzed: 1,
+          deltas: [delta],
+        );
 
-      reporter.printReport(deltaSummary: summary);
-      check(outBuf.toString()).contains(
-        '::warning file=lib/service.dart,line=12,'
-        'title=Cognitive Complexity Increased (+5)::Service.execute '
-        'increased from 5 to 10 (+5 points).',
-      );
-    });
+        reporter.printReport(deltaSummary: summary, failThreshold: 15);
+        check(outBuf.toString()).not((s) => s.contains('::warning'));
+        check(outBuf.toString()).not((s) => s.contains('::error'));
+      },
+    );
 
     test('Emits workflow error annotations when failure thresholds breach', () {
       final outBuf = StringBuffer();


### PR DESCRIPTION
Unconditional ::warning annotations on all DeltaStatus.increased
declarations produce distracting PR diff warnings for trivial complexity
growth (such as 0 -> 1 when adding an if check).

- Remove workflow ::warning annotation emission from GitHubReporter
- Reserve workflow annotations exclusively for threshold violations (::error)
- Retain granular delta tracking in GitHub step summaries and sticky comment tables
- Update delta analyzer and comment output test suites
