### PR TITLE
docs(skills): reframe provenance reporting and user confirmation gates

### DIFF
--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -13,7 +13,7 @@ key_features:
   - Scoped execution matrix (targeted / delta / full)
   - Interactive refactoring triage
   - Dart 3 pattern matching refactorings
-  - Reproducible PR provenance injection
+  - Reproducible PR provenance reporting
 ---
 
 ## 1. When to Use This Skill
@@ -149,13 +149,12 @@ the desired sequencing:
    in descending order.
 3. **Report-Only / Exit**: Acknowledge complexity scores without code mutation.
 
-> **Explicit Bypass & Headless Fallback**:
+> **Explicit Bypass & Direct Directives**:
 > - **Direct Directives**: Skip Stage 1 triage if given an explicit remediation
 >   directive upfront (e.g., "Refactor `processOrder` in `lib/src/order.dart` to
 >   fix complexity" or "Refactor the top complexity outlier").
-> - **Autonomous Sessions**: In non-interactive contexts (e.g. `evalin` or
->   subagents), proceed with Option 1 (Refactor Primary Outlier) automatically
->   after verifying baseline tests pass.
+> - **Automated Task Execution**: When explicitly directed to remediate, proceed
+>   with Option 1 (Refactor Primary Outlier) after verifying baseline tests pass.
 
 ---
 
@@ -178,7 +177,7 @@ this verification baseline:
    flagged function is inadequate:
    - **Interactive Sessions**: Pause execution and warn the user. Offer options
      to (1) write unit tests first, or (2) proceed with surgical refactoring.
-   - **Autonomous / Headless Sessions**: Log a low-coverage warning and author a
+   - **Automated Task Execution**: Log a low-coverage warning and author a
      minimal regression test before modifying complex logic.
    2. Proceed with structural refactoring and verify functionality manually.
 
@@ -429,22 +428,22 @@ Run these verification commands before committing refactored code:
 
 When staging refactored code and preparing a commit message or Pull Request:
 
-### 1. User Confirmation Gate & Headless Defaults
+### 1. User Confirmation Gate
 
 - **Interactive Sessions**: Before writing the PR description or commit body,
   explicitly prompt the user in chat or via the harness confirmation tool (e.g.
   `ask_question`) whether to include a **Tool Provenance & Complexity Delta
   block**.
-- **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
-  subagents, automated eval suites like `evalin`, or headless CI), default to
-  including the block automatically without blocking on user confirmation.
+- **User Prompt Inclusion**: When the user explicitly requests inclusion (or
+  confirms via prompt), append the standardized markdown block below. In
+  unattended or automated workflows, output the summary to chat or step
+  summaries rather than modifying commit bodies without user confirmation.
 
 ### 2. Standardized Provenance Block Format
 
-When confirmed (or running headlessly), append the following markdown block to
-the PR description or commit body so reviewers understand where the changes
-originated, see the quantified readability improvements, and can rerun the audit
-locally:
+When confirmed by the user, include the following markdown block in the PR
+description or commit body so reviewers understand where the changes originated,
+see the quantified readability improvements, and can rerun the audit locally:
 
 ````markdown
 ### 🤖 Tool Provenance & Complexity Delta

--- a/skills/dart-dedupe/SKILL.md
+++ b/skills/dart-dedupe/SKILL.md
@@ -14,7 +14,7 @@ key_features:
   - PR/CL Git diff delta scanning (--git-diff / --only-changed)
   - Actionable vs Necessary architectural verification gates
   - Empirical baseline and post-refactor test suite validation
-  - Reproducible PR provenance injection
+  - Reproducible PR provenance reporting
 ---
 
 # Dart Dedupe (`dart-dedupe`)
@@ -212,12 +212,12 @@ the desired remediation scope:
    across sibling classes into a unified shared base/mixin.
 3. **Report-Only / Exit**: Acknowledge findings without code mutations.
 
-> **Explicit Bypass & Headless Fallback**:
+> **Explicit Bypass & Direct Directives**:
 > - **Direct Directives**: Skip Stage 1 pause if given explicit remediation
 >   instructions (e.g., "Deduplicate clusters in `pkgs/foo` using `dart-dedupe`").
-> - **Autonomous Sessions**: In non-interactive contexts (e.g. `evalin` or
->   subagents), proceed with Option 1 (Refactor Top Actionable Cluster Across
->   All Files) automatically after verifying baseline tests pass.
+> - **Automated Task Execution**: When explicitly directed to remediate, proceed
+>   with Option 1 (Refactor Top Actionable Cluster Across All Files) after
+>   verifying baseline tests pass.
 
 ---
 
@@ -246,19 +246,20 @@ Wrap all deduplication refactoring in a strict verification sandwich:
 
 When staging deduplicated code and preparing a commit message or Pull Request:
 
-### 1. User Confirmation Gate & Headless Defaults
+### 1. User Confirmation Gate
 
 - **Interactive Sessions**: Before writing the PR description or commit body,
   explicitly prompt the user in chat or via the harness confirmation tool (e.g.
   `ask_question`) whether to include a **Tool Provenance & Reproduction block**.
-- **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
-  subagents, automated eval suites like `evalin`, or headless CI), default to
-  including the block automatically without blocking on user confirmation.
+- **User Prompt Inclusion**: When the user explicitly requests inclusion (or
+  confirms via prompt), append the standardized markdown block below. In
+  unattended or automated workflows, output the summary to chat or step
+  summaries rather than modifying commit bodies without user confirmation.
 
 ### 2. Standardized Provenance Block Format
 
-When confirmed (or running headlessly), append the following markdown block to
-the PR description or commit body:
+When confirmed by the user, include the following markdown block in the PR
+description or commit body:
 
 ````markdown
 ### 🤖 Tool Provenance & Reproduction

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -14,7 +14,7 @@ key_features:
   - Co-invoked test hazard detection
   - Sealed class & framework entrypoint protection
   - Safe 2-stage triage & deletion protocol
-  - Reproducible PR provenance injection
+  - Reproducible PR provenance reporting
 ---
 
 # Dart Undead (`dart-undead`)
@@ -243,12 +243,12 @@ the desired remediation scope:
    placeholders.
 4. **Report-Only / Exit**: Acknowledge findings without code mutations.
 
-> **Explicit Bypass & Headless Fallback**:
+> **Explicit Bypass & Direct Directives**:
 > - **Direct Directives**: Skip Stage 1 pause if given explicit remediation
 >   instructions (e.g., "Prune dead code in `pkgs/foo` using `dart-undead`").
-> - **Autonomous Sessions**: In non-interactive contexts (e.g. `evalin` or
->   subagents), proceed with Option 1 (Prune All Verified Dead Subsystems)
->   automatically after verifying baseline tests pass.
+> - **Automated Task Execution**: When explicitly directed to remediate, proceed
+>   with Option 1 (Prune All Verified Dead Subsystems) after verifying baseline
+>   tests pass.
 
 ---
 
@@ -280,19 +280,20 @@ Always wrap code deletions in a strict test and analysis sandwich:
 
 When staging pruned code and preparing a commit message or Pull Request:
 
-### 1. User Confirmation Gate & Headless Defaults
+### 1. User Confirmation Gate
 
 - **Interactive Sessions**: Before writing the PR description or commit body,
   explicitly prompt the user in chat or via the harness confirmation tool (e.g.
   `ask_question`) whether to include a **Tool Provenance & Reproduction block**.
-- **Headless / Autonomous Fallback**: In non-interactive contexts (e.g.
-  subagents, automated eval suites like `evalin`, or headless CI), default to
-  including the block automatically without blocking on user confirmation.
+- **User Prompt Inclusion**: When the user explicitly requests inclusion (or
+  confirms via prompt), append the standardized markdown block below. In
+  unattended or automated workflows, output the summary to chat or step
+  summaries rather than modifying commit bodies without user confirmation.
 
 ### 2. Standardized Provenance Block Format
 
-When confirmed (or running headlessly), append the following markdown block to
-the PR description or commit body so reviewers understand where the deletions
+When confirmed by the user, include the following markdown block in the PR
+description or commit body so reviewers understand where the deletions
 originated and can rerun the reachability analysis locally:
 
 ````markdown


### PR DESCRIPTION
- Harmonize terminology across dart-cognitive-complexity, dart-dedupe, and dart-undead skills.
- Replace 'provenance injection' phrasing with 'provenance reporting' to avoid prompt-injection false positives.
- Reframe Section Provenance Protocol to require explicit user confirmation or prompt inclusion instead of automated/headless commit mutations.
- Update Stage 2 bypass and test gates to use explicit direct directives and automated task execution framing.
