### PR TITLE
feat(analytica): power PathFilter with package:glob

### DIFF
--- a/packages/analytica/CHANGELOG.md
+++ b/packages/analytica/CHANGELOG.md
@@ -6,6 +6,14 @@
 - **Breaking:** `[`, `]`, `{` and `}` in an exclusion pattern are now glob
   metacharacters rather than literal characters. Escape them with
   `Glob.quote` to match them literally.
+- **Breaking:** a backslash in an exclusion *pattern* is now a glob escape
+  rather than a path separator, so patterns use `/` on every platform.
+  Candidate paths passed to `PathFilter.isExcluded` are still normalized from
+  Windows separators.
+- Add `splitGlobPatterns`, which splits a comma-separated pattern list without
+  breaking commas inside a brace group or character class. `parsePathFilter`
+  uses it, and `addPathFilterOptions` sets `splitCommas: false` so the two do
+  not fight.
 - **Breaking:** a malformed exclusion pattern now throws a `FormatException`
   naming the pattern, where it previously matched nothing silently.
 - Match paths that escape the scanned tree (a leading `../`, as produced by

--- a/packages/analytica/CHANGELOG.md
+++ b/packages/analytica/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## 0.1.2-wip
 
+- Power `PathFilter` with `package:glob`, so exclusion patterns support the
+  full glob syntax including brace expansion (`**/*.{g,freezed}.dart`) and
+  character classes (`**/*_[0-9].dart`).
+- **Breaking:** `[`, `]`, `{` and `}` in an exclusion pattern are now glob
+  metacharacters rather than literal characters. Escape them with
+  `Glob.quote` to match them literally.
+- **Breaking:** a malformed exclusion pattern now throws a `FormatException`
+  naming the pattern, where it previously matched nothing silently.
+- Match paths that escape the scanned tree (a leading `../`, as produced by
+  `undead --extra-roots`) on their in-tree remainder, so a root-anchored
+  pattern now applies to them.
+- Pin exclusion matching to POSIX separators and case sensitivity on every
+  platform.
 - Add `PathFilter` in `package:analytica/analyzer.dart` for centralized path
   exclusion matching and generated Dart code filtering.
 - Add `addPathFilterOptions` and `parsePathFilter` CLI utilities in

--- a/packages/analytica/doc/path_filter.md
+++ b/packages/analytica/doc/path_filter.md
@@ -1,0 +1,218 @@
+# PathFilter design
+
+Reference for `PathFilter` after the move to `package:glob`. Covers the public
+API surface, the two transformation pipelines, and where a bad pattern becomes
+visible.
+
+> [!NOTE]
+> Exclusion is **not opt-in**. `PathFilter.defaults` compiles 15 patterns —
+> 5 ignored directories plus 10 generated-file patterns — and applies them to
+> every scanned file before any `--exclude` is supplied. A regression here
+> changes the output of `cognitive_complexity`, `dedupe` and `undead` at once.
+
+## API surface
+
+<!-- mdformat off(prevent table wrapping) -->
+
+| Symbol | Kind | Exported from | Status |
+| :--- | :--- | :--- | :--- |
+| `PathFilter` | class | `analyzer.dart`, `analytica.dart`, `cli.dart` | Behaviour changed |
+| `PathFilter.defaultIgnoredDirectories` | `static const List<String>` | as above | **Unchanged** |
+| `PathFilter.defaultGeneratedPatterns` | `static const List<String>` | as above | **Unchanged** |
+| `PathFilter.defaults` | `static final PathFilter` | as above | Unchanged |
+| `PathFilter({excludePatterns, ignoreGenerated})` | constructor | as above | Now throws `FormatException` |
+| `PathFilter.isExcluded(String)` | method | as above | Signature unchanged |
+| `splitGlobPatterns(String)` | top-level function | `cli.dart`, `analytica.dart` | **New** |
+| `parsePathFilter(ArgResults, {defaultExcludes})` | top-level function | as above | Splitting changed |
+| `addPathFilterOptions()` | `ArgParser` extension | as above | `splitCommas: false` |
+| `WildcardPattern` | class | `analyzer.dart` | **Untouched** |
+
+<!-- mdformat on -->
+
+`WildcardPattern` is deliberately left alone. It has three consumers that are
+not `PathFilter`, one of which does not match paths at all:
+
+```mermaid
+flowchart LR
+  WP["WildcardPattern<br/>(unchanged)"]
+  UD["undead<br/>reachability_engine.dart"]
+  WD["undead<br/>workspace_discovery.dart"]
+  DD["dedupe<br/>engine.dart"]
+  PF["PathFilter<br/>(now package:glob)"]
+
+  WP --> UD
+  WP --> WD
+  WP --> DD
+  PF -.->|"no longer uses"| WP
+
+  UD --- UDN["declaration names<br/>Fake*, Mock*, *_generated"]
+  WD --- WDN["bare directory basenames"]
+  DD --- DDN["include patterns<br/>(PathFilter is excludes only)"]
+```
+
+`package:glob` is segment-oriented and is the wrong tool for matching Dart
+identifiers, and `glob_matcher_test.dart` deliberately pins regex
+metacharacters as literal. Both rule out changing `WildcardPattern` itself.
+
+## Pipeline 1 — compiling a pattern
+
+Runs once per pattern, eagerly, in the constructor.
+
+```mermaid
+flowchart TD
+  A["raw pattern"] --> B{"trim().isEmpty?"}
+  B -->|yes| SKIP["skip — inert,<br/>as before"]
+  B -->|no| C["_normalizePattern<br/>strip leading ./ and /<br/>slash-less becomes **/pat"]
+  C --> D["collapse repeated<br/>double-star segments"]
+  D --> E["prepend anchor &lt;root&gt;/"]
+  E --> F["relax boundaries<br/>/**/ becomes /{**/,}"]
+  F --> G{"Glob(context: p.posix)"}
+  G -->|ok| H["compiled Glob"]
+  G -->|throws| I["FormatException<br/>naming the pattern"]
+```
+
+Worked examples, taken from the running pipeline:
+
+<!-- mdformat off(prevent table wrapping) -->
+
+| Raw | After normalize | After collapse | Compiled |
+| :--- | :--- | :--- | :--- |
+| `**/*.g.dart` | `**/*.g.dart` | `**/*.g.dart` | `<root>/{**/,}*.g.dart` |
+| `legacy_*.dart` | `**/legacy_*.dart` | `**/legacy_*.dart` | `<root>/{**/,}legacy_*.dart` |
+| `build/**` | `build/**` | `build/**` | `<root>/build/**` |
+| `lib/**/*.g.dart` | `lib/**/*.g.dart` | `lib/**/*.g.dart` | `<root>/lib/{**/,}*.g.dart` |
+| `**/**/x.dart` | `**/**/x.dart` | `**/x.dart` | `<root>/{**/,}x.dart` |
+| `/custom/**` | `custom/**` | `custom/**` | `<root>/custom/**` |
+
+<!-- mdformat on -->
+
+### Why the anchor exists
+
+`package:glob` has no way to say "zero or more leading directories", which is
+what the previous matcher's `(?:.*/)?` meant. Without it, `**/*.g.dart` stops
+matching a root-level `model.g.dart` — and that is a *default* pattern.
+
+The natural spelling is `{**/,}`. It parses, then throws when matched:
+
+```
+Glob("{,**/}x").matches("x")        StateError: No element
+Glob("A/{,**/}x").matches("A/x")    true
+Glob("A/{,**/}x").matches("A/b/x")  true
+```
+
+`SequenceNode.canMatchAbsolute` reads `nodes.first` of the empty alternative,
+and that read only happens when the options group is the **first** node. A
+constant leading segment moves it off position 0, so the relaxation is legal
+everywhere — including interior `**`, which a leading-only fix would miss.
+
+### Why `context: p.posix`
+
+`Glob` derives `caseSensitive` from the context style, so the ambient context
+would make matching **case-insensitive on Windows** while the old matcher was
+always case-sensitive. CI is `ubuntu-latest` only and would never surface it.
+
+## Pipeline 2 — testing a path
+
+Runs per candidate file.
+
+```mermaid
+flowchart TD
+  A["relativePath"] --> B["p.posix.normalize<br/>backslashes to /"]
+  B --> C["strip leading ./ or /"]
+  C --> D{"segment is .dart_tool,<br/>.git, .idea, .vscode,<br/>or first is build?"}
+  D -->|yes| EX["excluded — fast path,<br/>no glob evaluated"]
+  D -->|no| E["strip leading ../<br/>(extra roots)"]
+  E --> F["prepend anchor &lt;root&gt;/"]
+  F --> G{"any compiled Glob matches?"}
+  G -->|yes| EX2["excluded"]
+  G -->|no| KEEP["kept"]
+```
+
+The fast path is **broader** than the pattern list, not redundant with it:
+`segments.contains('.dart_tool')` fires at any depth, whereas `.dart_tool/**`
+is root-anchored. It is retained unchanged, which is why `lib/.dart_tool/x`
+and a bare `.git` still behave as before.
+
+## Observability — where a bad pattern surfaces
+
+Patterns compile eagerly in the constructor, so a malformed pattern fails at
+startup rather than silently matching nothing forever. This matters more under
+glob, where `[`, `{` and `!` are now syntax and users will get them wrong.
+
+```mermaid
+flowchart TD
+  CLI["--exclude with a<br/>malformed pattern"] --> AP["ArgParser<br/>splitCommas: false"]
+  AP --> SP["splitGlobPatterns<br/>respects { } and [ ]"]
+  SP --> PPF["parsePathFilter"]
+  PPF --> CTOR["PathFilter(...)<br/>eager compile"]
+  CTOR --> FE["FormatException<br/>naming the pattern"]
+
+  FE --> CC["cognitive_complexity<br/>cli.dart on FormatException"]
+  FE --> DP["dedupe<br/>_handleFormatException"]
+  FE --> UD["undead<br/>_usageError"]
+
+  CC --> X1["stderr + usage<br/>exit 64"]
+  DP --> X2["stderr + usage<br/>exit 64"]
+  UD --> X3["stderr + usage<br/>exit 64"]
+
+  LIB["library consumer<br/>UndeadOptions / DedupeOptions"] --> CTOR
+  LIB -.->|"unguarded"| THROW["FormatException propagates<br/>— documented on both ctors"]
+```
+
+`undead` previously had no guard: `parsePathFilter` sits between the
+arg-parsing `try` and the analysis `try`, so a malformed pattern exited **255**
+with a raw stack trace. It now matches the other two.
+
+### Detection map
+
+Every failure mode of this change is silent by nature — a filter that stops
+matching does not crash, it analyses fewer files and reports success. Each row
+below names where it is caught instead.
+
+<!-- mdformat off(prevent table wrapping) -->
+
+| Failure mode | Detection | Stage |
+| :--- | :--- | :--- |
+| Root-level files stop being filtered | golden matrix, `defaults` group | local test |
+| Interior `**` stops matching | golden matrix, `lib/**/*.g.dart` rows | local test |
+| Runs of `**/` partly unrelaxed | golden matrix, `**/**/x.dart` rows | local test |
+| `build` loses root-anchoring | pre-existing `path_filter_test.dart` | local test |
+| Case-sensitivity flips on Windows | `context: p.posix` — the pin is the control | authoring |
+| Malformed pattern | eager compile | runtime, startup |
+| `undead` crashes on one | `cli_test.dart` in-process test | local test |
+| `../` paths stop being excluded | golden matrix, out-of-tree group | local test |
+| Unknown semantic drift | golden matrix diff | review |
+| Consumer breakage | six package suites | CI |
+
+<!-- mdformat on -->
+
+The golden matrix (`path_filter_characterization_test.dart`) records what the
+filter *does*, captured from the running implementation rather than written by
+hand. It was confirmed green against the old `WildcardPattern` engine before
+the swap; the swap then flipped exactly two groups. To re-check independently,
+revert `path_filter.dart` and the matrix passes except those two.
+
+## Behaviour changes
+
+<!-- mdformat off(prevent table wrapping) -->
+
+| Change | Before | After |
+| :--- | :--- | :--- |
+| `[ ] { } ( )` in a pattern | literal | glob syntax; `Glob.quote` to escape |
+| `\` in a pattern | path separator | glob escape (paths still normalize) |
+| Malformed pattern | matched nothing, silently | `FormatException` naming it |
+| `../` prefix vs anchored pattern | not matched | matched on in-tree remainder |
+
+<!-- mdformat on -->
+
+The `../` direction is a deliberate choice: neither option is fully
+behaviour-preserving. Stripping widens anchored patterns; not stripping makes
+`**` stop absorbing `../`, which would silently un-exclude generated files
+under an `undead --extra-roots`. The second is the more damaging.
+
+## Performance
+
+`Glob` caches its compiled `RegExp` on the AST node, and patterns compile once
+in the constructor, so there is no per-call recompilation. Measured over 20k
+paths through `PathFilter.defaults`: ~33ms before, ~58ms after — roughly 3µs
+per path, against AST parsing that dominates by orders of magnitude.

--- a/packages/analytica/lib/src/analyzer/path_filter.dart
+++ b/packages/analytica/lib/src/analyzer/path_filter.dart
@@ -78,8 +78,8 @@ class PathFilter {
   static List<Glob> _compileAll(Iterable<String> patterns) {
     final globs = <Glob>[];
     for (final raw in patterns) {
-      // A trailing comma or an unset CI variable yields a blank entry, which
-      // `Glob` rejects. Dropping it keeps such input inert, as it was before.
+      // A trailing comma or unset CI variable yields a blank entry, which
+      // `Glob` rejects but the previous matcher treated as inert.
       if (raw.trim().isEmpty) continue;
       globs.add(_compile(raw));
     }
@@ -87,19 +87,15 @@ class PathFilter {
   }
 
   static Glob _compile(String raw) {
-    // Relax `**` at a path boundary to span zero or more directories, so
-    // `**/*.g.dart` also matches a root-level `model.g.dart`. Scoped to
-    // boundaries so a caller's own brace group is left intact.
-    // Collapse runs of `**/` first: `replaceAll` is non-overlapping, so
-    // `**/**/x` would otherwise leave the second occurrence unrelaxed.
+    // `replaceAll` is non-overlapping, so a run of `**/` must collapse before
+    // the boundaries are relaxed, or all but the first survive unrelaxed.
     final collapsed = _normalizePattern(
       raw,
     ).replaceAll(RegExp(r'(?:\*\*/)+'), '**/');
     final anchored = '$_anchor$collapsed'.replaceAll('/**/', '/{**/,}');
     try {
-      // p.posix pins the separator and case sensitivity. Glob's default
-      // context is case-insensitive on Windows, which the Linux-only CI
-      // would never surface.
+      // Glob's default context is case-insensitive on Windows, which the
+      // Linux-only CI would never surface.
       return Glob(anchored, context: p.posix);
     } on FormatException catch (e) {
       throw FormatException('Invalid exclude pattern "$raw": ${e.message}');
@@ -107,9 +103,6 @@ class PathFilter {
   }
 
   static String _normalizePattern(String raw) {
-    // Patterns are glob syntax: `/` separates segments on every platform and
-    // `\` escapes a metacharacter, as `Glob.quote` produces. Candidate paths
-    // are still normalized from Windows separators in [isExcluded].
     var pat = raw.trim();
     if (pat.startsWith('./')) {
       pat = pat.substring(2);

--- a/packages/analytica/lib/src/analyzer/path_filter.dart
+++ b/packages/analytica/lib/src/analyzer/path_filter.dart
@@ -1,9 +1,15 @@
+import 'package:glob/glob.dart';
 import 'package:path/path.dart' as p;
-
-import 'glob_matcher.dart';
 
 /// Configurable path filter evaluating whether file paths should be excluded
 /// from analysis.
+///
+/// Patterns are matched with `package:glob`, so the full glob syntax is
+/// available: `*` and `?` within a segment, `**` across segments, brace
+/// expansion (`**/*.{g,freezed}.dart`), and character classes
+/// (`**/*_[0-9].dart`). Matching is always case-sensitive and always uses
+/// `/` as the separator, on every platform. A literal `[`, `]`, `{` or `}`
+/// in a pattern must be escaped with [Glob.quote].
 class PathFilter {
   /// Default directory names and glob patterns excluded from scanning.
   static const defaultIgnoredDirectories = <String>[
@@ -28,6 +34,16 @@ class PathFilter {
     '**/*.pbserver.dart',
   ];
 
+  /// Prefix applied to every compiled pattern and every candidate path.
+  ///
+  /// `package:glob` cannot otherwise express "zero or more leading
+  /// directories". The natural spelling, `{**/,}`, parses correctly but throws
+  /// `StateError` when matched, because `SequenceNode.canMatchAbsolute` reads
+  /// `nodes.first` of the empty alternative. That read only happens when the
+  /// options group is the first node of the pattern, so a constant leading
+  /// segment keeps the relaxation legal wherever it appears.
+  static const _anchor = '<root>/';
+
   /// The custom exclusion glob patterns configured on this filter.
   final List<String> excludePatterns;
 
@@ -35,28 +51,55 @@ class PathFilter {
   /// excluded.
   final bool ignoreGenerated;
 
-  final List<WildcardPattern> _wildcards;
+  final List<Glob> _globs;
 
   /// Creates a [PathFilter] with optional custom [excludePatterns] and
   /// [ignoreGenerated] toggle (defaults to `true`).
+  ///
+  /// Throws a [FormatException] naming the offending pattern if any of
+  /// [excludePatterns] is not valid glob syntax.
   PathFilter({
     Iterable<String> excludePatterns = const [],
     this.ignoreGenerated = true,
   }) : excludePatterns = List.unmodifiable(excludePatterns),
-       _wildcards = [
-         ...defaultIgnoredDirectories.map(
-           (p) => WildcardPattern(_normalizePattern(p)),
-         ),
-         if (ignoreGenerated)
-           ...defaultGeneratedPatterns.map(
-             (p) => WildcardPattern(_normalizePattern(p)),
-           ),
-         ...excludePatterns.map((p) => WildcardPattern(_normalizePattern(p))),
-       ];
+       _globs = _compileAll([
+         ...defaultIgnoredDirectories,
+         if (ignoreGenerated) ...defaultGeneratedPatterns,
+         ...excludePatterns,
+       ]);
 
   /// Default constant filter instance with standard ignored directories and
   /// generated file exclusion enabled.
   static final PathFilter defaults = PathFilter();
+
+  static List<Glob> _compileAll(Iterable<String> patterns) {
+    final globs = <Glob>[];
+    for (final raw in patterns) {
+      // A trailing comma or an unset CI variable yields a blank entry, which
+      // `Glob` rejects. Dropping it keeps such input inert, as it was before.
+      if (raw.trim().isEmpty) continue;
+      globs.add(_compile(raw));
+    }
+    return List.unmodifiable(globs);
+  }
+
+  static Glob _compile(String raw) {
+    // Relax `**` at a path boundary to span zero or more directories, so
+    // `**/*.g.dart` also matches a root-level `model.g.dart`. Scoped to
+    // boundaries so a caller's own brace group is left intact.
+    final anchored = '$_anchor${_normalizePattern(raw)}'.replaceAll(
+      '/**/',
+      '/{**/,}',
+    );
+    try {
+      // p.posix pins the separator and case sensitivity. Glob's default
+      // context is case-insensitive on Windows, which the Linux-only CI
+      // would never surface.
+      return Glob(anchored, context: p.posix);
+    } on FormatException catch (e) {
+      throw FormatException('Invalid exclude pattern "$raw": ${e.message}');
+    }
+  }
 
   static String _normalizePattern(String raw) {
     var pat = raw.trim().replaceAll(r'\', '/');
@@ -93,6 +136,18 @@ class PathFilter {
       return true;
     }
 
-    return WildcardPattern.anyMatch(_wildcards, clean);
+    // Patterns describe the scanned tree, so a path that escapes it — as
+    // `undead --extra-roots` and multi-target runs produce via `p.relative` —
+    // is matched on its in-tree remainder. `**` will not match a leading
+    // `../` on its own.
+    while (clean.startsWith('../')) {
+      clean = clean.substring(3);
+    }
+
+    final candidate = '$_anchor$clean';
+    for (final glob in _globs) {
+      if (glob.matches(candidate)) return true;
+    }
+    return false;
   }
 }

--- a/packages/analytica/lib/src/analyzer/path_filter.dart
+++ b/packages/analytica/lib/src/analyzer/path_filter.dart
@@ -7,9 +7,12 @@ import 'package:path/path.dart' as p;
 /// Patterns are matched with `package:glob`, so the full glob syntax is
 /// available: `*` and `?` within a segment, `**` across segments, brace
 /// expansion (`**/*.{g,freezed}.dart`), and character classes
-/// (`**/*_[0-9].dart`). Matching is always case-sensitive and always uses
-/// `/` as the separator, on every platform. A literal `[`, `]`, `{` or `}`
-/// in a pattern must be escaped with [Glob.quote].
+/// (`**/*_[0-9].dart`). Matching is always case-sensitive.
+///
+/// Patterns always use `/` as the segment separator, on every platform, and
+/// `\` escapes a metacharacter — so a literal `[`, `]`, `{` or `}` is written
+/// with [Glob.quote]. Candidate paths passed to [isExcluded] may use either
+/// separator.
 class PathFilter {
   /// Default directory names and glob patterns excluded from scanning.
   static const defaultIgnoredDirectories = <String>[
@@ -87,10 +90,12 @@ class PathFilter {
     // Relax `**` at a path boundary to span zero or more directories, so
     // `**/*.g.dart` also matches a root-level `model.g.dart`. Scoped to
     // boundaries so a caller's own brace group is left intact.
-    final anchored = '$_anchor${_normalizePattern(raw)}'.replaceAll(
-      '/**/',
-      '/{**/,}',
-    );
+    // Collapse runs of `**/` first: `replaceAll` is non-overlapping, so
+    // `**/**/x` would otherwise leave the second occurrence unrelaxed.
+    final collapsed = _normalizePattern(
+      raw,
+    ).replaceAll(RegExp(r'(?:\*\*/)+'), '**/');
+    final anchored = '$_anchor$collapsed'.replaceAll('/**/', '/{**/,}');
     try {
       // p.posix pins the separator and case sensitivity. Glob's default
       // context is case-insensitive on Windows, which the Linux-only CI
@@ -102,7 +107,10 @@ class PathFilter {
   }
 
   static String _normalizePattern(String raw) {
-    var pat = raw.trim().replaceAll(r'\', '/');
+    // Patterns are glob syntax: `/` separates segments on every platform and
+    // `\` escapes a metacharacter, as `Glob.quote` produces. Candidate paths
+    // are still normalized from Windows separators in [isExcluded].
+    var pat = raw.trim();
     if (pat.startsWith('./')) {
       pat = pat.substring(2);
     }

--- a/packages/analytica/lib/src/cli.dart
+++ b/packages/analytica/lib/src/cli.dart
@@ -65,19 +65,20 @@ extension AnalyticaArgParserExtensions on ArgParser {
 }
 
 /// Splits a comma-separated list of glob patterns, ignoring commas inside a
-/// brace group.
+/// brace group or a character class.
 ///
 /// `**/*.{g,freezed}.dart,lib/**` yields `['**/*.{g,freezed}.dart', 'lib/**']`
-/// rather than tearing the brace group apart on its inner comma.
+/// rather than tearing the brace group apart on its inner comma, and
+/// `**/*_[0,1].dart` is likewise left whole.
 List<String> splitGlobPatterns(String value) {
   final parts = <String>[];
   final buffer = StringBuffer();
   var depth = 0;
   for (final rune in value.runes) {
     final char = String.fromCharCode(rune);
-    if (char == '{') {
+    if (char == '{' || char == '[') {
       depth++;
-    } else if (char == '}') {
+    } else if (char == '}' || char == ']') {
       if (depth > 0) depth--;
     } else if (char == ',' && depth == 0) {
       parts.add(buffer.toString());

--- a/packages/analytica/lib/src/cli.dart
+++ b/packages/analytica/lib/src/cli.dart
@@ -50,6 +50,9 @@ extension AnalyticaArgParserExtensions on ArgParser {
           'Glob patterns of files/directories to exclude (repeatable or '
           'comma-separated).',
       valueHelp: 'glob',
+      // Split in parsePathFilter instead: a brace group such as
+      // `**/*.{g,freezed}.dart` contains commas that must survive.
+      splitCommas: false,
     );
     addFlag(
       'ignore-generated',
@@ -59,6 +62,32 @@ extension AnalyticaArgParserExtensions on ArgParser {
           'etc.).',
     );
   }
+}
+
+/// Splits a comma-separated list of glob patterns, ignoring commas inside a
+/// brace group.
+///
+/// `**/*.{g,freezed}.dart,lib/**` yields `['**/*.{g,freezed}.dart', 'lib/**']`
+/// rather than tearing the brace group apart on its inner comma.
+List<String> splitGlobPatterns(String value) {
+  final parts = <String>[];
+  final buffer = StringBuffer();
+  var depth = 0;
+  for (final rune in value.runes) {
+    final char = String.fromCharCode(rune);
+    if (char == '{') {
+      depth++;
+    } else if (char == '}') {
+      if (depth > 0) depth--;
+    } else if (char == ',' && depth == 0) {
+      parts.add(buffer.toString());
+      buffer.clear();
+      continue;
+    }
+    buffer.write(char);
+  }
+  parts.add(buffer.toString());
+  return parts;
 }
 
 /// Parses a [PathFilter] from the standard `--exclude` and `--ignore-generated`
@@ -71,7 +100,7 @@ PathFilter parsePathFilter(
       ? results.multiOption('exclude')
       : const <String>[];
   final userExcludes = rawExcludes
-      .expand((e) => e.split(','))
+      .expand(splitGlobPatterns)
       .map((e) => e.trim())
       .where((e) => e.isNotEmpty);
 

--- a/packages/analytica/pubspec.yaml
+++ b/packages/analytica/pubspec.yaml
@@ -18,6 +18,7 @@ environment:
 dependencies:
   analyzer: '>=12.0.0 <15.0.0'
   args: ^2.7.0
+  glob: ^2.1.3
   io: ^1.0.5
   path: ^1.9.1
 

--- a/packages/analytica/test/analyzer/path_filter_characterization_test.dart
+++ b/packages/analytica/test/analyzer/path_filter_characterization_test.dart
@@ -4,16 +4,13 @@ import 'package:test/scaffolding.dart';
 
 /// Golden matrix pinning [PathFilter] matching behaviour.
 ///
-/// Every expectation here was captured from the running implementation rather
-/// than written by hand, so the matrix records what the filter *does*, not what
-/// it was assumed to do. Its purpose is to make behaviour changes to the
-/// matching engine visible in review: a change that edits no rows is
-/// behaviour-preserving, and a change that edits rows has documented precisely
-/// what it altered.
+/// Expectations were captured from the running implementation, so the matrix
+/// records what the filter *does*, not what it was assumed to do: a change
+/// that edits no rows is behaviour-preserving, and one that edits rows has
+/// listed exactly what it altered.
 ///
-/// Exclusion is not opt-in — [PathFilter.defaults] applies fifteen patterns to
-/// every scanned file before any `--exclude` is supplied — so a silent
-/// regression here changes the output of every tool in the workspace.
+/// Exclusion is not opt-in — [PathFilter.defaults] applies fifteen patterns
+/// before any `--exclude` — so a regression here reaches every tool.
 typedef _Case = ({String path, bool excluded});
 
 void _expectAll(PathFilter filter, List<_Case> cases) {
@@ -54,7 +51,6 @@ void main() {
     test('ignored directories, including the bare directory itself', () {
       _expectAll(PathFilter.defaults, const [
         (path: '.dart_tool/package_config.json', excluded: true),
-        // Matched at any depth, not only at the root.
         (path: 'lib/.dart_tool/x.dart', excluded: true),
         (path: '.dart_tool', excluded: true),
         (path: '.git/HEAD', excluded: true),
@@ -227,25 +223,21 @@ void main() {
   });
 
   group('PathFilter characterization: glob metacharacters', () {
-    // CHANGED by the move to package:glob. Previously every metacharacter was
-    // escaped and matched literally; they are now glob syntax. This is the
-    // point of the change, but it is a breaking one for any pattern that
-    // relied on the old literal reading.
+    // CHANGED by the move to package:glob: metacharacters were escaped and
+    // matched literally, and are now syntax.
     test('bracket characters are a character class, not literal', () {
       _expectAll(
         PathFilter(excludePatterns: [r'lib/a[0].dart'], ignoreGenerated: false),
         const [
-          // Was `true` under the literal matcher.
           (path: 'lib/a[0].dart', excluded: false),
-          // Was `false`.
           (path: 'lib/a0.dart', excluded: true),
         ],
       );
     });
 
     test('a brace group with a single option is a syntax error', () {
-      // Was matched literally and silently. Failing loudly is the intended
-      // trade: a pattern that cannot mean what the author wrote should say so.
+      // Was matched literally. A pattern that cannot mean what the author
+      // wrote should say so.
       check(
           () => PathFilter(excludePatterns: [r'lib/b{c}.dart']),
         ).throws<FormatException>().has((e) => e.message, 'message')
@@ -262,12 +254,10 @@ void main() {
       _expectAll(
         PathFilter(excludePatterns: ['custom/**'], ignoreGenerated: false),
         const [
-          // CHANGED, both were `false`. Escaping segments are now stripped
-          // before matching, so a root-anchored pattern applies to an
-          // out-of-tree path by its in-tree remainder. Without the strip the
-          // asymmetry runs the other way and `**` stops absorbing `../`,
-          // which would silently un-exclude generated files under an extra
-          // root -- the more damaging direction of the two.
+          // CHANGED, both were `false`. Escaping segments are stripped, so
+          // a root-anchored pattern now reaches an out-of-tree path. Without
+          // the strip `**` stops absorbing `../` instead, silently
+          // un-excluding generated files under an extra root.
           (path: '../custom/x.dart', excluded: true),
           (path: '../../custom/x.dart', excluded: true),
           (path: 'custom/x.dart', excluded: true),

--- a/packages/analytica/test/analyzer/path_filter_characterization_test.dart
+++ b/packages/analytica/test/analyzer/path_filter_characterization_test.dart
@@ -115,6 +115,20 @@ void main() {
       );
     });
 
+    test('consecutive ** segments collapse', () {
+      // `replaceAll` is non-overlapping, so a run of `**/` would otherwise
+      // leave all but the first unrelaxed and stop matching at the root.
+      _expectAll(
+        PathFilter(excludePatterns: ['**/**/x.dart'], ignoreGenerated: false),
+        const [
+          (path: 'x.dart', excluded: true),
+          (path: 'lib/x.dart', excluded: true),
+          (path: 'a/b/x.dart', excluded: true),
+          (path: 'lib/y.dart', excluded: false),
+        ],
+      );
+    });
+
     test('a slash-less pattern matches at any depth', () {
       _expectAll(
         PathFilter(excludePatterns: ['legacy_*.dart'], ignoreGenerated: false),

--- a/packages/analytica/test/analyzer/path_filter_characterization_test.dart
+++ b/packages/analytica/test/analyzer/path_filter_characterization_test.dart
@@ -1,0 +1,264 @@
+import 'package:analytica/analyzer.dart';
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
+
+/// Golden matrix pinning [PathFilter] matching behaviour.
+///
+/// Every expectation here was captured from the running implementation rather
+/// than written by hand, so the matrix records what the filter *does*, not what
+/// it was assumed to do. Its purpose is to make behaviour changes to the
+/// matching engine visible in review: a change that edits no rows is
+/// behaviour-preserving, and a change that edits rows has documented precisely
+/// what it altered.
+///
+/// Exclusion is not opt-in — [PathFilter.defaults] applies fifteen patterns to
+/// every scanned file before any `--exclude` is supplied — so a silent
+/// regression here changes the output of every tool in the workspace.
+typedef _Case = ({String path, bool excluded});
+
+void _expectAll(PathFilter filter, List<_Case> cases) {
+  for (final c in cases) {
+    check(
+      because: 'isExcluded(${_show(c.path)})',
+      filter.isExcluded(c.path),
+    ).equals(c.excluded);
+  }
+}
+
+String _show(String s) => "'${s.replaceAll(r'\', r'\\')}'";
+
+void main() {
+  group('PathFilter characterization: defaults', () {
+    test('generated files, at every depth', () {
+      _expectAll(PathFilter.defaults, const [
+        (path: 'lib/src/model.g.dart', excluded: true),
+        // Root-level generated files: the case a naive glob port loses,
+        // because `**/` there requires at least one directory.
+        (path: 'model.g.dart', excluded: true),
+        (path: 'a/b/c/model.g.dart', excluded: true),
+        (path: 'lib/src/model.freezed.dart', excluded: true),
+        (path: 'model.freezed.dart', excluded: true),
+        (path: 'test/service.mocks.dart', excluded: true),
+        (path: 'lib/di.config.dart', excluded: true),
+        (path: 'lib/generated.reflectable.dart', excluded: true),
+        (path: 'lib/assets.gen.dart', excluded: true),
+        (path: 'lib/schema.pb.dart', excluded: true),
+        (path: 'lib/schema.pbenum.dart', excluded: true),
+        (path: 'lib/schema.pbjson.dart', excluded: true),
+        (path: 'lib/schema.pbserver.dart', excluded: true),
+        (path: 'lib/src/model.dart', excluded: false),
+        (path: 'lib/generator.dart', excluded: false),
+      ]);
+    });
+
+    test('ignored directories, including the bare directory itself', () {
+      _expectAll(PathFilter.defaults, const [
+        (path: '.dart_tool/package_config.json', excluded: true),
+        // Matched at any depth, not only at the root.
+        (path: 'lib/.dart_tool/x.dart', excluded: true),
+        (path: '.dart_tool', excluded: true),
+        (path: '.git/HEAD', excluded: true),
+        (path: 'packages/p/.git/HEAD', excluded: true),
+        (path: '.git', excluded: true),
+        (path: '.idea/workspace.xml', excluded: true),
+        (path: '.vscode/settings.json', excluded: true),
+        (path: 'build/app/outputs', excluded: true),
+        (path: 'build', excluded: true),
+      ]);
+    });
+
+    test('build is root-anchored, and lookalikes are not excluded', () {
+      _expectAll(PathFilter.defaults, const [
+        (path: 'lib/src/build/builder.dart', excluded: false),
+        (path: 'packages/p/build/bin.dart', excluded: false),
+        (path: 'lib/builders/code_builder.dart', excluded: false),
+        (path: '.github/workflows/ci.yml', excluded: false),
+      ]);
+    });
+
+    test('path prefixes are normalized, and matching is case-sensitive', () {
+      _expectAll(PathFilter.defaults, const [
+        (path: './lib/model.g.dart', excluded: true),
+        (path: '/lib/model.g.dart', excluded: true),
+        (path: r'lib\src\model.g.dart', excluded: true),
+        (path: 'LIB/MODEL.G.DART', excluded: false),
+      ]);
+    });
+
+    test('ignoreGenerated: false keeps directory exclusion active', () {
+      _expectAll(PathFilter(ignoreGenerated: false), const [
+        (path: 'lib/src/model.g.dart', excluded: false),
+        (path: 'model.g.dart', excluded: false),
+        (path: '.dart_tool/x', excluded: true),
+        (path: 'build/x', excluded: true),
+        (path: 'lib/src/model.dart', excluded: false),
+      ]);
+    });
+  });
+
+  group('PathFilter characterization: pattern shapes', () {
+    test('interior ** spans zero or more directories', () {
+      // Distinct from a leading `**/`: a port that relaxes only the leading
+      // occurrence silently stops matching `lib/model.g.dart` here.
+      _expectAll(
+        PathFilter(
+          excludePatterns: ['lib/**/*.g.dart'],
+          ignoreGenerated: false,
+        ),
+        const [
+          (path: 'lib/model.g.dart', excluded: true),
+          (path: 'lib/x/model.g.dart', excluded: true),
+          (path: 'lib/x/y/model.g.dart', excluded: true),
+          (path: 'model.g.dart', excluded: false),
+          (path: 'test/model.g.dart', excluded: false),
+        ],
+      );
+    });
+
+    test('a slash-less pattern matches at any depth', () {
+      _expectAll(
+        PathFilter(excludePatterns: ['legacy_*.dart'], ignoreGenerated: false),
+        const [
+          (path: 'legacy_a.dart', excluded: true),
+          (path: 'lib/legacy_a.dart', excluded: true),
+          (path: 'lib/src/legacy_a.dart', excluded: true),
+          (path: 'lib/other.dart', excluded: false),
+          (path: 'lib/x_legacy_a.dart', excluded: false),
+        ],
+      );
+    });
+
+    test('trailing ** requires at least one segment beneath', () {
+      _expectAll(
+        PathFilter(
+          excludePatterns: ['test/fixtures/**'],
+          ignoreGenerated: false,
+        ),
+        const [
+          (path: 'test/fixtures/a.dart', excluded: true),
+          (path: 'test/fixtures/a/b.dart', excluded: true),
+          (path: 'test/fixtures', excluded: false),
+          (path: 'test/other/a.dart', excluded: false),
+        ],
+      );
+    });
+
+    test('leading ./ and / are stripped from patterns', () {
+      _expectAll(
+        PathFilter(
+          excludePatterns: ['/custom/**', './other/**'],
+          ignoreGenerated: false,
+        ),
+        const [
+          (path: r'.\custom\sub\file.dart', excluded: true),
+          (path: './custom/sub/file.dart', excluded: true),
+          (path: '/custom/sub/file.dart', excluded: true),
+          (path: 'custom/sub/file.dart', excluded: true),
+          (path: 'other/sub/file.dart', excluded: true),
+          (path: 'unrelated/x.dart', excluded: false),
+        ],
+      );
+    });
+
+    test('* and ? stop at a separator', () {
+      _expectAll(
+        PathFilter(excludePatterns: ['a?.dart'], ignoreGenerated: false),
+        const [
+          (path: 'ab.dart', excluded: true),
+          (path: 'lib/ab.dart', excluded: true),
+          (path: 'a/b.dart', excluded: false),
+          (path: 'abc.dart', excluded: false),
+        ],
+      );
+      _expectAll(
+        PathFilter(excludePatterns: ['lib/*.dart'], ignoreGenerated: false),
+        const [
+          (path: 'lib/a.dart', excluded: true),
+          (path: 'lib/x/a.dart', excluded: false),
+          (path: 'a.dart', excluded: false),
+        ],
+      );
+    });
+
+    test('degenerate patterns', () {
+      _expectAll(
+        PathFilter(excludePatterns: ['**'], ignoreGenerated: false),
+        const [
+          (path: 'a.dart', excluded: true),
+          (path: 'lib/a.dart', excluded: true),
+        ],
+      );
+      // `**/` alone matches nothing; it is not a synonym for `**`.
+      _expectAll(
+        PathFilter(excludePatterns: ['**/'], ignoreGenerated: false),
+        const [
+          (path: 'a.dart', excluded: false),
+          (path: 'lib/a.dart', excluded: false),
+        ],
+      );
+    });
+
+    test('blank patterns are inert rather than an error', () {
+      // A trailing comma or an unset CI variable produces these.
+      for (final blank in ['', '   ']) {
+        check(
+          because: 'blank pattern ${_show(blank)}',
+          PathFilter(
+            excludePatterns: [blank],
+            ignoreGenerated: false,
+          ).isExcluded('a.dart'),
+        ).isFalse();
+      }
+    });
+  });
+
+  group('PathFilter characterization: glob metacharacters', () {
+    // CHANGED by the move to package:glob. Previously every metacharacter was
+    // escaped and matched literally; they are now glob syntax. This is the
+    // point of the change, but it is a breaking one for any pattern that
+    // relied on the old literal reading.
+    test('bracket characters are a character class, not literal', () {
+      _expectAll(
+        PathFilter(excludePatterns: [r'lib/a[0].dart'], ignoreGenerated: false),
+        const [
+          // Was `true` under the literal matcher.
+          (path: 'lib/a[0].dart', excluded: false),
+          // Was `false`.
+          (path: 'lib/a0.dart', excluded: true),
+        ],
+      );
+    });
+
+    test('a brace group with a single option is a syntax error', () {
+      // Was matched literally and silently. Failing loudly is the intended
+      // trade: a pattern that cannot mean what the author wrote should say so.
+      check(
+          () => PathFilter(excludePatterns: [r'lib/b{c}.dart']),
+        ).throws<FormatException>().has((e) => e.message, 'message')
+        ..contains(r'lib/b{c}.dart')
+        ..contains('Invalid exclude pattern');
+    });
+  });
+
+  group('PathFilter characterization: paths outside the scanned tree', () {
+    test('../ prefixes', () {
+      // undead --extra-roots and multi-target runs produce these via
+      // p.relative().
+      check(PathFilter.defaults.isExcluded('../lib/model.g.dart')).isTrue();
+      _expectAll(
+        PathFilter(excludePatterns: ['custom/**'], ignoreGenerated: false),
+        const [
+          // CHANGED, both were `false`. Escaping segments are now stripped
+          // before matching, so a root-anchored pattern applies to an
+          // out-of-tree path by its in-tree remainder. Without the strip the
+          // asymmetry runs the other way and `**` stops absorbing `../`,
+          // which would silently un-exclude generated files under an extra
+          // root -- the more damaging direction of the two.
+          (path: '../custom/x.dart', excluded: true),
+          (path: '../../custom/x.dart', excluded: true),
+          (path: 'custom/x.dart', excluded: true),
+        ],
+      );
+    });
+  });
+}

--- a/packages/analytica/test/analyzer/path_filter_test.dart
+++ b/packages/analytica/test/analyzer/path_filter_test.dart
@@ -1,5 +1,6 @@
 import 'package:analytica/analyzer.dart';
 import 'package:checks/checks.dart';
+import 'package:glob/glob.dart';
 import 'package:test/scaffolding.dart';
 
 void main() {
@@ -94,6 +95,41 @@ void main() {
       check(filter.isExcluded('lib/part_3.dart')).isTrue();
       check(filter.isExcluded('part_0.dart')).isTrue();
       check(filter.isExcluded('lib/part_x.dart')).isFalse();
+    });
+
+    test('Glob.quote escapes a metacharacter back to a literal', () {
+      // The documented migration path for the literal -> metacharacter break.
+      final filter = PathFilter(
+        excludePatterns: [Glob.quote('lib/a[0].dart')],
+        ignoreGenerated: false,
+      );
+
+      check(filter.isExcluded('lib/a[0].dart')).isTrue();
+      check(filter.isExcluded('lib/a0.dart')).isFalse();
+    });
+
+    test('a backslash in a pattern escapes, it does not separate', () {
+      // Patterns are glob syntax on every platform; only candidate paths are
+      // normalized from Windows separators.
+      final filter = PathFilter(
+        excludePatterns: [r'lib/a\{b.dart'],
+        ignoreGenerated: false,
+      );
+
+      check(filter.isExcluded('lib/a{b.dart')).isTrue();
+      check(filter.isExcluded(r'lib\a{b.dart')).isTrue();
+    });
+
+    test('consecutive ** segments still match at the root', () {
+      final filter = PathFilter(
+        excludePatterns: ['**/**/x.dart'],
+        ignoreGenerated: false,
+      );
+
+      check(filter.isExcluded('x.dart')).isTrue();
+      check(filter.isExcluded('lib/x.dart')).isTrue();
+      check(filter.isExcluded('a/b/x.dart')).isTrue();
+      check(filter.isExcluded('lib/y.dart')).isFalse();
     });
 
     test('rejects a malformed pattern, naming the pattern', () {

--- a/packages/analytica/test/analyzer/path_filter_test.dart
+++ b/packages/analytica/test/analyzer/path_filter_test.dart
@@ -109,8 +109,7 @@ void main() {
     });
 
     test('a backslash in a pattern escapes, it does not separate', () {
-      // Patterns are glob syntax on every platform; only candidate paths are
-      // normalized from Windows separators.
+      // Only candidate paths are normalized from Windows separators.
       final filter = PathFilter(
         excludePatterns: [r'lib/a\{b.dart'],
         ignoreGenerated: false,

--- a/packages/analytica/test/analyzer/path_filter_test.dart
+++ b/packages/analytica/test/analyzer/path_filter_test.dart
@@ -71,4 +71,39 @@ void main() {
       check(filter.isExcluded(r'lib\src\model.g.dart')).isTrue();
     });
   });
+
+  group('PathFilter glob syntax', () {
+    test('supports brace expansion', () {
+      final filter = PathFilter(
+        excludePatterns: ['**/*.{g,freezed}.dart'],
+        ignoreGenerated: false,
+      );
+
+      check(filter.isExcluded('lib/src/model.g.dart')).isTrue();
+      check(filter.isExcluded('lib/src/model.freezed.dart')).isTrue();
+      check(filter.isExcluded('model.g.dart')).isTrue();
+      check(filter.isExcluded('lib/src/model.dart')).isFalse();
+    });
+
+    test('supports character classes', () {
+      final filter = PathFilter(
+        excludePatterns: ['**/*_[0-9].dart'],
+        ignoreGenerated: false,
+      );
+
+      check(filter.isExcluded('lib/part_3.dart')).isTrue();
+      check(filter.isExcluded('part_0.dart')).isTrue();
+      check(filter.isExcluded('lib/part_x.dart')).isFalse();
+    });
+
+    test('rejects a malformed pattern, naming the pattern', () {
+      // The previous matcher escaped anything it did not understand, so a
+      // typo silently matched nothing for the life of the process.
+      check(
+          () => PathFilter(excludePatterns: ['lib/[unclosed']),
+        ).throws<FormatException>().has((e) => e.message, 'message')
+        ..contains('lib/[unclosed')
+        ..contains('Invalid exclude pattern');
+    });
+  });
 }

--- a/packages/analytica/test/cli_test.dart
+++ b/packages/analytica/test/cli_test.dart
@@ -48,6 +48,19 @@ void main() {
         customFilter.excludePatterns,
       ).deepEquals(['test/fixtures/**', 'legacy/**', '*.gen.dart']);
     });
+
+    test('keeps brace groups intact when splitting on commas', () {
+      // A brace group contains commas, so naive comma splitting tears
+      // `**/*.{g,freezed}.dart` into two invalid patterns.
+      final parser = ArgParser()..addPathFilterOptions();
+      final results = parser.parse([
+        '--exclude=**/*.{g,freezed}.dart,lib/legacy/**',
+      ]);
+
+      check(
+        parsePathFilter(results).excludePatterns,
+      ).deepEquals(['**/*.{g,freezed}.dart', 'lib/legacy/**']);
+    });
   });
 
   group('parseLineBounds', () {

--- a/packages/analytica/test/cli_test.dart
+++ b/packages/analytica/test/cli_test.dart
@@ -49,6 +49,15 @@ void main() {
       ).deepEquals(['test/fixtures/**', 'legacy/**', '*.gen.dart']);
     });
 
+    test('keeps character classes intact when splitting on commas', () {
+      final parser = ArgParser()..addPathFilterOptions();
+      final results = parser.parse(['--exclude=**/*_[0,1].dart,lib/legacy/**']);
+
+      check(
+        parsePathFilter(results).excludePatterns,
+      ).deepEquals(['**/*_[0,1].dart', 'lib/legacy/**']);
+    });
+
     test('keeps brace groups intact when splitting on commas', () {
       // A brace group contains commas, so naive comma splitting tears
       // `**/*.{g,freezed}.dart` into two invalid patterns.

--- a/packages/cognitive_complexity/CHANGELOG.md
+++ b/packages/cognitive_complexity/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.2.5-wip
 
+- `--exclude` now accepts the full glob syntax, including brace expansion and
+  character classes, via `PathFilter`.
 - Support `--exclude` and `--[no-]ignore-generated` CLI options to configure
   file exclusion and generated code filtering via `PathFilter`.
 - Add `pathFilter` parameter to `ComplexityAnalyzer` and `DeltaAnalyzer`.

--- a/packages/dedupe/CHANGELOG.md
+++ b/packages/dedupe/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - `--exclude` now accepts the full glob syntax, including brace expansion and
   character classes, via `PathFilter`.
+- `PathFilter` construction now validates patterns eagerly, so building
+  options with a malformed `excludePatterns` entry throws a `FormatException`
+  where it previously matched nothing silently.
 - Adopt centralized `PathFilter` for `--exclude` and generated code filtering
   (`--[no-]ignore-generated`).
 - Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in

--- a/packages/dedupe/CHANGELOG.md
+++ b/packages/dedupe/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.1.1-wip
 
+- `--exclude` now accepts the full glob syntax, including brace expansion and
+  character classes, via `PathFilter`.
 - Adopt centralized `PathFilter` for `--exclude` and generated code filtering
   (`--[no-]ignore-generated`).
 - Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in

--- a/packages/dedupe/lib/src/models.dart
+++ b/packages/dedupe/lib/src/models.dart
@@ -540,6 +540,8 @@ final class DedupeOptions {
   List<String> get excludePatterns => pathFilter.excludePatterns;
   bool get ignoreGenerated => pathFilter.ignoreGenerated;
 
+  /// Throws a [FormatException] if an `excludePatterns` entry is not valid
+  /// glob syntax; [PathFilter] compiles patterns eagerly.
   DedupeOptions({
     required this.targetPath,
     List<String> targets = const ['lib'],

--- a/packages/undead/CHANGELOG.md
+++ b/packages/undead/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - `--exclude` now accepts the full glob syntax, including brace expansion and
   character classes, via `PathFilter`.
+- `PathFilter` construction now validates patterns eagerly, so building
+  options with a malformed `excludePatterns` entry throws a `FormatException`
+  where it previously matched nothing silently.
 - Report a malformed `--exclude` pattern as a usage error instead of an
   unhandled exception.
 - Adopt centralized `PathFilter` in `UndeadOptions` and CLI for `--exclude` and

--- a/packages/undead/CHANGELOG.md
+++ b/packages/undead/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.1.2-wip
 
+- `--exclude` now accepts the full glob syntax, including brace expansion and
+  character classes, via `PathFilter`.
+- Report a malformed `--exclude` pattern as a usage error instead of an
+  unhandled exception.
 - Adopt centralized `PathFilter` in `UndeadOptions` and CLI for `--exclude` and
   `--[no-]ignore-generated` file filtering.
 - Add `ensure_cli_readme_test.dart` to verify CLI `--help` documentation in

--- a/packages/undead/lib/src/cli.dart
+++ b/packages/undead/lib/src/cli.dart
@@ -122,16 +122,21 @@ class UndeadCliRunner {
       outSink = outSink ?? stdout,
       errSink = errSink ?? stderr;
 
+  /// Reports [message] as a usage error with the full option list.
+  int _usageError(String message) {
+    errSink.writeln('Error: $message');
+    errSink.writeln();
+    errSink.writeln('Usage: undead [options] [target_path]');
+    errSink.writeln(parser.usage);
+    return ExitCode.usage.code;
+  }
+
   Future<int> run(List<String> args) async {
     final ArgResults results;
     try {
       results = parser.parse(args);
     } on FormatException catch (e) {
-      errSink.writeln('Error: ${e.message}');
-      errSink.writeln();
-      errSink.writeln('Usage: undead [options] [target_path]');
-      errSink.writeln(parser.usage);
-      return ExitCode.usage.code;
+      return _usageError(e.message);
     }
 
     if (results.flag('help')) {
@@ -171,7 +176,13 @@ class UndeadCliRunner {
     final format = OutputFormat.fromString(results.option('format')!);
     final exampleMode = ExampleMode.fromString(results.option('example-mode')!);
     final mode = AnalysisMode.fromString(results.option('mode')!);
-    var pathFilter = parsePathFilter(results);
+    final PathFilter parsedFilter;
+    try {
+      parsedFilter = parsePathFilter(results);
+    } on FormatException catch (e) {
+      return _usageError(e.message);
+    }
+    var pathFilter = parsedFilter;
     if (results.wasParsed('include-generated') &&
         results.flag('include-generated')) {
       pathFilter = PathFilter(

--- a/packages/undead/lib/src/cli.dart
+++ b/packages/undead/lib/src/cli.dart
@@ -124,9 +124,6 @@ class UndeadCliRunner {
 
   /// Builds the path filter, honouring the deprecated `--include-generated`
   /// alias for `--no-ignore-generated`.
-  ///
-  /// Throws a [FormatException] if an `--exclude` pattern is not valid glob
-  /// syntax; patterns are compiled eagerly.
   PathFilter _resolvePathFilter(ArgResults results) {
     final filter = parsePathFilter(results);
     if (results.wasParsed('include-generated') &&
@@ -139,7 +136,6 @@ class UndeadCliRunner {
     return filter;
   }
 
-  /// Reports [message] as a usage error with the full option list.
   int _usageError(String message) {
     errSink.writeln('Error: $message');
     errSink.writeln();

--- a/packages/undead/lib/src/cli.dart
+++ b/packages/undead/lib/src/cli.dart
@@ -122,6 +122,23 @@ class UndeadCliRunner {
       outSink = outSink ?? stdout,
       errSink = errSink ?? stderr;
 
+  /// Builds the path filter, honouring the deprecated `--include-generated`
+  /// alias for `--no-ignore-generated`.
+  ///
+  /// Throws a [FormatException] if an `--exclude` pattern is not valid glob
+  /// syntax; patterns are compiled eagerly.
+  PathFilter _resolvePathFilter(ArgResults results) {
+    final filter = parsePathFilter(results);
+    if (results.wasParsed('include-generated') &&
+        results.flag('include-generated')) {
+      return PathFilter(
+        excludePatterns: filter.excludePatterns,
+        ignoreGenerated: false,
+      );
+    }
+    return filter;
+  }
+
   /// Reports [message] as a usage error with the full option list.
   int _usageError(String message) {
     errSink.writeln('Error: $message');
@@ -176,19 +193,11 @@ class UndeadCliRunner {
     final format = OutputFormat.fromString(results.option('format')!);
     final exampleMode = ExampleMode.fromString(results.option('example-mode')!);
     final mode = AnalysisMode.fromString(results.option('mode')!);
-    final PathFilter parsedFilter;
+    final PathFilter pathFilter;
     try {
-      parsedFilter = parsePathFilter(results);
+      pathFilter = _resolvePathFilter(results);
     } on FormatException catch (e) {
       return _usageError(e.message);
-    }
-    var pathFilter = parsedFilter;
-    if (results.wasParsed('include-generated') &&
-        results.flag('include-generated')) {
-      pathFilter = PathFilter(
-        excludePatterns: pathFilter.excludePatterns,
-        ignoreGenerated: false,
-      );
     }
     final failOnUndead = results.flag('fail-on-undead');
     final autoPubGet = results.flag('pub-get');

--- a/packages/undead/lib/src/models.dart
+++ b/packages/undead/lib/src/models.dart
@@ -168,6 +168,8 @@ final class UndeadOptions {
   bool get ignoreGenerated => pathFilter.ignoreGenerated;
   List<String> get excludePatterns => pathFilter.excludePatterns;
 
+  /// Throws a [FormatException] if an `excludePatterns` entry is not valid
+  /// glob syntax; [PathFilter] compiles patterns eagerly.
   UndeadOptions({
     required this.packagePath,
     this.format = OutputFormat.markdown,

--- a/packages/undead/test/cli_test.dart
+++ b/packages/undead/test/cli_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:analytica/analytica.dart';
 import 'package:analytica/testing.dart';
 import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
@@ -506,6 +507,33 @@ void onlyUsedHere() {}
       check(firstFinding['name']).equals('onlyUsedHere');
       check(firstFinding['classification']).equals('privateCandidate');
       check(firstFinding['suggestedAction']).equals('makePrivate');
+    });
+  });
+
+  group('--exclude pattern errors', () {
+    test('reports a malformed pattern as a usage error', () async {
+      // Patterns are compiled eagerly, so an invalid glob throws from
+      // parsePathFilter -- which sits outside the arg-parsing try block.
+      // Unguarded that surfaces as an unhandled exception and exit 255.
+      await d.dir('bad_glob_pkg', [
+        d.file('pubspec.yaml', '''
+name: bad_glob_pkg
+environment:
+  sdk: '^3.5.0'
+'''),
+        d.dir('lib', [d.file('main.dart', 'void main() {}')]),
+      ]).create();
+
+      final err = StringBuffer();
+      final code = await UndeadCliRunner(
+        outSink: StringBuffer(),
+        errSink: err,
+      ).run(['--exclude=lib/[unclosed', d.path('bad_glob_pkg')]);
+
+      check(code).equals(ExitCode.usage.code);
+      check(err.toString())
+        ..contains('lib/[unclosed')
+        ..contains('Invalid exclude pattern');
     });
   });
 }


### PR DESCRIPTION
## Overview

Replaces `PathFilter`'s internal `WildcardPattern` matcher with `package:glob`,
per your suggestion on #90. Exclusion patterns now support the full glob
syntax — brace expansion (`**/*.{g,freezed}.dart`) and character classes
(`**/*_[0-9].dart`) — across `cognitive_complexity`, `dedupe` and `undead` at
once.

`WildcardPattern` itself is untouched and stays public: `undead` uses it to
match declaration *names* (`Fake*`, `Mock*`) rather than paths, and
`glob_matcher_test.dart` deliberately pins regex metacharacters as literal.
Only `PathFilter`'s internals changed.

`PathFilter.defaultIgnoredDirectories` and `defaultGeneratedPatterns` are
byte-identical, and the segment fast path in `isExcluded` is unchanged.

## Changes

**package:analytica**

- `PathFilter` compiles patterns to `Glob` instead of `WildcardPattern`.
  - Every pattern and candidate path is prefixed with a constant `<root>/`
    segment, and `/**/` is relaxed to `/{**/,}`. `package:glob` cannot
    otherwise express "zero or more leading directories": `{**/,}` parses, but
    matching throws `StateError` because `SequenceNode.canMatchAbsolute` reads
    `nodes.first` of the empty alternative — which only happens when the
    options group is first in the pattern. The anchor moves it off position 0.
  - Without that relaxation `**/*.g.dart` stops matching a root-level
    `model.g.dart`, and `lib/**/*.g.dart` stops matching `lib/model.g.dart`.
  - Compiled with `context: p.posix` to pin separators *and* case sensitivity.
    `Glob`'s default context is case-insensitive on Windows, which the
    Linux-only CI would not surface.
- `parsePathFilter` splits `--exclude` on commas outside brace groups only
  (new `splitGlobPatterns`), and `addPathFilterOptions` passes
  `splitCommas: false`. Without both, `--exclude='**/*.{g,freezed}.dart'` was
  torn into `**/*.{g` and `freezed}.dart` and rejected — brace expansion was
  unreachable from any CLI even though it worked at the API level.
- Blank patterns are skipped at compile time, keeping a trailing comma or an
  unset CI variable inert as before.

**package:undead**

- Guard `parsePathFilter` with the existing usage-error handler. It sits
  between the arg-parse `try` and the analysis `try`, so once patterns became
  throwable a malformed `--exclude` exited 255 with a raw stack trace.
  Now exits 64 like `cognitive_complexity` and `dedupe` already did.

**package:cognitive_complexity, package:dedupe, package:undead**

- CHANGELOG only; no source changes. They pick up glob syntax through
  `PathFilter`.

## Behaviour changes

Three, all documented in the analytica CHANGELOG:

1. `[`, `]`, `{`, `}` are now metacharacters rather than literal. This is the
   point of the change, but it is breaking for a pattern that relied on the
   old literal reading — `Glob.quote` escapes them.
2. A malformed pattern throws `FormatException` naming the pattern, where it
   previously matched nothing silently for the life of the process.
3. A leading `../` is stripped before matching, so a root-anchored pattern now
   applies to paths outside the scanned tree (`undead --extra-roots`).
   Today's behaviour there is asymmetric — `**` absorbs the `../`, anchored
   patterns don't. Stripping picks the safer side: without it, `**` stops
   absorbing `../` under glob and generated files under an extra root would
   silently stop being excluded.


