### PR TITLE
docs(skills): fix list syntax, duplicate headers, and non-interactive fallbacks

### DIFF
--- a/skills/dart-cognitive-complexity/SKILL.md
+++ b/skills/dart-cognitive-complexity/SKILL.md
@@ -149,12 +149,13 @@ the desired sequencing:
    in descending order.
 3. **Report-Only / Exit**: Acknowledge complexity scores without code mutation.
 
-> **Explicit Bypass & Direct Directives**:
+> **Explicit Bypass & Non-Interactive Fallback**:
 > - **Direct Directives**: Skip Stage 1 triage if given an explicit remediation
 >   directive upfront (e.g., "Refactor `processOrder` in `lib/src/order.dart` to
 >   fix complexity" or "Refactor the top complexity outlier").
-> - **Automated Task Execution**: When explicitly directed to remediate, proceed
->   with Option 1 (Refactor Primary Outlier) after verifying baseline tests pass.
+> - **Non-Interactive Execution**: In unattended or automated evaluation
+>   workflows (e.g. `evalin` or subagents), proceed with Option 1 (Refactor
+>   Primary Outlier) automatically after verifying baseline tests pass.
 
 ---
 
@@ -179,7 +180,6 @@ this verification baseline:
      to (1) write unit tests first, or (2) proceed with surgical refactoring.
    - **Automated Task Execution**: Log a low-coverage warning and author a
      minimal regression test before modifying complex logic.
-   2. Proceed with structural refactoring and verify functionality manually.
 
 ---
 
@@ -275,8 +275,6 @@ Future<void> syncPayload(User? user, Payload? data) async {
 single-use runner classes with mutable instance variables just to bring scores
 below 15. Reducing the metric must never sacrifice transparent data flow or hide
 bugs.
-
-#### Deterministic Tier Selection via `data_flow`
 
 #### Deterministic 3-Tier Selection via `data_flow`
 

--- a/skills/dart-dedupe/SKILL.md
+++ b/skills/dart-dedupe/SKILL.md
@@ -212,12 +212,13 @@ the desired remediation scope:
    across sibling classes into a unified shared base/mixin.
 3. **Report-Only / Exit**: Acknowledge findings without code mutations.
 
-> **Explicit Bypass & Direct Directives**:
+> **Explicit Bypass & Non-Interactive Fallback**:
 > - **Direct Directives**: Skip Stage 1 pause if given explicit remediation
 >   instructions (e.g., "Deduplicate clusters in `pkgs/foo` using `dart-dedupe`").
-> - **Automated Task Execution**: When explicitly directed to remediate, proceed
->   with Option 1 (Refactor Top Actionable Cluster Across All Files) after
->   verifying baseline tests pass.
+> - **Non-Interactive Execution**: In unattended or automated evaluation
+>   workflows (e.g. `evalin` or subagents), proceed with Option 1 (Refactor
+>   Top Actionable Cluster Across All Files) automatically after verifying
+>   baseline tests pass.
 
 ---
 
@@ -278,4 +279,7 @@ To reproduce or re-run this duplication scan locally:
 
 Determine the package version dynamically:
 
-- Check `pubspec.lock` in the workspace or run `dart run dedupe --version`.
+- Check `pubspec.lock` in the workspace or run
+  `dart run dedupe@^0.1.0 --version`.
+- If invoked with a specific version constraint (e.g. `dedupe@^0.1.0`), use that
+  exact version.

--- a/skills/dart-undead/SKILL.md
+++ b/skills/dart-undead/SKILL.md
@@ -112,6 +112,8 @@ dart run undead@^0.1.1 --example-mode=demonstration
 
 ### Common CLI Options Reference
 
+<!-- mdformat off(prevent table wrapping) -->
+
 | Option / Flag                     | Purpose                                                           | Default         |
 | :-------------------------------- | :---------------------------------------------------------------- | :-------------- |
 | `-m, --mode`                      | Analysis mode (`library` or `closed-app`).                        | `library`       |
@@ -126,6 +128,8 @@ dart run undead@^0.1.1 --example-mode=demonstration
 | `--[no-]suggest-private`          | Identify top-level declarations that can be made library-private. | `false`         |
 | `--pub-get`                       | Auto-run `dart pub get` / `flutter pub get` if needed.            | `false`         |
 | `--fail-on-undead`                | Exit with non-zero code (1) on findings (useful for CI).          | `false`         |
+
+<!-- mdformat on -->
 
 ---
 
@@ -243,12 +247,13 @@ the desired remediation scope:
    placeholders.
 4. **Report-Only / Exit**: Acknowledge findings without code mutations.
 
-> **Explicit Bypass & Direct Directives**:
+> **Explicit Bypass & Non-Interactive Fallback**:
 > - **Direct Directives**: Skip Stage 1 pause if given explicit remediation
 >   instructions (e.g., "Prune dead code in `pkgs/foo` using `dart-undead`").
-> - **Automated Task Execution**: When explicitly directed to remediate, proceed
->   with Option 1 (Prune All Verified Dead Subsystems) after verifying baseline
->   tests pass.
+> - **Non-Interactive Execution**: In unattended or automated evaluation
+>   workflows (e.g. `evalin` or subagents), proceed with Option 1 (Prune All
+>   Verified Dead Subsystems) automatically after verifying baseline tests
+>   pass.
 
 ---
 


### PR DESCRIPTION
- Harmonize Stage 2 Non-Interactive Fallback across dart-cognitive-complexity, dart-dedupe, and dart-undead skills.
- Remove orphaned broken list item in dart-cognitive-complexity Section 5.
- Remove duplicate Pattern C subheading in dart-cognitive-complexity Section 6.
- Add mdformat protection block around CLI options table in dart-undead.
- Align version resolution CLI invocation and version constraint bullet in dart-dedupe.
